### PR TITLE
Remove artificial delays from zoom commands

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -315,7 +315,8 @@ define(function (require, exports) {
                 interactionMode: descriptor.interactionMode.DISPLAY
             };
 
-        return Promise.delay(50).bind(this)
+        return this.transfer(ui.cloak)
+            .bind(this)
             .then(function () {
                 return descriptor.playObject(closeObj, playOptions);
             })
@@ -558,7 +559,8 @@ define(function (require, exports) {
 
         this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
 
-        return Promise.delay(50).bind(this)
+        return this.transfer(ui.cloak)
+            .bind(this)
             .then(function () {
                 return this.transfer(selectDocument, nextDocument);
             });
@@ -579,7 +581,8 @@ define(function (require, exports) {
 
         this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
 
-        return Promise.delay(50).bind(this)
+        return this.transfer(ui.cloak)
+            .bind(this)
             .then(function () {
                 this.transfer(selectDocument, previousDocument);
             });

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -103,17 +103,23 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setOverlayCloakingCommand = function () {
-        var centerOffsets = this.flux.store("ui").getState().centerOffsets,
-            windowWidth = window.document.body.clientWidth,
-            windowHeight = window.document.body.clientHeight,
-            cloakRect = {
-                left: centerOffsets.left,
-                top: centerOffsets.top,
-                bottom: windowHeight - centerOffsets.bottom,
-                right: windowWidth - centerOffsets.right
-            };
+        var uiStore = this.flux.store("ui"),
+            cloakRect = uiStore.getCloakRect();
 
         return adapterUI.setOverlayCloaking(cloakRect, ["scroll"], "afterPaint");
+    };
+
+    /**
+     * Cloak the non-UI portion of the screen immediately, redrawing on the
+     * next repaint.
+     *
+     * @return {Promise}
+     */
+    var cloakCommand = function () {
+        var uiStore = this.flux.store("ui"),
+            cloakRect = uiStore.getCloakRect();
+
+        return adapterUI.setOverlayCloaking(cloakRect, "immediate", "afterPaint");
     };
 
     /**
@@ -508,6 +514,12 @@ define(function (require, exports) {
         writes: [locks.JS_UI]
     };
 
+    var cloak = {
+        command: cloakCommand,
+        reads: [locks.JS_UI, locks.JS_APP],
+        writes: [locks.JS_UI]
+    };
+
     var togglePinnedToolbar = {
         command: togglePinnedToolbarCommand,
         reads: [],
@@ -537,6 +549,7 @@ define(function (require, exports) {
     exports.updateTransform = updateTransform;
     exports.setTransform = setTransform;
     exports.setOverlayCloaking = setOverlayCloaking;
+    exports.cloak = cloak;
     exports.updatePanelSizes = updatePanelSizes;
     exports.updateToolbarWidth = updateToolbarWidth;
     exports.centerBounds = centerBounds;

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -221,11 +221,8 @@ define(function (require, exports) {
         }
 
         var panZoom = _calculatePanZoom(bounds, offsets, zoom, factor),
-            centerPromise = Promise.delay(50)
+            centerPromise = descriptor.play("setPanZoom", panZoom)
                 .bind(this)
-                .then(function () {
-                    return descriptor.play("setPanZoom", panZoom);
-                })
                 .then(function () {
                     return this.transfer(updateTransform);
                 });
@@ -318,11 +315,8 @@ define(function (require, exports) {
             panZoomDescriptor.y = panDescriptor.y;
         }
 
-        return Promise.delay(50)
+        return descriptor.play("setPanZoom", panZoomDescriptor)
             .bind(this)
-            .then(function () {
-                return descriptor.play("setPanZoom", panZoomDescriptor);
-            })
             .then(function () {
                 return this.transfer(updateTransform);
             });

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -242,6 +242,26 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Get the current cloaking rectangle, which omits the static UI.
+         *
+         * @private
+         * @return {{top: number, right: number, left: number, bottom: number}}
+         */
+        getCloakRect: function () {
+            var centerOffsets = this._centerOffsets,
+                windowWidth = window.document.body.clientWidth,
+                windowHeight = window.document.body.clientHeight;
+
+            return {
+                left: centerOffsets.left,
+                top: centerOffsets.top,
+                bottom: windowHeight - centerOffsets.bottom,
+                right: windowWidth - centerOffsets.right
+            };
+        },
+
+
+        /**
          * Inverts the given affine transformation matrix
          *
          * @private


### PR DESCRIPTION
With the overlay cloaking functionality, bounds overlays are automagically cleared by the plugin on every "scroll" event. The zoom and centering commands always trigger a scroll event, so the current 50ms artificial delays in those commands (which were added to give the plugin time to repaint the CEF surface before changing the canvas) are no longer necessary.

It would be great to also remove these delays from the document open/close/selection actions, but those are not guaranteed to generate a scroll event. (They seem to do so only if the canvas is positioned or zoomed differently from one document to the next.) This will require some sort of core change, which I'll file a Watson bug for separately.

When testing, please confirm that there are no ghostly bounds when performing any of the zooming, centering or repositioning commands.