### PR TITLE
Use a multiget reference to load a document's layer descriptors

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -157,20 +157,14 @@ define(function (require, exports) {
      * @return {Promise.<{document: object, layers: Array.<object>}>}
      */
     var _getLayersForDocument = function (doc) {
-        var layerCount = doc.numberOfLayers,
-            startIndex = (doc.hasBackgroundLayer ? 0 : 1),
-            layerRefs = Immutable.Range(layerCount, startIndex - 1, -1).map(function (i) {
-                return [
-                    documentLib.referenceBy.id(doc.documentID),
-                    layerLib.referenceBy.index(i)
-                ];
-            });
+        var docRef = documentLib.referenceBy.id(doc.documentID),
+            startIndex = (doc.hasBackgroundLayer ? 0 : 1);
 
-        return layerActions._getLayersByRef(layerRefs)
+        return layerActions._getLayersForDocumentRef(docRef, startIndex)
             .then(function (layers) {
                 return {
                     document: doc,
-                    layers: layers
+                    layers: layers.reverse()
                 };
             });
     };

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -164,6 +164,36 @@ define(function (require, exports) {
     };
 
     /**
+     * Get all layer descriptors for the given document reference. Only the
+     * properties listed in the arrays above will be included for performance
+     * reasons.
+     * 
+     * @private
+     * @param {object} docRef A document reference
+     * @param {number} startIndex 
+     * @return {Promise.<Array.<object>>}
+     */
+    var _getLayersForDocumentRef = function (docRef, startIndex) {
+        var rangeOpts = {
+            range: "layer",
+            index: startIndex,
+            count: -1
+        };
+
+        var requiredPropertiesPromise = descriptor.getPropertiesRange(docRef, rangeOpts, _layerProperties, {
+            failOnMissingProperty: true
+        });
+
+        var optionalPropertiesPromise = descriptor.getPropertiesRange(docRef, rangeOpts, _optionalLayerProperties, {
+            failOnMissingProperty: false
+        });
+
+        return Promise.join(requiredPropertiesPromise, optionalPropertiesPromise, function (required, optional) {
+            return _.zipWith(required, optional, _.merge);
+        });
+    };
+
+    /**
      * Get the ordered list of layer IDs for the given Document ID.
      *
      * @private
@@ -1724,6 +1754,7 @@ define(function (require, exports) {
     exports.onReset = onReset;
 
     exports._getLayersByRef = _getLayersByRef;
+    exports._getLayersForDocumentRef = _getLayersForDocumentRef;
     exports._verifyLayerSelection = _verifyLayerSelection;
     exports._verifyLayerIndex = _verifyLayerIndex;
 });


### PR DESCRIPTION
Relies on adobe-photoshop/spaces-design#108, which adds a `getPropertiesRange` call to efficiently get a list of properties of a range of references (e.g., all layer references on a document). This adds a new private helper function, `layers._getLayersForDocumentRef` which uses `getPropertiesRange` to more efficiently get all the layer descriptor objects when loading documents (by, e.g., `initActiveDocument` and `initInactiveDocuments`).  This provides a significant performance improvement at document-load time for large documents. The mega-artboards document previously spent ~7s waiting on Photoshop for these descriptors and now only waits for ~4s. 

In a follow-up PR, I'll apply similar new functionality in `batchPlay` to the existing `_getLayersByRef` function to go from O(mn) play commands, for m layers with n properties, to O(m).