### PR TITLE
Add controller reference to action receivers 

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -30,8 +30,7 @@ define(function (require, exports) {
         ps = require("adapter/ps"),
         ui = require("adapter/ps/ui");
 
-    var main = require("js/main"),
-        events = require("js/events"),
+    var events = require("js/events"),
         locks = require("js/locks"),
         system = require("js/util/system"),
         log = require("js/util/log"),
@@ -225,8 +224,8 @@ define(function (require, exports) {
         });
 
         // Menu item clicks come to us from Photoshop through this event
+        var controller = this.controller;
         _adapterMenuHandler = function (payload) {
-            var controller = main.getController();
             if (!controller.active) {
                 return;
             }

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -28,8 +28,7 @@ define(function (require, exports) {
 
     var os = require("adapter/os");
 
-    var main = require("js/main"),
-        events = require("js/events"),
+    var events = require("js/events"),
         locks = require("js/locks"),
         policy = require("js/actions/policy");
 
@@ -130,12 +129,12 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartupCommand = function () {
-        var shortcutStore = this.flux.store("shortcut");
+        var shortcutStore = this.flux.store("shortcut"),
+            controller = this.controller;
 
         var _getKeyDownHandlerForPhase = function (capture) {
             return function (event) {
                 // Disable shortcuts when the controller is inactive
-                var controller = main.getController();
                 if (!controller.active) {
                     return;
                 }


### PR DESCRIPTION
This eliminates an unnecessary circular dependency that was only used to provide actions access to the `FluxController` instance. This is nicer. Some build tools (**cough**webpack) also don't like circular dependencies.
