### PR TITLE
Layer actions fixes: post-deletion selection reset, and minor resetSelection refactoring.

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -342,7 +342,9 @@ define(function (require, exports) {
             documentID: document.id
         };
 
-        return _getSelectedLayerIndices(document).then(function (selectedLayerIndices) {
+        return _getSelectedLayerIndices(document)
+            .bind(this)
+            .then(function (selectedLayerIndices) {
                 payload.selectedIndices = selectedLayerIndices;
                 this.dispatch(events.document.SELECT_LAYERS_BY_INDEX, payload);
             });
@@ -830,7 +832,7 @@ define(function (require, exports) {
             .concat(deletedDescendants)
             .toSet();
 
-        var resetSelection = false;
+        var selectionNeedsReset = false;
 
         if (nextSelected.size > 0) {
             var selectRef = nextSelected
@@ -844,7 +846,7 @@ define(function (require, exports) {
             var selectObj = layerLib.select(selectRef, false, "select");
             playObjects.push(selectObj);
         } else {
-            resetSelection = true;
+            selectionNeedsReset = true;
             // TODO: Add smart selection reset here, after we figure out
             // what Photoshop does, and remove the last link of the return chain below
         }
@@ -859,17 +861,8 @@ define(function (require, exports) {
                 this.dispatch(events.document.history.nonOptimistic.UNGROUP_SELECTED, payload);
             })
             .then(function () {
-                if (resetSelection) {
-                    return descriptor.getProperty("document", "targetLayers")
-                        .bind(this)
-                        .then(function (targetLayers) {
-                            var layerIndices = _.pluck(targetLayers, "_index"),
-                                selectPayload = {
-                                    documentID: document.id,
-                                    selectedIndices: layerIndices
-                                };
-                            this.dispatch(events.document.SELECT_LAYERS_BY_INDEX, selectPayload);
-                        });
+                if (selectionNeedsReset) {
+                    this.transfer(resetSelection, document);
                 }
             });
     };
@@ -1065,9 +1058,9 @@ define(function (require, exports) {
             reorderPromise = descriptor.playObject(reorderObj);
       
         return reorderPromise
-            .bind(this)
-            .then(getLayerOrderCommand(document));
+            .then(this.transfer.bind(this, getLayerOrder, document));
     };
+
     /**
      * Updates our layer information based on the current document 
      *
@@ -1076,14 +1069,10 @@ define(function (require, exports) {
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
      **/
     var getLayerOrderCommand = function (document) {
-        var documentRef = documentLib.referenceBy.id(document.id);
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
-                return descriptor.batchGetOptionalProperties(documentRef, ["targetLayers"])
-                    .bind(this)
-                    .then(function (targetLayers) {
-                        var layerIndices = _.pluck(targetLayers.targetLayers, "_index");
-                        payload.selectedIndices = layerIndices;
+                return _getSelectedLayerIndices(document).then(function (selectedIndices) {
+                        payload.selectedIndices = selectedIndices;
                         return payload;
                     });
             })
@@ -1477,31 +1466,13 @@ define(function (require, exports) {
                 
                 this.dispatch(events.document.history.nonOptimistic.DELETE_LAYERS, payload);
 
-                // FIXME I think the below can be replaced with
-                // return this.transfer(resetSelection, currentDocument).then(function () {
-                //     this.flux.actions.tools.select(toolStore.getDefaultTool());
-                // });
-                descriptor.getProperty("document", "targetLayers")
-                    .bind(this)
-                    .then(function (targetLayers) {
-                        var layerIndices = _.pluck(targetLayers, "_index"),
-                            selectPayload = {
-                                documentID: currentDocument.id,
-                                selectedIndices: layerIndices
-                            },
-                            targetPathObj = documentLib.setTargetPathVisible(
-                                documentLib.referenceBy.current,
-                                false
-                            ),
-                            currentTool = toolStore.getCurrentTool();
-                        
-                        this.dispatch(events.document.SELECT_LAYERS_BY_INDEX, selectPayload);
-
-                        if (currentTool && currentTool.id === "pen") {
-                            // Hide the path since we can't edit the selection dropped layer
-                            descriptor.playObject(targetPathObj);
-                        }
-                    });
+                return this.flux.actions.layers.resetSelection(currentDocument).then(function () {
+                    var currentTool = toolStore.getCurrentTool();
+                    if (currentTool && currentTool.id === "pen") {
+                        // Hide the path since we can't edit the selection dropped layer
+                        descriptor.playObject(documentLib.setTargetPathVisible(documentLib.referenceBy.current, false));
+                    }
+                });
             } else if (target === null) {
                 // If a path node is deleted, we get a simple delete notification with no info,
                 // so we update shape bounds here


### PR DESCRIPTION
Addresses #1489 

Two commits:

1. After deleting a layer, we now query photoshop for the current selection state.  We previously were making no attempt to update the selection state, and that was bad
1. Attempt to make more consistent use of "resetSelection" within the layer actions.  Note that this affects three "other" code paths: reordering layers, deleting the last anchor of a shape, certain types of "ungrouping".

Note: this "introduces" a post condition error when doing some ungrouping (such as ungrouping an empty group) but I think it is a separate, existing issue that is just being surfaced more correctly now.  I didn't want to hold up this PR for that fix.