### PR TITLE
Finish conversion to multiGetRefs 

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -107,30 +107,16 @@ define(function (require, exports) {
      * @return {Promise.<object>}
      */
     var _getDocumentByRef = function (reference, properties, optionalProperties) {
-        var makeRefObj = function (property) {
-            return {
-                reference: reference,
-                property: property
-            };
-        };
-
         if (properties === undefined) {
             properties = _documentProperties;
         }
-
-        var refObjs = properties.map(makeRefObj),
-            documentPropertiesPromise = descriptor.batchGetProperties(refObjs)
-                .reduce(function (result, value, index) {
-                    var property = properties[index];
-                    result[property] = value;
-                    return result;
-                }, {});
 
         if (optionalProperties === undefined) {
             optionalProperties = _optionalDocumentProperties;
         }
 
-        var optionalPropertiesPromise = descriptor.batchGetOptionalProperties(reference, optionalProperties);
+        var documentPropertiesPromise = descriptor.multiGetProperties(reference, properties),
+            optionalPropertiesPromise = descriptor.multiGetOptionalProperties(reference, optionalProperties);
 
         return Promise.join(documentPropertiesPromise, optionalPropertiesPromise,
             function (properties, optionalProperties) {
@@ -153,7 +139,7 @@ define(function (require, exports) {
             .then(function (layers) {
                 return {
                     document: doc,
-                    layers: layers.reverse()
+                    layers: layers
                 };
             });
     };

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -136,10 +136,14 @@ define(function (require, exports) {
             return descriptor.playObject(historyPlayObject)
                 .bind(this)
                 .then(function () {
-                    descriptor.batchGetOptionalProperties(documentLib.referenceBy.id(document.id), ["targetLayers"])
+                    descriptor.getProperty(documentLib.referenceBy.id(document.id), "targetLayers")
                         .bind(this)
-                        .then(function (batchResponse) {
-                            var selectedIndices = _.pluck(batchResponse.targetLayers || [], "_index");
+                        .catch(function () {
+                            // no targetLayers property means no document is open
+                            return [];
+                        })
+                        .then(function (targetLayers) {
+                            var selectedIndices = _.pluck(targetLayers, "_index");
                             return this.dispatchAsync(events.history.LOAD_HISTORY_STATE, {
                                 documentID: document.id,
                                 count: count,

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -25,7 +25,8 @@ define(function (require, exports) {
     "use strict";
 
     var Promise = require("bluebird"),
-        Immutable = require("immutable");
+        Immutable = require("immutable"),
+        _ = require("lodash");
 
     var descriptor = require("adapter/ps/descriptor"),
         layerLib = require("adapter/lib/layer"),
@@ -145,7 +146,7 @@ define(function (require, exports) {
         var layerIDs = collection.pluck(layers, "id"),
             refs = layerLib.referenceBy.id(layerIDs.toArray());
 
-        return descriptor.batchGetProperty(refs._ref, "AGMStrokeStyleInfo")
+        return descriptor.batchMultiGetProperties(refs._ref, ["AGMStrokeStyleInfo"])
             .bind(this)
             .then(function (batchGetResponse) {
                 if (!batchGetResponse || batchGetResponse.length !== layers.size) {
@@ -155,7 +156,7 @@ define(function (require, exports) {
                     documentID: document.id,
                     strokeIndex: strokeIndex,
                     layerIDs: layerIDs,
-                    strokeStyleDescriptor: Immutable.List(batchGetResponse)
+                    strokeStyleDescriptor: Immutable.List(_.pluck(batchGetResponse, "AGMStrokeStyleInfo"))
                 };
                 this.dispatch(events.document.history.nonOptimistic.STROKE_ADDED, payload);
             });

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -35,6 +35,16 @@ define(function (require, exports) {
         synchronization = require("js/util/synchronization");
 
     /**
+     * @private
+     * @const
+     * @type {Array.<string>} Document properties needed to update the window transform
+     */
+    var _transformProperties = [
+        "viewTransform",
+        "zoom"
+    ];
+
+    /**
      * Toggle pinned toolbar
      *    
      * @return {Promise}
@@ -47,7 +57,7 @@ define(function (require, exports) {
 
         return this.flux.actions.preferences.setPreference("toolbarPinned", newToolbarPinned);
     };
-    
+
     /**
      * Query Photoshop for the curent window transform and emit a
      * TRANSFORM_UPDATED event with that value.
@@ -68,28 +78,18 @@ define(function (require, exports) {
             return this.dispatchAsync(events.ui.TRANSFORM_UPDATED, nullPayload);
         }
 
-        var docRef = documentLib.referenceBy.id(currentDocument.id),
-            propertyRefs = [{
-                reference: docRef,
-                property: "viewTransform"
-            }, {
-                reference: docRef,
-                property: "zoom"
-            }];
+        var docRef = documentLib.referenceBy.id(currentDocument.id);
 
         // Despite the misleading property name, this array appears to
         // encode an affine transformation from the window coordinate
         // space to the document canvas cooridinate space. 
         
-        return descriptor.batchGetProperties(propertyRefs, { continueOnError: true })
+        return descriptor.multiGetOptionalProperties(docRef, _transformProperties)
             .bind(this)
-            .then(function (transform) {
-                return [transform[0][0].viewTransform, transform[0][1].zoom._value];
-            })
-            .then(function (transformAndZoom) {
+            .then(function (result) {
                 var payload = {
-                    transformMatrix: transformAndZoom[0],
-                    zoom: transformAndZoom[1]
+                    transformMatrix: result.viewTransform,
+                    zoom: result.zoom._value
                 };
 
                 this.dispatch(events.ui.TRANSFORM_UPDATED, payload);


### PR DESCRIPTION
This PR makes full use of multiGetRefs, added in adobe-photoshop/spaces-adapter#110, for a variety of modest performance gains. `layers.addLayers`, for example, takes about 75% as long as on master. But, it all adds up!

Unless you're fetching an arbitrary set of properties from an arbitrary set of references, there isn't a good reason now to use `batchGet` and friends. Instead, choose something like `getPropertiesRange` if you're getting a fixed set of properties from a contiguous range of references, or `batchMultiGetProperties` to get a fixed set of properties from an arbitrary set of references.

Relies on adobe-photoshop/spaces-adapter#110. 