### PR TITLE
Unlock background layer: correct history states and layer replacement

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -277,12 +277,14 @@ define(function (require, exports) {
      * Emit an ADD_LAYER event with the layer ID, descriptor, index, whether
      * it should be selected, and whether the existing layer should be replaced.
      *
+     * If `replace` is  unspecified, an existing single selected layer will only be replaced if it is an empty
+     * non-background layer.  If a number is specified, that layer ID will be replace.
+     * If false, no replacement will take place
+     *
      * @param {Document} document
      * @param {number|Array.<number>} layerSpec
      * @param {boolean=} selected Default is true
-     * @param {boolean=} replace Whether to replace the layer at the given index.
-     *  If unspecified, the existing layer will only be replaced if it is an empty
-     *  non-background layer.
+     * @param {boolean= || number=} replace replace the layer at the given index, or use default if undefined
      * @return {Promise}
      */
     var addLayersCommand = function (document, layerSpec, selected, replace) {
@@ -892,7 +894,7 @@ define(function (require, exports) {
             .bind(this)
             .then(function (event) {
                 var layerID = event.layerID;
-                return this.transfer(addLayers, document, layerID, true, true);
+                return this.transfer(addLayers, document, layerID, true, layer.id);
             });
     };
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -918,15 +918,14 @@ define(function (require, exports) {
                 layerLib.referenceBy.id(layer.id)
             ];
 
-        var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.LOCK_CHANGED, payload),
-            lockPromise;
         if (layer.isBackground) {
-            lockPromise = _unlockBackgroundLayer.call(this, document, layer);
+            return _unlockBackgroundLayer.call(this, document, layer);
         } else {
-            lockPromise = descriptor.playObject(layerLib.setLocking(layerRef, locked));
-        }
+            var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.LOCK_CHANGED, payload),
+                lockPromise = descriptor.playObject(layerLib.setLocking(layerRef, locked));
 
-        return Promise.join(dispatchPromise, lockPromise);
+            return Promise.join(dispatchPromise, lockPromise);
+        }
     };
 
     /**

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -278,13 +278,13 @@ define(function (require, exports) {
      * it should be selected, and whether the existing layer should be replaced.
      *
      * If `replace` is  unspecified, an existing single selected layer will only be replaced if it is an empty
-     * non-background layer.  If a number is specified, that layer ID will be replace.
-     * If false, no replacement will take place
+     * non-background layer.  If a number is specified, that layer ID will be replaced.
+     * If false, no replacement will take place.
      *
      * @param {Document} document
      * @param {number|Array.<number>} layerSpec
      * @param {boolean=} selected Default is true
-     * @param {boolean= || number=} replace replace the layer at the given index, or use default if undefined
+     * @param {boolean= || number=} replace replace the layer with this ID, or use default logic if undefined
      * @return {Promise}
      */
     var addLayersCommand = function (document, layerSpec, selected, replace) {

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -238,7 +238,7 @@ define(function (require, exports, module) {
          *      layerID: Array.<number>,
          *      descriptor: Array.<object>,
          *      selected: boolean,
-         *      replace: boolean
+         *      replace: boolean || number
          *  }
          */
         _handleLayerAdd: function (payload) {


### PR DESCRIPTION
This PR provides proper background layer unlocking wrt to both history store, *and* the "replace layer" logic.

1. The replace layer logic now handles the special case of unlock background layer by allowing an explicit layer ID parameter of that which is to be replaced.  The recent simplifications to replace layers based on selection state does not handle this situation gracefully otherwise.
2. The unlock background layer action no longer emits two separate history-changing flux events

addresses #1443