### PR TITLE
Deselect All Layers should be recorded as a history state because of a current photoshop quirk/feature

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -563,13 +563,21 @@ define(function (require, exports) {
         }
 
         var payload = {
-            documentID: document.id,
-            selectedIDs: []
-        };
+                documentID: document.id,
+                selectedIDs: []
+            },
+            options = {
+                historyStateInfo: {
+                    name: strings.ACTIONS.DESELECT_LAYERS,
+                    target: documentLib.referenceBy.id(document.id)
+                }
+            };
 
-        // FIXME: The descriptor below should be specific to the document ID
-        var deselectPromise = descriptor.playObject(layerLib.deselectAll()),
-            dispatchPromise = this.dispatchAsync(events.document.SELECT_LAYERS_BY_ID, payload);
+        // This currently silently creates a history state in Photoshop, so we're explicitly passing 
+        // historyStateInfo option to force our getting a historyState notification 
+        // TODO: The descriptor below should be specific to the document ID
+        var deselectPromise = descriptor.playObject(layerLib.deselectAll(), options),
+            dispatchPromise = this.dispatchAsync(events.document.history.optimistic.SELECT_LAYERS_BY_ID, payload);
 
         return Promise.join(dispatchPromise, deselectPromise);
     };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
                     REPOSITION_LAYERS: "repositionLayers",
                     NUDGE_LAYERS: "nudgeLayers",
                     RESIZE_LAYERS: "resizeLayers",
+                    SELECT_LAYERS_BY_ID: "optimisticHistorySelectLayersByID",
                     SET_LAYERS_PROPORTIONAL: "setLayersProportional",
                     STROKE_COLOR_CHANGED: "strokeColorChanged",
                     STROKE_OPACITY_CHANGED: "strokeOpacityChanged",

--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -65,6 +65,7 @@ define(function (require, exports, module) {
                 events.dialog.CLOSE_DIALOG, this._handleClose,
                 events.dialog.CLOSE_ALL_DIALOGS, this._handleCloseAll,
                 events.document.SELECT_LAYERS_BY_ID, this._handleSelectionChange,
+                events.document.history.optimistic.SELECT_LAYERS_BY_ID, this._handleSelectionChange,
                 events.document.SELECT_LAYERS_BY_INDEX, this._handleSelectionChange,
                 events.document.history.optimistic.GROUP_SELECTED, this._handleSelectionChange,
                 events.document.CLOSE_DOCUMENT, this._handleDocumentChange,

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -54,6 +54,7 @@ define(function (require, exports, module) {
                 events.document.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.history.optimistic.REORDER_LAYERS, this._handleLayerReorder,
                 events.document.SELECT_LAYERS_BY_ID, this._handleLayerSelectByID,
+                events.document.history.optimistic.SELECT_LAYERS_BY_ID, this._handleLayerSelectByID,
                 events.document.SELECT_LAYERS_BY_INDEX, this._handleLayerSelectByIndex,
                 events.document.VISIBILITY_CHANGED, this._handleVisibilityChanged,
                 events.document.history.optimistic.LOCK_CHANGED, this._handleLockChanged,

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -69,6 +69,7 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._updateMenuItems,
                 events.document.history.optimistic.REORDER_LAYERS, this._updateMenuItems,
                 events.document.SELECT_LAYERS_BY_ID, this._updateMenuItems,
+                events.document.history.optimistic.SELECT_LAYERS_BY_ID, this._updateMenuItems,
                 events.document.SELECT_LAYERS_BY_INDEX, this._updateMenuItems,
                 events.document.VISIBILITY_CHANGED, this._updateMenuItems,
                 events.document.history.optimistic.LOCK_CHANGED, this._updateMenuItems,

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
             SET_FILL_COLOR: "Set Fill Color",
             SET_FILL_OPACITY: "Set Fill Opacity",
             DELETE_LAYERS: "Delete Layers",
+            DESELECT_LAYERS: "Deselect Layers",
             CHANGE_LAYER_OPACITY: "Change Layer Opacity",
             SET_BLEND_MODE: "Set Blend Mode",
             FLIP_LAYERS: "Flip Layers",


### PR DESCRIPTION
Currently, photoshop is recording our "deselect all layers" Actions as a history state, but _not_ emitting a historyState event.  This is no bueno for our History Store.  Eventually we hope to address the issue in core, but for now we can at least avoid history inconsistency issues with "if you can't beat 'em, join 'em" approach.  If we explicitly force a history state using a play option, then we do get a historyState event.

For now, this means we'll have some "extra" history states to step through if you do any delectAllLayer actions ... which is pretty easy with empty marquee selects, or canvas clicks.

addresses:
#1528
#1565
