### PR TITLE
Fixes for option-dragging a new layer

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1066,10 +1066,10 @@ define(function (require, exports) {
      * Updates our layer information based on the current document 
      *
      * @param {Document} document Document for which layers should be reordered
-     *
+     * @param {boolean=} suppressHistory if truthy, dispatch a non-history-changing event.
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
      **/
-    var getLayerOrderCommand = function (document) {
+    var getLayerOrderCommand = function (document, suppressHistory) {
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
                 return _getSelectedLayerIndices(document).then(function (selectedIndices) {
@@ -1077,7 +1077,13 @@ define(function (require, exports) {
                         return payload;
                     });
             })
-            .then(this.dispatch.bind(this, events.document.history.optimistic.REORDER_LAYERS));
+            .then(function (payload) {
+                if (suppressHistory) {
+                    return this.dispatchAsync(events.document.REORDER_LAYERS, payload);
+                } else {
+                    return this.dispatchAsync(events.document.history.optimistic.REORDER_LAYERS, payload);
+                }
+            });
     };
 
     /**
@@ -1618,7 +1624,6 @@ define(function (require, exports) {
         writes: [locks.PS_DOC, locks.JS_DOC],
         post: [_verifyLayerIndex, _verifyLayerSelection]
     };
-
 
     var setBlendMode = {
         command: setBlendModeCommand,

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -630,11 +630,12 @@ define(function (require, exports) {
 
                         _moveListener = function () {
                             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-                            if (artboardNested) {
-                                this.flux.actions.layers.getLayerOrder(doc);
-                            }
-
                             if (!copyDrag) {
+                                // In the case of artboards, we have to just ask Ps for the layer order
+                                if (artboardNested) {
+                                    this.flux.actions.layers.getLayerOrder(doc, true);
+                                }
+
                                 // Since finishing the click, the selected layers may have changed, so we'll get
                                 // the most current document model before proceeding.
                                 var documentStore = this.flux.store("document"),

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
             SELECT_LAYERS_BY_ID: "selectLayersByID",
             SELECT_LAYERS_BY_INDEX: "selectLayersByIndex",
             VISIBILITY_CHANGED: "layerVisibilityChanged",
+            REORDER_LAYERS: "reorderLayersNoHistory",
             LAYER_BOUNDS_CHANGED: "layerBoundsChanged",
             RESET_BOUNDS: "resetBoundsNoHistory", // slightly different than above LAYER_BOUNDS_CHANGED
             RESET_LAYERS: "resetLayers",

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.history.optimistic.REORDER_LAYERS, this._handleLayerReorder,
+                events.document.REORDER_LAYERS, this._handleLayerReorder,
                 events.document.SELECT_LAYERS_BY_ID, this._handleLayerSelectByID,
                 events.document.SELECT_LAYERS_BY_INDEX, this._handleLayerSelectByIndex,
                 events.document.VISIBILITY_CHANGED, this._handleVisibilityChanged,
@@ -467,11 +468,11 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Payload contains the array of layer IDs after reordering,
+         * Payload contains the array of layer IDs after reordering, and the selected indexes
          * Sends it to layertree model to rebuild the tree
          *
          * @private
-         * @param {{documentID: number, layerIDs: Array.<number>}} payload
+         * @param {{documentID: number, layerIDs: Array.<number>, selectedIndices: Array.<number>}} payload
          *
          */
         _handleLayerReorder: function (payload) {

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
                 events.document.RESET_LAYERS_BY_INDEX, this._updateMenuItems,
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._updateMenuItems,
                 events.document.history.optimistic.REORDER_LAYERS, this._updateMenuItems,
+                events.document.REORDER_LAYERS, this._updateMenuItems,
                 events.document.SELECT_LAYERS_BY_ID, this._updateMenuItems,
                 events.document.SELECT_LAYERS_BY_INDEX, this._updateMenuItems,
                 events.document.VISIBILITY_CHANGED, this._updateMenuItems,


### PR DESCRIPTION
This PR adds a new type of REORDER_LAYERS event that does *not* increment history.  This is to support the recently added logic that, after moving a layer between Artboards, resets the entire layer order by asking photoshop.  Additionally, this step is *no longer* called in the "copyDrag" case, because that ends up doing a full updateDocument anyway.

addresses #1613