### PR TITLE
Get JSDoc to run alongside linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 bower_components
 node_modules
 src/font/*.otf
+docs/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,16 @@ module.exports = function (grunt) {
                 config: ".jscsrc"
             }
         },
+        jsdoc: {
+            dist: {
+                src: ["src"],
+                options: {
+                    destination: "docs",
+                    recurse: true,
+                    pedantic: true
+                }
+            }
+        },
 
         clean: ["./build"],
         copy: {
@@ -85,13 +95,14 @@ module.exports = function (grunt) {
 
     grunt.loadNpmTasks("grunt-jsxhint");
     grunt.loadNpmTasks("grunt-jscs");
+    grunt.loadNpmTasks("grunt-jsdoc");
 
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-contrib-copy");
     grunt.loadNpmTasks("grunt-contrib-requirejs");
     grunt.loadNpmTasks("grunt-contrib-less");
 
-    grunt.registerTask("test", ["jshint", "jscs"]);
+    grunt.registerTask("test", ["jshint", "jscs", "jsdoc"]);
     grunt.registerTask("build", [
         "test", "clean", "copy:requirejs", "copy:html", "copy:img", "requirejs", "less"
     ]);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-requirejs": "^0.4.4",
     "grunt-jscs": "^1.6.0",
+    "grunt-jsdoc": "^0.6.7",
     "grunt-jsxhint": "^0.6.0",
     "jscs-trailing-whitespace-in-source": "0.0.1",
     "react-tools": "^0.13.1"

--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -48,9 +48,11 @@ define(function (require, exports) {
         templates = JSON.parse(templatesJSON);
 
     /**
-     * @private
-     * @type {Array.<string>} Properties to be included when requesting document
+     * Properties to be included when requesting document
      * descriptors from Photoshop.
+     * 
+     * @private
+     * @type {Array.<string>} 
      */
     var _documentProperties = [
         "documentID",
@@ -66,9 +68,11 @@ define(function (require, exports) {
     ];
 
     /**
-     * @private
-     * @type {Array.<string>} Properties to be included if present when requesting
+     * Properties to be included if present when requesting
      * document descriptors from Photoshop.
+     * 
+     * @private
+     * @type {Array.<string>} 
      */
     var _optionalDocumentProperties = [
         "targetLayers",

--- a/src/js/actions/draganddrop.js
+++ b/src/js/actions/draganddrop.js
@@ -81,7 +81,7 @@ define(function (require, exports) {
     /**
     * Check the intersection of the current dragTarget and available drop targets
     *
-    * @param {Object {x: number, y: number}} point Point from event
+    * @param {{x: number, y: number}} point Point from event
     * @return {Promise}    
     */
     var moveAndCheckBoundsCommand = function (point) {

--- a/src/js/actions/example.js
+++ b/src/js/actions/example.js
@@ -50,7 +50,7 @@ define(function (require, exports) {
      * of read and write locks that must be acquired before the command can safely
      * be executed.
      *
-     * @type {command: function(): Promise, reads: Array.<string>=, writes: Array.<string>=}
+     * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
      */
     var syncAction = {
         command: syncCommand
@@ -86,7 +86,7 @@ define(function (require, exports) {
      * This action acquires all write locks before executing. Hence, this action
      * will never be executed concurrently with any other action.
      *
-     * @type {command: function(): Promise, reads: Array.<string>=, writes: Array.<string>=}
+     * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
      */
     var asyncActionReadWrite = {
         command: asyncCommand,
@@ -99,7 +99,7 @@ define(function (require, exports) {
      * with other actions that only require read locks, but will never be executed
      * concurrently with other actions that require any write locks.
      *
-     * @type {command: function(): Promise, reads: Array.<string>=, writes: Array.<string>=}
+     * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
      */
     var asyncActionReadOnly = {
         command: asyncCommand,

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -50,9 +50,10 @@ define(function (require, exports) {
     var PS_MAX_NEST_DEPTH = 9;
 
     /**
-     * @private
-     * @type {Array.<string>} Properties to be included when requesting layer
+     * Properties to be included when requesting layer
      * descriptors from Photoshop.
+     * @private
+     * @type {Array.<string>} 
      */
     var _layerProperties = [
         "layerID",
@@ -68,9 +69,11 @@ define(function (require, exports) {
     ];
 
     /**
-     * @private
-     * @type {Array.<string>} Properties to be included if present when requesting
+     * Properties to be included if present when requesting
      * layer descriptors from Photoshop.
+     * 
+     * @private
+     * @type {Array.<string>} 
      */
     var _optionalLayerProperties = [
         "adjustment",
@@ -259,7 +262,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {number|Array.<number>} layerSpec
      * @param {boolean=} selected Default is true
-     * @param {boolean= || number=} replace replace the layer with this ID, or use default logic if undefined
+     * @param {boolean= | number=} replace replace the layer with this ID, or use default logic if undefined
      * @return {Promise}
      */
     var addLayersCommand = function (document, layerSpec, selected, replace) {

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -50,7 +50,7 @@ define(function (require, exports) {
     /**
      * Execute a native Photoshop menu command.
      * 
-     * @param {{commandID: number, waitForCompletion:boolean?}} payload
+     * @param {{commandID: number, waitForCompletion: boolean?}} payload
      * @return {Promise}
      */
     var nativeCommand = function (payload) {

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -80,7 +80,7 @@ define(function (require, exports) {
      * @return {Promise.<{
      *             tool: Tool, 
      *             keyboardPolicyListID: number, 
-     *             pointerPolicyListID: number}
+     *             pointerPolicyListID: number
      *         }>}
      *         Resolves to the new tool and it's policy IDs
      */

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -364,7 +364,7 @@ define(function (require, exports) {
      *
      * @private
      * @param {Document} document Owner document
-     * @param {[<Layer>, <Layer>]} layers An array of two layers
+     * @param {Array.<Layer>} layers An array of two layers
      *
      * @return {Promise}
      */
@@ -492,7 +492,7 @@ define(function (require, exports) {
      * @private
      * @param {Document} document Owner document
      * @param {Layer|Immutable.Iterable.<Layer>} layerSpec Either a Layer reference or array of Layers
-     * @param {w: {number}, h: {number}} size New width and height of the layers
+     * @param {{w: number, h: number}} size New width and height of the layers
      *
      * @returns {Promise}
      */

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -40,8 +40,10 @@ define(function (require, exports) {
         strings = require("i18n!nls/strings");
 
     /**
+     * Minimum and maximum Photoshop-supported font sizes
+     * 
      * @const
-     * @type {number} Minimum and maximum Photoshop-supported font sizes
+     * @type {number} 
      */
     var PS_MIN_FONT_SIZE = 0.04,
         PS_MAX_FONT_SIZE = 5400;

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -35,9 +35,11 @@ define(function (require, exports) {
         synchronization = require("js/util/synchronization");
 
     /**
+     * Document properties needed to update the window transform
+     * 
      * @private
      * @const
-     * @type {Array.<string>} Document properties needed to update the window transform
+     * @type {Array.<string>} 
      */
     var _transformProperties = [
         "viewTransform",
@@ -241,7 +243,7 @@ define(function (require, exports) {
      * Options for key "on" are "document", "selection"
      * If zoomInto is provided, will zoom into the selection as well
      *
-     * @param {on: "document"|"selection", zoomInto: <boolean>} payload
+     * @param {{on: "document"|"selection", zoomInto: boolean}} payload
      * @return {Promise}
      */
     var centerOnCommand = function (payload) {
@@ -273,7 +275,7 @@ define(function (require, exports) {
      * Zooms in or out into the document
      * Right now doubles or halves the zoom depending on direction
      *
-     * @param {zoomIn: <boolean>} payload True if zooming in
+     * @param {{zoomIn: boolean}} payload True if zooming in
      * @return {Promise}
      */
     var zoomInOutCommand = function (payload) {
@@ -287,7 +289,7 @@ define(function (require, exports) {
      * Sets zoom to the value in the payload
      * Centering on the selection, pan is on by default
      *
-     * @param {zoom: <number>, pan: <boolean>} payload
+     * @param {{zoom: number, pan: boolean}} payload
      * @return {Promise}
      */
     var zoomCommand = function (payload) {

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -43,16 +43,20 @@ define(function (require, exports, module) {
         global = require("./util/global");
 
     /**
+     * Suffix used to name throttled actions.
+     * 
      * @const
-     * @type {string} Suffix used to name throttled actions.
+     * @type {string} 
      */
     var THROTTLED_ACTION_SUFFIX = "Throttled";
 
 
     /**
-     * @const
-     * @type {number} Maximum delay after which reset retry will continue
+     * Maximum delay after which reset retry will continue
      *  before failing definitively.
+     *  
+     * @const
+     * @type {number} 
      */
     var MAX_RETRY_WINDOW = 6400;
 
@@ -115,20 +119,25 @@ define(function (require, exports, module) {
     FluxController.prototype._flux = null;
 
     /**
+     * Whether the flux instance is running
      * @private
-     * @type {boolean} Whether the flux instance is running
+     * @type {boolean} 
      */
     FluxController.prototype._running = false;
 
     /**
+     * Used to synchronize flux action execution
+     * 
      * @private
-     * @type {ActionQueue} Used to synchronize flux action execution
+     * @type {ActionQueue} 
      */
     FluxController.prototype._actionQueue = null;
 
     /**
+     * Per-action cache of action receivers
+     * 
      * @private
-     * @type {Map.<Action, ActionReceiver>} Per-action cache of action receivers
+     * @type {Map.<Action, ActionReceiver>} 
      */
     FluxController.prototype._actionReceivers = null;
 
@@ -168,14 +177,16 @@ define(function (require, exports, module) {
 
         var receiver = Object.create(proto, {
             /**
-             * @type {FluxController} Provides direct controller access to actions
+             * Provides direct controller access to actions
+             * @type {FluxController} 
              */
             controller: {
                 value: self
             },
 
             /**
-             * @type {string} The name of this action
+             * The name of this action
+             * @type {string} 
              */
             actionName: {
                 value: actionName
@@ -240,7 +251,7 @@ define(function (require, exports, module) {
     /**
      * Get an action receiver for the given action, creating it if necessary.
      *
-     * @param {{flux: Flux: dispatch: function}} proto Fluxxor "dispatch binder",
+     * @param {{flux: Flux, dispatch: function}} proto Fluxxor "dispatch binder",
      *  which is used as the prototype for the action receiver.
      * @param {Action} action
      * @return {ActionReceiver}
@@ -527,21 +538,24 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Whether there is a reset pending
      * @private
-     * @type {boolean} Whether there is a reset pending
+     * @type {boolean} 
      */
     FluxController.prototype._resetPending = false;
     
     /**
+     * Initial reset retry delay
      * @private
      * @const
-     * @type {number} Initial reset retry delay
+     * @type {number} 
      */
     FluxController.prototype._resetRetryDelayInitial = 200;
 
     /**
+     * Current reset retry delay. Increases exponentially until quiescence.
      * @private
-     * @type {number} Current reset retry delay. Increases exponentially until quiescence.
+     * @type {number} 
      */
     FluxController.prototype._resetRetryDelay = FluxController.prototype._resetRetryDelayInitial;
 
@@ -587,8 +601,9 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Progressively throttled reset helper function
      * @private
-     * @type {function()} Progressively throttled reset helper function
+     * @type {function()} 
      */
     FluxController.prototype._resetHelper = null;
 

--- a/src/js/jsx/mixin/Coalesce.js
+++ b/src/js/jsx/mixin/Coalesce.js
@@ -26,14 +26,16 @@ define(function (require, exports, module) {
 
     module.exports = {
         /**
+         * Whether history state coalescing is in effect.
          * @private
-         * @type {boolean} Whether history state coalescing is in effect.
+         * @type {boolean} 
          */
         _coalescing: false,
 
         /**
+         * If coalescing is in effect, whether the next command should be coalesced.
          * @private
-         * @type {boolean} If coalescing is in effect, whether the next command should be coalesced.
+         * @type {boolean} 
          */
         _coalesce: false,
 

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
      * @param {object?} descriptor.pathBounds If available, will be parsed as shape layer
      * @param {object?} descriptor.boundsNoEffects Bounds object available for all layers
      *
-     * @return {top: number, left: number, bottom: number, right: number}
+     * @return {{top: number, left: number, bottom: number, right: number}}
      */
     Bounds.parseLayerDescriptor = function (descriptor) {
         var boundsObject;

--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -37,27 +37,32 @@ define(function (require, exports, module) {
      */
     var CharacterStyle = Immutable.Record({
         /**
-         * @type {string} PostScript font name
+         * PostScript font name
+         * @type {string} 
          */
         postScriptName: null,
 
         /**
-         * @type {number} Size in pixels
+         * Size in pixels
+         * @type {number} 
          */
         textSize: null,
 
         /**
-         * @type {Color} Opaque color
+         * Opaque color
+         * @type {Color} 
          */
         color: null,
 
         /**
-         * @type {number} Tracking (letter spacing) value
+         * Tracking (letter spacing) value
+         * @type {number} 
          */
         tracking: null,
 
         /**
-         * @type {?number} Leading (letter spacing) in pixels, or null if "auto-leading" is used.
+         * Leading (letter spacing) in pixels, or null if "auto-leading" is used.
+         * @type {?number} 
          */
         leading: null
     });

--- a/src/js/models/color.js
+++ b/src/js/models/color.js
@@ -105,7 +105,8 @@ define(function (require, exports, module) {
     Object.defineProperties(Color.prototype, objUtil.cachedGetSpecs({
         /**
          * The opacity percentage of this color object
-         * @type {number} In [0, 100] 
+         * In [0, 100] 
+         * @type {number} 
          */
         "opacity": function () {
             return mathjs.round(this.a * 100, 0);

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -38,66 +38,79 @@ define(function (require, exports, module) {
      */
     var Document = Immutable.Record({
         /**
-         * @type {number} Document ID
+         * Document ID
+         * @type {number} 
          */
         id: null,
 
         /**
-         * @type {boolean} Whether the document is dirty
+         * Whether the document is dirty
+         * @type {boolean} 
          */
         dirty: null,
 
         /**
-         * @type {string} Document name
+         * Document name
+         * @type {string} 
          */
         name: null,
 
         /**
-         * @type {boolean} True if there is a background layer (affects layer indexing)
+         * True if there is a background layer (affects layer indexing)
+         * @type {boolean} 
          */
         hasBackgroundLayer: null,
 
         /**
-         * @type {LayerTree} The layers in a tree format
+         * The layers in a tree format
+         * @type {LayerTree} 
          */
         layers: null,
 
         /**
-         * @type {Bounds} Document bounds
+         * Document bounds
+         * @type {Bounds} 
          */
         bounds: null,
 
         /**
-         * @type {number} Document resolution
+         * Document resolution
+         * @type {number} 
          */
         resolution: null,
 
         /**
-         * @type {Bounds} Document color mode
+         * Document color mode
+         * @type {Bounds} 
          */
         mode: null,
 
         /**
-         * @type {boolean} visibility of guides
+         * Visibility of guides
+         * @type {boolean} 
          */
         guidesVisible: null,
 
         /**
-         * @type {boolean} visibility of smart guides
+         * Visibility of smart guides
+         * @type {boolean} 
          */
         smartGuidesVisible: null,
 
 
         /**
-         * @type {string} If file is saved, contains the file type (e.g. "Photoshop" for PSD)
+         * If file is saved, contains the file type (e.g. "Photoshop" for PSD)
+         * @type {string} 
          */
         format: null
     });
 
     Object.defineProperties(Document.prototype, object.cachedGetSpecs({
         /**
-         * @type {boolean} Indicates whether there are features in the document
+         * Indicates whether there are features in the document
          *  that are currently unsupported.
+         *  
+         * @type {boolean} 
          */
         unsupported: function () {
             if (this.mode !== "RGBColor") {

--- a/src/js/models/eventpolicy.js
+++ b/src/js/models/eventpolicy.js
@@ -106,7 +106,7 @@ define(function (require, exports) {
      * @param {!number} action
      * @param {!number} event
      * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}}=} modifiers
-     * @param {{x: number, y: number, width: number: height: number}=} area
+     * @param {{x: number, y: number, width: number, height: number}=} area
      */
     var PointerEventPolicy = function (action, event, modifiers, area) {
         BaseEventPolicy.call(this, action, event, modifiers);
@@ -118,7 +118,7 @@ define(function (require, exports) {
     util.inherits(PointerEventPolicy, BaseEventPolicy);
 
     /**
-     * @type {{x: number, y: number, width: number: height: number}=}
+     * @type {{x: number, y: number, width: number, height: number}=}
      */
     PointerEventPolicy.prototype.area = null;
 

--- a/src/js/models/fill.js
+++ b/src/js/models/fill.js
@@ -51,12 +51,14 @@ define(function (require, exports, module) {
      */
     var Fill = Immutable.Record({
         /**
-         * @type {string} True if fill is enabled
+         * True if fill is enabled
+         * @type {string} 
          */
         type: null,
 
         /**
-         * @type {boolean} True if fill is enabled
+         * True if fill is enabled
+         * @type {boolean} 
          */
         enabled: true,
 

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -43,67 +43,80 @@ define(function (require, exports, module) {
      */
     var Layer = Immutable.Record({
         /**
-         * @type {number} Id of layer
+         * Id of layer
+         * @type {number} 
          */
         id: null,
 
         /**
-         * @param {string} A unique key for the layer.
+         * A unique key for the layer.
+         * @param {string}
          */
         key: null,
 
         /**
-         * @type {string} Layer name
+         * Layer name
+         * @type {string} 
          */
         name: null,
 
         /**
-         * @type {boolean} True if layer is visible
+         * True if layer is visible
+         * @type {boolean} 
          */
         visible: null,
 
         /**
-         * @type {boolean} True if layer is locked
+         * True if layer is locked
+         * @type {boolean} 
          */
         locked: null,
 
         /**
-         * @type {boolean} True if layer is selected
+         * True if layer is selected
+         * @type {boolean} 
          */
         selected: null,
 
         /**
-         * @type {number} Layer Kind
+         * Layer Kind
+         * @type {number} 
          */
         kind: null,
 
         /**
-         * @type {Bounds} Bounding rectangle for this layer
+         * Bounding rectangle for this layer
+         * @type {Bounds} 
          */
         bounds: null,
 
         /**
-         * @type {boolean} True if this layer is a background layer
+         * True if this layer is a background layer
+         * @type {boolean} 
          */
         isBackground: null,
 
         /**
-         * @type {number} Layer opacity as a percentage in [0,100];
+         * Layer opacity as a percentage in [0,100];
+         * @type {number} 
          */
         opacity: null,
 
         /**
-         * @type {string} Blend mode ID.
+         * Blend mode ID.
+         * @type {string} 
          */
         blendMode: "normal",
 
         /**
-         * @type {Immutable.List.<Stroke>} stroke information
+         * stroke information
+         * @type {Immutable.List.<Stroke>} 
          */
         strokes: null,
 
         /**
-         * @type {?Radii} Border radii
+         * Border radii
+         * @type {?Radii} 
          */
         radii: null,
 
@@ -164,8 +177,9 @@ define(function (require, exports, module) {
 
     Object.defineProperties(Layer.prototype, object.cachedGetSpecs({
         /**
-         * @type {boolean} Indicates whether there are features in the layer
+         * Indicates whether there are features in the layer
          *  that are currently unsupported.
+         * @type {boolean} 
          */
         unsupported: function () {
             switch (this.kind) {

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -162,8 +162,10 @@ define(function (require, exports, module) {
         },
 
         /**
-         * @type {boolean} Indicates whether there are features in the document
+         * Indicates whether there are features in the document
          *  that are currently unsupported.
+         *  
+         * @type {boolean} 
          */
         "unsupported": function () {
             return this.layers.some(function (layer) {
@@ -281,7 +283,7 @@ define(function (require, exports, module) {
 
         /**
          * Overall bounds of selection
-         * @type {<Bounds>}
+         * @type {Bounds}
          */
         "selectedAreaBounds": function () {
             return Bounds.union(this.selectedChildBounds);
@@ -387,7 +389,7 @@ define(function (require, exports, module) {
          * 2) Any selected layers are locked
          * 3) No layers are selected
          * 
-         * @type {boolean} If any selected layers are locked, or if none are selected
+         * @return {boolean} If any selected layers are locked, or if none are selected
          */
         "selectedLocked": function () {
             var selectedLayers = this.selected;
@@ -713,7 +715,7 @@ define(function (require, exports, module) {
      * @param {Array.<object>} descriptors Photoshop layer descriptors
      * @param {boolean} selected Whether the new layer should be selected. If
      *  so, the existing selection is cleared.
-     * @param {boolean= || number=} replace can be explicitly false, undefined, or a layer ID
+     * @param {boolean= | number=} replace can be explicitly false, undefined, or a layer ID
      * @param {Document} document
      * @return {LayerStructure}
      */
@@ -1240,7 +1242,7 @@ define(function (require, exports, module) {
      * 
      * @param {Immutable.Iterable.<number>} layerIDs
      * @param {number} strokeIndex
-     * @param {object || Immutable.Iterable.<object>} strokeStyleDescriptor
+     * @param {object | Immutable.Iterable.<object>} strokeStyleDescriptor
      * @return {LayerStructure}
      */
     LayerStructure.prototype.addStroke = function (layerIDs, strokeIndex, strokeStyleDescriptor) {
@@ -1273,9 +1275,9 @@ define(function (require, exports, module) {
      * Set basic properties of the layerEffect at the given index of the given layers.
      * 
      * @param {Immutable.Iterable.<number>} layerIDs
-     * @param {number || Immutable.List.<number>} layerEffectIndex index of effect, or per-layer List thereof
+     * @param {number | Immutable.List.<number>} layerEffectIndex index of effect, or per-layer List thereof
      * @param {string} layerEffectType type of layer effect
-     * @param {object || Immutable.List.<object>} layerEffectProperties properties to merge, or per-layer List thereof
+     * @param {object | Immutable.List.<object>} layerEffectProperties properties to merge, or per-layer List thereof
      * @return {LayerStructure}
      */
     LayerStructure.prototype.setLayerEffectProperties = function (layerIDs,

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -447,7 +447,7 @@ define(function (require, exports, module) {
     /**
      * Private variables defined here for switch document shortcuts
      *
-     * @type {[type]}
+     * @type {Object}
      */
     var _switchDocModifiersMac = {
             "command": true,

--- a/src/js/models/menuitem.js
+++ b/src/js/models/menuitem.js
@@ -41,22 +41,26 @@ define(function (require, exports, module) {
      */
     var MenuItem = Immutable.Record({
         /**
-         * @type {string} "separator" for separators, unused otherwise
+         * "separator" for separators, unused otherwise
+         * @type {string} 
          */
         type: null,
 
         /**
-         * @type {string} ID of the menu item, building up from Root
+         * ID of the menu item, building up from Root
+         * @type {string} 
          */
         id: null,
 
         /**
-         * @type {string} in place identifier of menu item
+         * In-place identifier of menu item
+         * @type {string} 
          */
         itemID: null,
 
         /**
-         * @type {string} Localized label to show for this item
+         *  Localized label to show for this item
+         * @type {string}
          */
         label: null,
 
@@ -66,7 +70,8 @@ define(function (require, exports, module) {
         submenu: null,
 
         /**
-         * @type {Immutable.Map.<string, MenuItem>} Maps from itemID to submenus, sans separators
+         * Maps from itemID to submenus, sans separators
+         * @type {Immutable.Map.<string, MenuItem>} 
          */
         submenuMap: null,
 

--- a/src/js/models/radii.js
+++ b/src/js/models/radii.js
@@ -39,22 +39,26 @@ define(function (require, exports, module) {
      */
     var Radii = Immutable.Record({
         /**
-         * @type {number} Radius of the top-left border
+         * Radius of the top-left border
+         * @type {number} 
          */
         topLeft: 0,
 
         /**
-         * @type {number} Radius of the top-right border
+         * Radius of the top-right border
+         * @type {number} 
          */
         topRight: 0,
 
         /**
-         * @type {number} Radius of the bottom-right border
+         * Radius of the bottom-right border
+         * @type {number} 
          */
         bottomRight: 0,
 
         /**
-         * @type {number} Radius of the bottom-left border
+         * Radius of the bottom-left border
+         * @type {number} 
          */
         bottomLeft: 0
     });

--- a/src/js/models/shadow.js
+++ b/src/js/models/shadow.js
@@ -32,8 +32,10 @@ define(function (require, exports, module) {
         objUtil = require("js/util/object");
     
     /**
+     * Maximum Photoshop-supported shadow distance
+     * 
      * @const
-     * @type {number} Maximum Photoshop-supported shadow distance
+     * @type {number} 
      */
     var MAX_DISTANCE = 30000;
 
@@ -82,38 +84,45 @@ define(function (require, exports, module) {
      */
     var Shadow = Immutable.Record({
         /**
-         * @type {boolean} True if shadow is enabled
+         * True if shadow is enabled
+         * @type {boolean} 
          */
         enabled: true,
 
         /**
-         * @type {Color} Color of the shadow
+         * Color of the shadow
+         * @type {Color} 
          */
         color: Color.DEFAULT,
 
         /**
-         * @type {number} x coordinate of the shadow
+         * X coordinate of the shadow
+         * @type {number} 
          */
         x: 0,
 
         /**
-         * @type {number} y coordinate of the shadow
+         * Y coordinate of the shadow
+         * @type {number} 
          */
         y: 5,
 
         /**
-         * @type {number} blur size in pixels
+         * Blur size in pixels
+         * @type {number} 
          */
         blur: 5,
 
         /**
-         * @type {number} spread size in pixels
+         * Spread size in pixels
+         * @type {number} 
          */
         spread: 5,
 
         /**
-        * @type {BlendMode} blend mode of the shadow
-        */
+         * Blend mode of the shadow
+         * @type {BlendMode} 
+         */
         blendMode: "multiply"
 
     });
@@ -227,7 +236,7 @@ define(function (require, exports, module) {
      * Construct a list of Shadow models from a Photoshop layer descriptor.
      * 
      * @param {object} layerDescriptor
-     * @return {Immutable.List.<Shadow)}
+     * @return {Immutable.List.<Shadow>}
      */
     Shadow.fromLayerDescriptor = function (layerDescriptor, kind) {
         var layerEffects = layerDescriptor.layerEffects;

--- a/src/js/models/stroke.js
+++ b/src/js/models/stroke.js
@@ -64,12 +64,14 @@ define(function (require, exports, module) {
      */
     var Stroke = Immutable.Record({
         /**
-         * @type {string} Stroke type: pattern, color, or gradient 
+         * Stroke type
+         * @type {"pattern"|"color"|"gradient"} 
          */
         type: null,
 
         /**
-         * @type {boolean} True if stroke is enabled
+         * True if stroke is enabled
+         * @type {boolean} 
          */
         enabled: true,
 
@@ -79,12 +81,14 @@ define(function (require, exports, module) {
         color: Color.DEFAULT,
 
         /**
-         * @type {number} width value of the stroke
+         * Stroke Width
+         * @type {number}
          */
         width: 5,
 
         /**
-         * @type {string=} alignment type, optionally inside, outside, or center
+         * alignment type, optionally inside, outside, or center
+         * @type {"inside"|"outside"|"center"} 
          */
         alignment: null
     });

--- a/src/js/models/text.js
+++ b/src/js/models/text.js
@@ -47,12 +47,14 @@ define(function (require, exports, module) {
         paragraphStyles: null,
 
         /**
-         * @type {boolean} Indicates whether the text flows within a bounding box.
+         * Indicates whether the text flows within a bounding box.
+         * @type {boolean} 
          */
         box: null,
 
         /**
-         * @type {boolean} Indicates whether the text has been transformed.
+         * Indicates whether the text has been transformed.
+         * @type {boolean} 
          */
         hasTransform: false
     });

--- a/src/js/scrim/TransformScrim.js
+++ b/src/js/scrim/TransformScrim.js
@@ -1005,7 +1005,7 @@ define(function (require, exports, module) {
     /**
      * Bounds that are updated every time the drag quadrant changes
      *
-     * @type {[type]}
+     * @type {Bounds}
      */
     TransformScrim.prototype._quadrantBounds = null;
 

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -36,32 +36,46 @@ define(function (require, exports, module) {
     var DragAndDropStore = Fluxxor.createStore({
 
         /**
-         * @type {Immutable.OrderedMap.{b: bounds, 
+         * All available drop targets
+         * 
+         * @private
+         * @type {Immutable.OrderedMap<{b: bounds, 
          *                              node: DOMNode, 
          *                              keyObject: object, 
          *                              validate: function, 
-         *                              onDrop: function}} 
-         *  All available drop targets
+         *                              onDrop: function}>}  
          */
         _dropTargets: new Immutable.OrderedMap(),
 
         /**
-         * @type {List} Currently Active drag targets
+         * Currently Active drag targets
+         * 
+         * @private
+         * @type {List} 
          */
         _dragTargets: null,
 
         /**
-         * @type {object} Currently Active drop target
+         * Currently Active drop target
+         * 
+         * @private
+         * @type {object}
          */
         _dropTarget: null,
 
         /**
-         * @type {Object} Past drag target (for maintaining position during render)
+         * Past drag target (for maintaining position during render)
+         * 
+         * @private
+         * @type {Object} 
          */
         _pastDragTarget: null,
 
         /**
-         * @type {{top: number, bottom: number, left: number, right: number}} Bounds for current drop target
+         * Bounds for current drop target
+         *
+         * @private
+         * @type {{top: number, bottom: number, left: number, right: number}} 
          */
         _currentBounds: null,
 
@@ -129,7 +143,7 @@ define(function (require, exports, module) {
          * Sets _dragPosition which is used for moving dragged object on screen 
          * Emits change event which causes re-render
          *
-         * @param {object {x: number, y: number}} point Point where event occurred
+         * @param {{x: number, y: number}} point Point where event occurred
          */
         moveAndCheckBounds: function (point) {
             this.checkBounds(point);
@@ -148,7 +162,7 @@ define(function (require, exports, module) {
          * - Somehow cache getBoundingClientRect to make this faster
          * - Could consider using throttle here to stop some wasted calls - throttle around 16ms for 60fps
          *
-         * @param {object {x: number, y: number}} point Point were event occurred
+         * @param {{x: number, y: number}} point Point were event occurred
          *
          */
         checkBounds: function (point) {

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
          * Map of history states, keyed by the document ID
          * Values are an Immutable.List of HistoryStates
          *
-         * @type {Immutable.Map<number, Immutable.List.<HistoryState>>> }
+         * @type {Immutable.Map<number, Immutable.List.<HistoryState>>}
          */
         _history: null,
 

--- a/src/js/stores/preferences.js
+++ b/src/js/stores/preferences.js
@@ -32,14 +32,18 @@ define(function (require, exports, module) {
 
 
     /**
+     * The key at which the preferences index is stored.
+     * 
      * @const
-     * @type {string} The key at which the preferences index is stored.
+     * @type {string} 
      */
     var PREF_INDEX = "com.adobe.photoshop.prefs.index";
 
     /**
+     * The prefix with which preference keys are qualified.
+     * 
      * @const
-     * @type {string} The prefix with which preference keys are qualified.
+     * @type {string} 
      */
     var PREF_PREFIX = "com.adobe.photoshop.prefs.keys.";
 

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
          * The set of logical tools.
          * 
          * @const
-         * @type {Object.<string: Tool>}
+         * @type {{string: Tool}}
          */
         _allTools: null,
 

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
         /**
          * Center offsets to be applied to zoom calculations
          *
-         * @type {{top: <number>, left: <number>, bottom: <number>, right: <number>}}
+         * @type {{top: number, left: number, bottom: number, right: number}}
          */
         _centerOffsets: null,
 
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
          * Updates the center offsets when they change
          *
          * @private
-         * @param {{propertiesWidth: <number>, headerHeight: <number>}} payload
+         * @param {{propertiesWidth: number, headerHeight: number}} payload
          */
         _handlePanelResize: function (payload) {
             this._propertiesWidth = payload.propertiesWidth;
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
          * Updates the right center offset when toolbar is pinned
          *
          * @private
-         * @param {{toolbarWidth: <number>}} payload
+         * @param {{toolbarWidth: number}} payload
          */
         _handleToolbarPin: function (payload) {
             this._toolbarWidth = payload.toolbarWidth;
@@ -432,7 +432,7 @@ define(function (require, exports, module) {
         /**
          * Updates the marquee start location and flag
          *
-         * @param {{x: number, y: number, enabled: <boolean>}} payload
+         * @param {{x: number, y: number, enabled: boolean}} payload
          */
         _handleMarqueeStart: function (payload) {
             this._marqueeEnabled = payload.enabled;

--- a/src/js/util/global.js
+++ b/src/js/util/global.js
@@ -25,8 +25,10 @@ define(function (require, exports) {
     "use strict";
 
     /**
+     * Indicates whether the application is running in debug mode.
+     * 
      * @const
-     * @type {boolean} Indicates whether the application is running in debug mode.
+     * @type {boolean} 
      */
     var DEBUG = !!window.__PG_DEBUG__;
 

--- a/src/js/util/locking.js
+++ b/src/js/util/locking.js
@@ -97,7 +97,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers
      * @param {boolean} hide Hide if true, show if false
      *
-     * @return {[type]} [description]
+     * @return {playObject}
      */
     var _layerHiding = function (document, layers, hide) {
         var layerIDs = collection.pluck(layers, "id").toArray(),

--- a/src/js/util/math.js
+++ b/src/js/util/math.js
@@ -89,10 +89,12 @@ define(function (require, exports) {
     };
 
     /**
+     * A small number used to account for rounding errors when
+     *  determining whether a vector is scaled.
+     *  
      * @private
      * @const
-     * @type {number} A small number used to account for rounding errors when
-     *  determining whether a vector is scaled.
+     * @type {number} 
      */
     var _EPSILON = 1 - 0.99999;
 


### PR DESCRIPTION
Does not fully create the documentation yet, but checks for valid JSDoc on `grunt`.