### PR TITLE
Set cloaking overlay on window resize

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -21,8 +21,6 @@
  * 
  */
 
-/* global _spaces */
-
 define(function (require, exports) {
     "use strict";
 
@@ -35,13 +33,6 @@ define(function (require, exports) {
     var events = require("js/events"),
         locks = require("js/locks"),
         synchronization = require("js/util/synchronization");
-
-    /**
-     * This is the only _spaces.window function we use, so for now it's being
-     * promisified here
-     * FIX ME
-     */
-    var adapterSetCloaking = Promise.promisify(_spaces.window.setOverlayCloaking);
 
     /**
      * Toggle pinned toolbar
@@ -122,12 +113,7 @@ define(function (require, exports) {
                 right: windowWidth - centerOffsets.right
             };
 
-        return adapterSetCloaking({
-            list: [cloakRect],
-            debug: false,
-            enable: ["scroll"],
-            disable: "afterPaint"
-        }, {});
+        return adapterUI.setOverlayCloaking(cloakRect, ["scroll"], "afterPaint");
     };
 
     /**


### PR DESCRIPTION
This is an API Jesper developed for us, which allows us to set rectangles so certain events to immediately clear out regions of the HTML page. We use this during `scroll` events that come from Photoshop so when user starts panning / scrolling, we can immediately erase our layer bounds.

It's a big improvement to one of the oldest issues.