### PR TITLE
Get rid of action objects, instead define properties of action functions

### DIFF
--- a/src/js/actions/application.js
+++ b/src/js/actions/application.js
@@ -36,7 +36,7 @@ define(function (require, exports) {
      * Gets the application version
      * @return {Promise}
      */
-    var hostVersionCommand = function () {
+    var hostVersion = function () {
         return descriptor.getProperty("application", "hostVersion")
             .bind(this)
             .get("_value")
@@ -48,13 +48,15 @@ define(function (require, exports) {
                 this.dispatch(events.application.HOST_VERSION, payload);
             });
     };
+    hostVersion.reads = [locks.PS_APP];
+    hostVersion.writes = [locks.JS_APP];
 
     /** 
      * Gets list of recently opened files from Photoshop
      *
      * @return {Promise}
      */
-    var updateRecentFilesCommand = function () {
+    var updateRecentFiles = function () {
         return descriptor.getProperty("application", "recentFilesAsStrings")
             .bind(this)
             .catch(function () {
@@ -70,39 +72,24 @@ define(function (require, exports) {
                 this.dispatch(events.application.INITIALIZED, { item: "recentFiles" });
             });
     };
+    updateRecentFiles.reads = [locks.PS_APP];
+    updateRecentFiles.writes = [locks.JS_APP];
 
     /**
      * During init, grabs the recent file list for the menu
      *
      * @return {Promise}
      */
-    var afterStartupCommand = function () {
+    var afterStartup = function () {
         var updateRecentFilesPromise = this.transfer(updateRecentFiles),
             setRulerUnitsPromise = descriptor.playObject(ruler.setRulerUnits("rulerPixels"));
 
         return Promise.join(setRulerUnitsPromise, updateRecentFilesPromise);
     };
-
-    var hostVersion = {
-        command: hostVersionCommand,
-        reads: [locks.PS_APP],
-        writes: [locks.JS_APP]
-    };
-
-    var updateRecentFiles = {
-        command: updateRecentFilesCommand,
-        reads: [locks.PS_APP],
-        writes: [locks.JS_APP]
-    };
-
-    var afterStartup = {
-        command: afterStartupCommand,
-        reads: [locks.PS_APP],
-        writes: [locks.JS_APP]
-    };
+    afterStartup.reads = [locks.PS_APP];
+    afterStartup.writes = [locks.JS_APP];
 
     exports.hostVersion = hostVersion;
     exports.updateRecentFiles = updateRecentFiles;
-
     exports.afterStartup = afterStartup;
 });

--- a/src/js/actions/dialog.js
+++ b/src/js/actions/dialog.js
@@ -35,7 +35,7 @@ define(function (require, exports) {
      * @param {object} dismissalPolicy
      * @return {Promise}
      */
-    var registerDialogCommand = function (id, dismissalPolicy) {
+    var registerDialog = function (id, dismissalPolicy) {
         var payload = {
             id: id,
             dismissalPolicy: dismissalPolicy
@@ -43,6 +43,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.dialog.REGISTER_DIALOG, payload);
     };
+    registerDialog.reads = [];
+    registerDialog.writes = [locks.JS_DIALOG];
 
     /**
      * Deregister a dialog with a given ID
@@ -51,13 +53,15 @@ define(function (require, exports) {
      * @param {string} id
      * @return {Promise}
      */
-    var deregisterDialogCommand = function (id) {
+    var deregisterDialog = function (id) {
         var payload = {
             id: id
         };
 
         return this.dispatchAsync(events.dialog.DEREGISTER_DIALOG, payload);
     };
+    deregisterDialog.reads = [];
+    deregisterDialog.writes = [locks.JS_DIALOG];
 
     /**
      * Open a dialog with a given ID and optional dismissal policy.
@@ -68,7 +72,7 @@ define(function (require, exports) {
      * @param {object=} dismissalPolicy
      * @return {Promise}
      */
-    var openDialogCommand = function (id, dismissalPolicy) {
+    var openDialog = function (id, dismissalPolicy) {
         var payload = {
             id: id,
             dismissalPolicy: dismissalPolicy
@@ -76,6 +80,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.dialog.OPEN_DIALOG, payload);
     };
+    openDialog.reads = [];
+    openDialog.writes = [locks.JS_DIALOG];
 
     /**
      * Close an already open dialog with the given ID.
@@ -84,13 +90,15 @@ define(function (require, exports) {
      * @param {string} id
      * @return {Promise}
      */
-    var closeDialogCommand = function (id) {
+    var closeDialog = function (id) {
         var payload = {
             id: id
         };
 
         return this.dispatchAsync(events.dialog.CLOSE_DIALOG, payload);
     };
+    closeDialog.reads = [];
+    closeDialog.writes = [locks.JS_DIALOG];
 
     /**
      * Close all open dialogs.
@@ -98,54 +106,11 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var closeAllDialogsCommand = function () {
+    var closeAllDialogs = function () {
         return this.dispatchAsync(events.dialog.CLOSE_DIALOG);
     };
-
-    /**
-     * @type {Action}
-     */
-    var registerDialog = {
-        command: registerDialogCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var deregisterDialog = {
-        command: deregisterDialogCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var openDialog = {
-        command: openDialogCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var closeDialog = {
-        command: closeDialogCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var closeAllDialogs = {
-        command: closeAllDialogsCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
+    closeAllDialogs.reads = [];
+    closeAllDialogs.writes = [locks.JS_DIALOG];
 
     exports.registerDialog = registerDialog;
     exports.deregisterDialog = deregisterDialog;

--- a/src/js/actions/draganddrop.js
+++ b/src/js/actions/draganddrop.js
@@ -37,7 +37,7 @@ define(function (require, exports) {
     * @param {Object} keyObject Model object which is represented by this node
     * @return {Promise}
     */
-    var registerDroppableCommand = function (dropTarget, key, validateDrop, onDrop, keyObject) {
+    var registerDroppable = function (dropTarget, key, validateDrop, onDrop, keyObject) {
         var payload = {
             node: dropTarget,
             key: key,
@@ -48,6 +48,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.droppable.REGISTER_DROPPABLE, payload);
     };
+    registerDroppable.reads = [];
+    registerDroppable.writes = [];
 
     /**
     * Remove a drop target by key
@@ -55,9 +57,11 @@ define(function (require, exports) {
     * @param {string} key Unique key for droppable
     * @return {Promise}
     */
-    var deregisterDroppableCommand = function (key) {
+    var deregisterDroppable = function (key) {
         return this.dispatchAsync(events.droppable.DEREGISTER_DROPPABLE, key);
     };
+    deregisterDroppable.reads = [];
+    deregisterDroppable.writes = [];
 
     /**
     * Fire event that dragging started
@@ -65,18 +69,22 @@ define(function (require, exports) {
     * @param {Immutable.List} dragTarget List of currently dragging items
     * @return {Promise}
     */
-    var registerDraggingCommand = function (dragTarget) {
+    var registerDragging = function (dragTarget) {
         return this.dispatchAsync(events.droppable.REGISTER_DRAGGING, dragTarget);
     };
+    registerDragging.reads = [];
+    registerDragging.writes = [];
 
     /**
     * Fire event that dragging stopped
     *
     * @return {Promise}    
     */
-    var stopDraggingCommand = function () {
+    var stopDragging = function () {
         return this.dispatchAsync(events.droppable.STOP_DRAGGING);
     };
+    registerDragging.reads = [];
+    registerDragging.writes = [];
 
     /**
     * Check the intersection of the current dragTarget and available drop targets
@@ -84,39 +92,11 @@ define(function (require, exports) {
     * @param {{x: number, y: number}} point Point from event
     * @return {Promise}    
     */
-    var moveAndCheckBoundsCommand = function (point) {
+    var moveAndCheckBounds = function (point) {
         return this.dispatchAsync(events.droppable.MOVE_AND_CHECK_BOUNDS, point);
     };
-
-    var registerDroppable = {
-        command: registerDroppableCommand,
-        reads: [],
-        writes: []
-    };
-
-    var deregisterDroppable = {
-        command: deregisterDroppableCommand,
-        reads: [],
-        writes: []
-    };
-
-    var registerDragging = {
-        command: registerDraggingCommand,
-        reads: [],
-        writes: []
-    };
-
-    var stopDragging = {
-        command: stopDraggingCommand,
-        reads: [],
-        writes: []
-    };
-
-    var moveAndCheckBounds = {
-        command: moveAndCheckBoundsCommand,
-        reads: [],
-        writes: []
-    };
+    moveAndCheckBounds.reads = [];
+    moveAndCheckBounds.writes = [];
 
     exports.registerDroppable = registerDroppable;
     exports.deregisterDroppable = deregisterDroppable;

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -87,11 +87,14 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var nativeCutCommand = function () {
+    var nativeCut = function () {
         return this.flux.actions.menu.nativeModal({
             commandID: CUT_NATIVE_MENU_COMMMAND_ID
         });
     };
+    nativeCut.modal = true;
+    nativeCut.reads = [];
+    nativeCut.writes = [];
 
     /**
      * Execute a native copy command.
@@ -99,11 +102,14 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var nativeCopyCommand = function () {
+    var nativeCopy = function () {
         return this.flux.actions.menu.nativeModal({
             commandID: COPY_NATIVE_MENU_COMMMAND_ID
         });
     };
+    nativeCopy.modal = true;
+    nativeCopy.reads = [];
+    nativeCopy.writes = [];
 
     /**
      * Execute a native paste command.
@@ -111,11 +117,14 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var nativePasteCommand = function () {
+    var nativePaste = function () {
         return this.flux.actions.menu.nativeModal({
             commandID: PASTE_NATIVE_MENU_COMMMAND_ID
         });
     };
+    nativePaste.modal = true;
+    nativePaste.reads = [];
+    nativePaste.writes = [];
 
     /**
      * Execute a native selectAll command.
@@ -124,7 +133,7 @@ define(function (require, exports) {
      * @param {boolean} waitForCompletion Flag for nativeModal
      * @return {Promise}
      */
-    var nativeSelectAllCommand = function (waitForCompletion) {
+    var nativeSelectAll = function (waitForCompletion) {
         waitForCompletion = waitForCompletion || false;
 
         return this.flux.actions.menu.nativeModal({
@@ -132,6 +141,9 @@ define(function (require, exports) {
             waitForCompletion: waitForCompletion
         });
     };
+    nativeSelectAll.modal = true;
+    nativeSelectAll.reads = [];
+    nativeSelectAll.writes = [];
 
     /**
      * Execute either a cut or copy operation, depending on the value of the parameter.
@@ -140,7 +152,7 @@ define(function (require, exports) {
      * @param {boolean} cut If true, perform a cut operation; otherwise, a copy.
      * @return {Promise}
      */
-    var _cutOrCopyCommand = function (cut) {
+    var _cutOrCopy = function (cut) {
         return os.hasKeyboardFocus()
             .bind(this)
             .then(function (cefHasFocus) {
@@ -205,9 +217,12 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var cutCommand = function () {
-        return _cutOrCopyCommand.call(this, true);
+    var cut = function () {
+        return _cutOrCopy.call(this, true);
     };
+    cut.modal = true;
+    cut.reads = [];
+    cut.writes = [locks.JS_DOC, locks.PS_DOC];
 
     /**
      * Execute a copy operation on the currently active HTML element.
@@ -215,9 +230,12 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var copyCommand = function () {
-        return _cutOrCopyCommand.call(this, false);
+    var copy = function () {
+        return _cutOrCopy.call(this, false);
     };
+    copy.modal = true;
+    copy.reads = [locks.JS_DOC];
+    copy.writes = [];
 
     /**
      * Execute a paste operation on the currently active HTML element.
@@ -225,7 +243,7 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var pasteCommand = function () {
+    var paste = function () {
         return os.hasKeyboardFocus()
             .bind(this)
             .then(function (cefHasFocus) {
@@ -293,6 +311,9 @@ define(function (require, exports) {
                 }
             });
     };
+    paste.modal = true;
+    paste.reads = [];
+    paste.writes = [locks.JS_DOC, locks.PS_DOC];
 
     /**
      * Execute a select operation on the currently active HTML element.
@@ -300,7 +321,7 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var selectAllCommand = function () {
+    var selectAll = function () {
         return os.hasKeyboardFocus()
             .bind(this)
             .then(function (cefHasFocus) {
@@ -319,6 +340,9 @@ define(function (require, exports) {
                 }
             });
     };
+    selectAll.modal = true;
+    selectAll.reads = [];
+    selectAll.writes = [];
 
     /**
      * Step Backwards by transferring to the appropriate history action
@@ -326,7 +350,7 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var undoCommand = function () {
+    var undo = function () {
         var currentDocument = this.flux.store("application").getCurrentDocument();
         if (!currentDocument) {
             return Promise.resolve();
@@ -339,6 +363,8 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
+    undo.reads = [locks.PS_DOC];
+    undo.writes = [locks.JS_DOC, locks.JS_HISTORY];
 
     /**
      * Step Forward by transferring to the appropriate history action
@@ -346,7 +372,7 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var redoCommand = function () {
+    var redo = function () {
         var currentDocument = this.flux.store("application").getCurrentDocument();
         if (!currentDocument) {
             return Promise.resolve();
@@ -359,99 +385,8 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
-
-
-    /**
-     * @type {Action}
-     */
-    var cut = {
-        command: cutCommand,
-        modal: true,
-        reads: [],
-        writes: [locks.JS_DOC, locks.PS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var copy = {
-        command: copyCommand,
-        modal: true,
-        reads: [locks.JS_DOC],
-        writes: []
-    };
-
-    /**
-     * @type {Action}
-     */
-    var paste = {
-        command: pasteCommand,
-        modal: true,
-        reads: [],
-        writes: [locks.JS_DOC, locks.PS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var selectAll = {
-        command: selectAllCommand,
-        modal: true,
-        reads: [],
-        writes: []
-    };
-
-    /**
-     * @type {Action}
-     */
-    var nativeCut = {
-        command: nativeCutCommand,
-        modal: true,
-        reads: [],
-        writes: []
-    };
-
-    /**
-     * @type {Action}
-     */
-    var nativeCopy = {
-        command: nativeCopyCommand,
-        modal: true,
-        reads: [],
-        writes: []
-    };
-
-    /**
-     * @type {Action}
-     */
-    var nativePaste = {
-        command: nativePasteCommand,
-        modal: true,
-        reads: [],
-        writes: []
-    };
-
-    /**
-     * @type {Action}
-     */
-    var nativeSelectAll = {
-        command: nativeSelectAllCommand,
-        modal: true,
-        reads: [],
-        writes: []
-    };
-
-    var undo = {
-        command: undoCommand,
-        reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC, locks.JS_HISTORY]
-    };
-
-    var redo = {
-        command: redoCommand,
-        reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC, locks.JS_HISTORY]
-    };
+    redo.reads = [locks.PS_DOC];
+    redo.writes = [locks.JS_DOC, locks.JS_HISTORY];
 
     exports.nativeCut = nativeCut;
     exports.nativeCopy = nativeCopy;

--- a/src/js/actions/example.js
+++ b/src/js/actions/example.js
@@ -35,7 +35,7 @@ define(function (require, exports) {
      * @param {number} count Example paramter
      * @return {!Promise}
      */
-    var syncCommand = function (count) {
+    var syncAction = function (count) {
         var payload = {
             count: count
         };
@@ -46,24 +46,13 @@ define(function (require, exports) {
     };
 
     /**
-     * Example synchonous action, which includes a command and optionally lists
-     * of read and write locks that must be acquired before the command can safely
-     * be executed.
-     *
-     * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
-     */
-    var syncAction = {
-        command: syncCommand
-    };
-
-    /**
      * Example asynchronous command. Returned promise does not resolve until all
      * events have been dispatched.
      * 
      * @param {number} count Example paramter
      * @return {!Promise}
      */
-    var asyncCommand = function (count) {
+    var async = function (count) {
         return new Promise(function (resolve) {
             var payload = {
                 count: count
@@ -88,10 +77,8 @@ define(function (require, exports) {
      *
      * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
      */
-    var asyncActionReadWrite = {
-        command: asyncCommand,
-        writes: locks.ALL_LOCKS
-    };
+    var asyncActionReadWrite = function () { return async.apply(this, arguments); };
+    asyncActionReadWrite.writes = locks.ALL_LOCKS;
 
     /**
      * Example asynchonous action. This action acquires all read locks but no
@@ -101,11 +88,9 @@ define(function (require, exports) {
      *
      * @type {{command: function, reads: Array.<string>=, writes: Array.<string>=}}
      */
-    var asyncActionReadOnly = {
-        command: asyncCommand,
-        reads: locks.ALL_LOCKS,
-        writes: []
-    };
+    var asyncActionReadOnly = function () { return async.apply(this, arguments); };
+    asyncActionReadOnly.reads = locks.ALL_LOCKS;
+    asyncActionReadOnly.writes = [];
 
     exports.syncAction = syncAction;
     exports.asyncActionReadOnly = asyncActionReadOnly;

--- a/src/js/actions/help.js
+++ b/src/js/actions/help.js
@@ -34,18 +34,22 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var openFirstLaunchCommand = function () {
+    var openFirstLaunch = function () {
         return this.transfer(dialog.openDialog, "first-launch-dialog");
     };
+    openFirstLaunch.reads = [];
+    openFirstLaunch.writes = [locks.JS_DIALOG];
 
     /**
      * Open the keyboard shortcuts dialog.
      *
      * @return {Promise}
      */
-    var openKeyboardShortcutsCommand = function () {
+    var openKeyboardShortcuts = function () {
         return this.transfer(dialog.openDialog, "keyboard-shortcut-dialog");
     };
+    openKeyboardShortcuts.reads = [];
+    openKeyboardShortcuts.writes = [locks.JS_DIALOG];
 
     /**
      * After startup, display the "first launch" dialog, 
@@ -53,7 +57,7 @@ define(function (require, exports) {
      * 
      * @return {Promise}
      */
-    var afterStartupCommand = function () {
+    var afterStartup = function () {
         var preferences = this.flux.store("preferences").getState();
 
         if (preferences.get("showFirstLaunch", true)) {
@@ -62,24 +66,8 @@ define(function (require, exports) {
             return Promise.resolve();
         }
     };
-
-    var openFirstLaunch = {
-        command: openFirstLaunchCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    var openKeyboardShortcuts = {
-        command: openKeyboardShortcutsCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
-
-    var afterStartup = {
-        command: afterStartupCommand,
-        reads: [locks.JS_PREF],
-        writes: [locks.JS_DIALOG]
-    };
+    afterStartup.reads = [locks.JS_PREF];
+    afterStartup.writes = [locks.JS_DIALOG];
 
     exports.openFirstLaunch = openFirstLaunch;
     exports.openKeyboardShortcuts = openKeyboardShortcuts;

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -29,8 +29,10 @@ define(function (require, exports, module) {
         application: require("./application"),
         dialog: require("./dialog"),
         documents: require("./documents"),
+        draganddrop: require("./draganddrop"),
         edit: require("./edit"),
         example: require("./example"),
+        help: require("./help"),
         history: require("./history"),
         keyevents: require("./keyevents"),
         layers: require("./layers"),
@@ -38,15 +40,13 @@ define(function (require, exports, module) {
         menu: require("./menu"),
         policy: require("./policy"),
         preferences: require("./preferences"),
+        search: require("./search"),
         shapes: require("./shapes"),
         shortcuts: require("./shortcuts"),
         superselect: require("./superselect"),
         tools: require("./tools"),
         transform: require("./transform"),
         type: require("./type"),
-        ui: require("./ui"),
-        help: require("./help"),
-        search: require("./search"),
-        draganddrop: require("./draganddrop")
+        ui: require("./ui")
     };
 });

--- a/src/js/actions/keyevents.js
+++ b/src/js/actions/keyevents.js
@@ -93,11 +93,13 @@ define(function (require, exports) {
      * 
      * @return {Promise}
      */
-    var beforeStartupCommand = function () {
+    var beforeStartup = function () {
         os.addListener(os.notifierKind.EXTERNAL_KEYEVENT, _externalKeyEventHandler);
 
         return Promise.resolve();
     };
+    beforeStartup.reads = [];
+    beforeStartup.writes = [];
 
     /**
      * Remove event handlers.
@@ -105,23 +107,13 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var onResetCommand = function () {
+    var onReset = function () {
         os.removeListener(os.notifierKind.EXTERNAL_KEYEVENT, _externalKeyEventHandler);
 
         return Promise.resolve();
     };
-
-    var beforeStartup = {
-        command: beforeStartupCommand,
-        reads: [],
-        writes: []
-    };
-
-    var onReset = {
-        command: onResetCommand,
-        reads: [],
-        writes: []
-    };
+    onReset.reads = [];
+    onReset.writes = [];
 
     exports.beforeStartup = beforeStartup;
     exports.onReset = onReset;

--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -155,9 +155,11 @@ define(function (require, exports) {
      * @param {Immutable.Iterable.<Layer>} layers list of layers to update
      * @return {Promise}
      */
-    var addShadowCommand = function (document, layers, type) {
+    var addShadow = function (document, layers, type) {
         return _upsertShadowProperties.call(this, document, layers, null, { enabled: true }, undefined, type);
     };
+    addShadow.reads = [locks.PS_DOC, locks.JS_DOC];
+    addShadow.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the  Shadow enabled flag for all selected layers
@@ -169,10 +171,12 @@ define(function (require, exports) {
      * @return {Promise}
      */
 
-    var setShadowEnabledCommand = function (document, layers, shadowIndex, enabled, type) {
+    var setShadowEnabled = function (document, layers, shadowIndex, enabled, type) {
         return _upsertShadowProperties.call(
             this, document, layers, shadowIndex, { enabled: enabled }, 0, type);
     };
+    setShadowEnabled.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Shadow alpha value for all selected layers. Preserves the opaque color.
@@ -184,7 +188,7 @@ define(function (require, exports) {
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var setShadowAlphaCommand = function (document, layers, shadowIndex, alpha, coalesce, type) {
+    var setShadowAlpha = function (document, layers, shadowIndex, alpha, coalesce, type) {
         var alphaUpdater = function (shadow) {
             if (shadow && shadow.color) {
                 return { color: shadow.color.setAlpha(alpha) };
@@ -195,6 +199,8 @@ define(function (require, exports) {
         return _upsertShadowProperties.call(
             this, document, layers, shadowIndex, alphaUpdater, coalesce, type);
     };
+    setShadowAlpha.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowAlpha.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Drop Shadow Color for all selected layers
@@ -208,7 +214,7 @@ define(function (require, exports) {
      *  given color and only update the opaque color value.
      * @return {Promise}
      */
-    var setShadowColorCommand = function (document, layers, shadowIndex, color, coalesce, ignoreAlpha, type) {
+    var setShadowColor = function (document, layers, shadowIndex, color, coalesce, ignoreAlpha, type) {
         if (ignoreAlpha) {
             var colorUpdater = function (shadow) {
                 if (shadow && shadow.color) {
@@ -226,6 +232,8 @@ define(function (require, exports) {
                 this, document, layers, shadowIndex, { color: normalizedColor }, coalesce, type);
         }
     };
+    setShadowColor.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowColor.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Drop Shadow X coordinate for all selected layers
@@ -236,11 +244,12 @@ define(function (require, exports) {
      * @param {number} x x coordinate in pixels
      * @return {Promise}
      */
-    var setShadowXCommand = function (document, layers, shadowIndex, x, type) {
+    var setShadowX = function (document, layers, shadowIndex, x, type) {
         return _upsertShadowProperties.call(
            this, document, layers, shadowIndex, { x: x }, null, type);
     };
-
+    setShadowX.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowX.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Drop Shadow Y coordinate for all selected layers
@@ -251,10 +260,12 @@ define(function (require, exports) {
      * @param {number} y y coordinate in pixels
      * @return {Promise}
      */
-    var setShadowYCommand = function (document, layers, shadowIndex, y, type) {
+    var setShadowY = function (document, layers, shadowIndex, y, type) {
         return _upsertShadowProperties.call(
            this, document, layers, shadowIndex, { y: y }, null, type);
     };
+    setShadowY.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowY.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Drop Shadow Blur value for all selected layers
@@ -265,10 +276,12 @@ define(function (require, exports) {
      * @param {number} blur blur value in pixels
      * @return {Promise}
      */
-    var setShadowBlurCommand = function (document, layers, shadowIndex, blur, type) {
+    var setShadowBlur = function (document, layers, shadowIndex, blur, type) {
         return _upsertShadowProperties.call(
             this, document, layers, shadowIndex, { blur: blur }, null, type);
     };
+    setShadowBlur.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowBlur.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the Drop Shadow Spread value for all selected layers
@@ -279,58 +292,12 @@ define(function (require, exports) {
      * @param {number} spread spread value in pixels
      * @return {Promise}
      */
-    var setShadowSpreadCommand = function (document, layers, shadowIndex, spread, type) {
+    var setShadowSpread = function (document, layers, shadowIndex, spread, type) {
         return _upsertShadowProperties.call(
             this, document, layers, shadowIndex, { spread: spread }, null, type);
     };
-
-    var addShadow = {
-        command: addShadowCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowEnabled = {
-        command: setShadowEnabledCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowAlpha = {
-        command: setShadowAlphaCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowColor = {
-        command: setShadowColorCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowX = {
-        command: setShadowXCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowY = {
-        command: setShadowYCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowBlur = {
-        command: setShadowBlurCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setShadowSpread = {
-        command: setShadowSpreadCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
+    setShadowSpread.reads = [locks.PS_DOC, locks.JS_DOC];
+    setShadowSpread.writes = [locks.PS_DOC, locks.JS_DOC];
 
     exports.addShadow = addShadow;
     exports.setShadowEnabled = setShadowEnabled;

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -41,7 +41,7 @@ define(function (require, exports) {
      * @param {{shift: boolean=, control: boolean=, alt: boolean=, command: boolean=}} modifiers
      * @return {Promise.<number>} Resolves with the installed policy list ID
      */
-    var addKeydownPolicyCommand = function (propagate, key, modifiers) {
+    var addKeydownPolicy = function (propagate, key, modifiers) {
         var policyAction = propagate ?
                 adapterUI.policyAction.ALWAYS_PROPAGATE :
                 adapterUI.policyAction.NEVER_PROPAGATE,
@@ -51,6 +51,8 @@ define(function (require, exports) {
 
         return this.transfer(addKeyboardPolicies, [policy], true);
     };
+    addKeydownPolicy.reads = [];
+    addKeydownPolicy.writes = [locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Install a new policy list.
@@ -124,9 +126,11 @@ define(function (require, exports) {
      * @param {Array.<KeyboardEventPolicy>} policies
      * @return {Promise}
      */
-    var addKeyboardPoliciesCommand = function (policies) {
+    var addKeyboardPolicies = function (policies) {
         return _addPolicies.call(this, PolicyStore.eventKind.KEYBOARD, policies);
     };
+    addKeyboardPolicies.reads = [];
+    addKeyboardPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Remove an already-installed keyboard policy list.
@@ -138,9 +142,11 @@ define(function (require, exports) {
      *  policies.
      * @return {Promise}
      */
-    var removeKeyboardPoliciesCommand = function (id, commit) {
+    var removeKeyboardPolicies = function (id, commit) {
         return _removePolicies.call(this, PolicyStore.eventKind.KEYBOARD, id, commit);
     };
+    removeKeyboardPolicies.reads = [];
+    removeKeyboardPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Install a new pointer policy list.
@@ -148,9 +154,11 @@ define(function (require, exports) {
      * @param {Array.<PointerEventPolicy>} policies
      * @return {Promise}
      */
-    var addPointerPoliciesCommand = function (policies) {
+    var addPointerPolicies = function (policies) {
         return _addPolicies.call(this, PolicyStore.eventKind.POINTER, policies);
     };
+    addPointerPolicies.reads = [];
+    addPointerPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Remove an already-installed pointer policy list.
@@ -162,16 +170,18 @@ define(function (require, exports) {
      *  policies.
      * @return {Promise}
      */
-    var removePointerPoliciesCommand = function (id, commit) {
+    var removePointerPolicies = function (id, commit) {
         return _removePolicies.call(this, PolicyStore.eventKind.POINTER, id, commit);
     };
+    removePointerPolicies.reads = [];
+    removePointerPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the default keyboard propagation policy.
      *
      * @return {Promise}
      */
-    var beforeStartupCommand = function () {
+    var beforeStartup = function () {
         var policyMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
             policyDescriptor = {
                 defaultMode: policyMode
@@ -179,46 +189,8 @@ define(function (require, exports) {
 
         return adapterUI.setKeyboardPropagationMode(policyDescriptor);
     };
-
-    var addKeydownPolicy = {
-        command: addKeydownPolicyCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
-
-    var addKeyboardPolicies = {
-        command: addKeyboardPoliciesCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
-
-    var removeKeyboardPolicies = {
-        command: removeKeyboardPoliciesCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
-
-    var addPointerPolicies = {
-        command: addPointerPoliciesCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
-
-    var removePointerPolicies = {
-        command: removePointerPoliciesCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
-
-    /**
-     * @see beforeStartupCommand
-     * @type {Action}
-     */
-    var beforeStartup = {
-        command: beforeStartupCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_POLICY]
-    };
+    beforeStartup.reads = [];
+    beforeStartup.writes = [locks.PS_APP, locks.JS_POLICY];
 
     exports.addKeydownPolicy = addKeydownPolicy;
     exports.addKeyboardPolicies = addKeyboardPolicies;

--- a/src/js/actions/preferences.js
+++ b/src/js/actions/preferences.js
@@ -34,12 +34,14 @@ define(function (require, exports) {
      * @param {*} value Must be JSON.stringifyable
      * @return {Promise}
      */
-    var setPreferenceCommand = function (key, value) {
+    var setPreference = function (key, value) {
         return this.dispatchAsync(events.preferences.SET_PREFERENCE, {
             key: key,
             value: value
         });
     };
+    setPreference.reads = [];
+    setPreference.writes = [locks.JS_PREF];
 
     /**
      * Bulk set preferences.
@@ -47,11 +49,13 @@ define(function (require, exports) {
      * @param {Object.<string, *>} prefs Values must be JSON.stringifyable
      * @return {Promise}
      */
-    var setPreferencesCommand = function (prefs) {
+    var setPreferences = function (prefs) {
         return this.dispatchAsync(events.preferences.SET_PREFERENCES, {
             prefs: prefs
         });
     };
+    setPreferences.reads = [];
+    setPreferences.writes = [locks.JS_PREF];
 
     /**
      * Delete a single preference.
@@ -59,44 +63,24 @@ define(function (require, exports) {
      * @param {string} key
      * @return {Promise}
      */
-    var deletePreferenceCommand = function (key) {
+    var deletePreference = function (key) {
         return this.dispatchAsync(events.preferences.DELETE_PREFERENCE, {
             key: key
         });
     };
+    deletePreference.reads = [];
+    deletePreference.writes = [locks.JS_PREF];
 
     /**
      * Clear all preferences.
      *
      * @return {Promise}
      */
-    var clearPreferencesCommand = function () {
+    var clearPreferences = function () {
         return this.dispatchAsync(events.preferences.CLEAR_PREFERENCES);
     };
-
-    var setPreference = {
-        command: setPreferenceCommand,
-        reads: [],
-        writes: [locks.JS_PREF]
-    };
-
-    var setPreferences = {
-        command: setPreferencesCommand,
-        reads: [],
-        writes: [locks.JS_PREF]
-    };
-
-    var deletePreference = {
-        command: deletePreferenceCommand,
-        reads: [],
-        writes: [locks.JS_PREF]
-    };
-
-    var clearPreferences = {
-        command: clearPreferencesCommand,
-        reads: [],
-        writes: [locks.JS_PREF]
-    };
+    clearPreferences.reads = [];
+    clearPreferences.writes = [locks.JS_PREF];
 
     exports.setPreference = setPreference;
     exports.setPreferences = setPreferences;

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -32,16 +32,12 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var openSearchBarCommand = function () {
+    var openSearchBar = function () {
         return this.transfer(dialog.openDialog, "search-bar-dialog");
     };
+    openSearchBar.reads = [];
+    openSearchBar.writes = [locks.JS_DIALOG];
 
-
-    var openSearchBar = {
-        command: openSearchBarCommand,
-        reads: [],
-        writes: [locks.JS_DIALOG]
-    };
 
     exports.openSearchBar = openSearchBar;
 });

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -173,11 +173,13 @@ define(function (require, exports) {
      * @param {boolean=} enabled
      * @return {Promise}
      */
-    var setStrokeEnabledCommand = function (document, layers, strokeIndex, color, enabled) {
+    var setStrokeEnabled = function (document, layers, strokeIndex, color, enabled) {
         // TODO is it reasonable to not require a color, but instead to derive it here based on the selected layers?
         // the only problem with that is having to define a default color here if none can be derived
-        return setStrokeColorCommand.call(this, document, layers, strokeIndex, color, false, enabled);
+        return setStrokeColor.call(this, document, layers, strokeIndex, color, false, enabled);
     };
+    setStrokeEnabled.reads = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the color of the stroke for the given layers of the given document
@@ -195,7 +197,7 @@ define(function (require, exports) {
      *  supplied color and only update the opaque color.
      * @return {Promise}
      */
-    var setStrokeColorCommand = function (document, layers, strokeIndex, color, coalesce, enabled, ignoreAlpha) {
+    var setStrokeColor = function (document, layers, strokeIndex, color, coalesce, enabled, ignoreAlpha) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
 
@@ -251,6 +253,8 @@ define(function (require, exports) {
                 });
         }
     };
+    setStrokeColor.reads = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeColor.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the alignment of the stroke for all selected layers of the given document.
@@ -260,7 +264,7 @@ define(function (require, exports) {
      * @param {string} alignmentType type as inside,outside, or center
      * @return {Promise}
      */
-    var setStrokeAlignmentCommand = function (document, layers, strokeIndex, alignmentType) {
+    var setStrokeAlignment = function (document, layers, strokeIndex, alignmentType) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeAlignment(layerRef, alignmentType),
             documentRef = documentLib.referenceBy.id(document.id),
@@ -291,6 +295,9 @@ define(function (require, exports) {
                 });
         }
     };
+    setStrokeAlignment.reads = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeAlignment.writes = [locks.PS_DOC, locks.JS_DOC];
+
     /**
      * Set the opacity of the stroke for all selected layers of the given document.
      * @param {Document} document
@@ -300,7 +307,7 @@ define(function (require, exports) {
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var setStrokeOpacityCommand = function (document, layers, strokeIndex, opacity, coalesce) {
+    var setStrokeOpacity = function (document, layers, strokeIndex, opacity, coalesce) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeOpacity(layerRef, opacity),
             documentRef = documentLib.referenceBy.id(document.id),
@@ -330,6 +337,8 @@ define(function (require, exports) {
                 });
         }
     };
+    setStrokeOpacity.reads = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeOpacity.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the size of the stroke for all selected layers of the given document
@@ -340,7 +349,7 @@ define(function (require, exports) {
      * @param {number} width stroke width, in pixels
      * @return {Promise}
      */
-    var setStrokeWidthCommand = function (document, layers, strokeIndex, width) {
+    var setStrokeWidth = function (document, layers, strokeIndex, width) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setShapeStrokeWidth(layerRef, width),
             documentRef = documentLib.referenceBy.id(document.id),
@@ -371,6 +380,8 @@ define(function (require, exports) {
                 });
         }
     };
+    setStrokeWidth.reads = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeWidth.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Add a stroke from scratch
@@ -379,7 +390,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @return {Promise}
      */
-    var addStrokeCommand = function (document, layers) {
+    var addStroke = function (document, layers) {
         // build the playObject
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setShapeStrokeWidth(layerRef, 1), // TODO hardcoded default
@@ -402,6 +413,8 @@ define(function (require, exports) {
                 this.dispatch(events.document.history.nonOptimistic.STROKE_ADDED, payload);
             });
     };
+    addStroke.reads = [locks.PS_DOC, locks.JS_DOC];
+    addStroke.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the enabled flag for the given fill of all selected Layers on a given doc
@@ -413,9 +426,11 @@ define(function (require, exports) {
      * @param {boolean=} enabled
      * @return {Promise}
      */
-    var setFillEnabledCommand = function (document, layers, fillIndex, color, enabled) {
-        return setFillColorCommand.call(this, document, layers, fillIndex, color, false, enabled);
+    var setFillEnabled = function (document, layers, fillIndex, color, enabled) {
+        return setFillColor.call(this, document, layers, fillIndex, color, false, enabled);
     };
+    setFillEnabled.reads = [locks.PS_DOC, locks.JS_DOC];
+    setFillEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the color of the fill for all selected layers of the given document
@@ -430,7 +445,7 @@ define(function (require, exports) {
      *  supplied color and only update the opaque color.
      * @return {Promise}
      */
-    var setFillColorCommand = function (document, layers, fillIndex, color, coalesce, enabled, ignoreAlpha) {
+    var setFillColor = function (document, layers, fillIndex, color, coalesce, enabled, ignoreAlpha) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
         // if enabled is not provided, assume it is true
@@ -464,6 +479,8 @@ define(function (require, exports) {
 
         return Promise.join(dispatchPromise, colorPromise);
     };
+    setFillColor.reads = [locks.PS_DOC, locks.JS_DOC];
+    setFillColor.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the opacity of the fill for all selected layers of the given document
@@ -476,7 +493,7 @@ define(function (require, exports) {
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var setFillOpacityCommand = function (document, layers, fillIndex, opacity, coalesce) {
+    var setFillOpacity = function (document, layers, fillIndex, opacity, coalesce) {
         // dispatch the change event
         var dispatchPromise = _fillChangeDispatch.call(this,
             document,
@@ -495,6 +512,8 @@ define(function (require, exports) {
 
         return Promise.join(dispatchPromise, opacityPromise);
     };
+    setFillOpacity.reads = [locks.PS_DOC, locks.JS_DOC];
+    setFillOpacity.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Add a new fill to the specified layers of the specified document.
@@ -504,7 +523,7 @@ define(function (require, exports) {
      * @param {Color} color of the fill to be added
      * @return {Promise}
      */
-    var addFillCommand = function (document, layers, color) {
+    var addFill = function (document, layers, color) {
         // build the playObject
         var contentLayerRef = contentLayerLib.referenceBy.current,
             fillObj = contentLayerLib.setShapeFillTypeSolidColor(contentLayerRef, color),
@@ -523,6 +542,8 @@ define(function (require, exports) {
                 this.dispatch(events.document.history.optimistic.FILL_ADDED, payload);
             });
     };
+    addFill.reads = [locks.PS_DOC, locks.JS_DOC];
+    addFill.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Call the adapter and then transfer to another action to reset layers as necessary
@@ -591,7 +612,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers 
      * @return {Promise}
      */
-    var combineUnionCommand = function (document, layers) {
+    var combineUnion = function (document, layers) {
         if (layers.isEmpty()) {
             return Promise.resolve();
         } else if (layers.size === 1) {
@@ -600,6 +621,8 @@ define(function (require, exports) {
             return _playCombine.call(this, document, layers, pathLib.combineLayersUnion());
         }
     };
+    combineUnion.reads = [];
+    combineUnion.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Combine paths using SUBTRACT operation
@@ -608,7 +631,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers 
      * @return {Promise}
      */
-    var combineSubtractCommand = function (document, layers) {
+    var combineSubtract = function (document, layers) {
         if (layers.isEmpty()) {
             return Promise.resolve();
         } else if (layers.size === 1) {
@@ -617,6 +640,8 @@ define(function (require, exports) {
             return _playCombine.call(this, document, layers, pathLib.combineLayersSubtract());
         }
     };
+    combineSubtract.reads = [];
+    combineSubtract.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Combine paths using INTERSECT operation
@@ -625,7 +650,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers 
      * @return {Promise}
      */
-    var combineIntersectCommand = function (document, layers) {
+    var combineIntersect = function (document, layers) {
         if (layers.isEmpty()) {
             return Promise.resolve();
         } else if (layers.size === 1) {
@@ -634,6 +659,8 @@ define(function (require, exports) {
             return _playCombine.call(this, document, layers, pathLib.combineLayersIntersect());
         }
     };
+    combineIntersect.reads = [];
+    combineIntersect.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Combine paths using DIFFERENCE operation
@@ -642,7 +669,7 @@ define(function (require, exports) {
      * @param {Immutable.List.<Layer>} layers 
      * @return {Promise}
      */
-    var combineDifferenceCommand = function (document, layers) {
+    var combineDifference = function (document, layers) {
         if (layers.isEmpty()) {
             return Promise.resolve();
         } else if (layers.size === 1) {
@@ -651,6 +678,8 @@ define(function (require, exports) {
             return _playCombine.call(this, document, layers, pathLib.combineLayersDifference());
         }
     };
+    combineDifference.reads = [];
+    combineDifference.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Called by the menu items, runs the union operation on 
@@ -658,7 +687,7 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var combineUnionSelectedInCurrentDocumentCommand = function () {
+    var combineUnionSelectedInCurrentDocument = function () {
         var applicationStore = this.flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument();
 
@@ -668,6 +697,8 @@ define(function (require, exports) {
 
         return this.transfer(combineUnion, currentDocument, currentDocument.layers.selected);
     };
+    combineUnionSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
+    combineUnionSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Called by the menu items, runs the subtract operation on 
@@ -675,7 +706,7 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var combineSubtractSelectedInCurrentDocumentCommand = function () {
+    var combineSubtractSelectedInCurrentDocument = function () {
         var applicationStore = this.flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument();
 
@@ -685,6 +716,8 @@ define(function (require, exports) {
 
         return this.transfer(combineSubtract, currentDocument, currentDocument.layers.selected);
     };
+    combineSubtractSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
+    combineSubtractSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Called by the menu items, runs the intersect operation on 
@@ -692,7 +725,7 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var combineIntersectSelectedInCurrentDocumentCommand = function () {
+    var combineIntersectSelectedInCurrentDocument = function () {
         var applicationStore = this.flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument();
 
@@ -702,6 +735,8 @@ define(function (require, exports) {
 
         return this.transfer(combineIntersect, currentDocument, currentDocument.layers.selected);
     };
+    combineIntersectSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
+    combineIntersectSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Called by the menu items, runs the difference operation on 
@@ -709,7 +744,7 @@ define(function (require, exports) {
      *
      * @return {Promise}
      */
-    var combineDifferenceSelectedInCurrentDocumentCommand = function () {
+    var combineDifferenceSelectedInCurrentDocument = function () {
         var applicationStore = this.flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument();
 
@@ -719,117 +754,8 @@ define(function (require, exports) {
 
         return this.transfer(combineDifference, currentDocument, currentDocument.layers.selected);
     };
-
-    // STROKE
-    var setStrokeEnabled = {
-        command: setStrokeEnabledCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setStrokeWidth = {
-        command: setStrokeWidthCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setStrokeColor = {
-        command: setStrokeColorCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setStrokeOpacity = {
-        command: setStrokeOpacityCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setStrokeAlignment = {
-        command: setStrokeAlignmentCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var addStroke = {
-        command: addStrokeCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    // FILL
-    var setFillEnabled = {
-        command: setFillEnabledCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setFillColor = {
-        command: setFillColorCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var setFillOpacity = {
-        command: setFillOpacityCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var addFill = {
-        command: addFillCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    // COMBINE
-    var combineUnion = {
-        command: combineUnionCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineSubtract = {
-        command: combineSubtractCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineIntersect = {
-        command: combineIntersectCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineDifference = {
-        command: combineDifferenceCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineUnionSelectedInCurrentDocument = {
-        command: combineUnionSelectedInCurrentDocumentCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC, locks.JS_APP],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineSubtractSelectedInCurrentDocument = {
-        command: combineSubtractSelectedInCurrentDocumentCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC, locks.JS_APP],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineIntersectSelectedInCurrentDocument = {
-        command: combineIntersectSelectedInCurrentDocumentCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC, locks.JS_APP],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    var combineDifferenceSelectedInCurrentDocument = {
-        command: combineDifferenceSelectedInCurrentDocumentCommand,
-        reads: [locks.PS_DOC, locks.JS_DOC, locks.JS_APP],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
+    combineDifferenceSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
+    combineDifferenceSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
 
     exports.setStrokeEnabled = setStrokeEnabled;
     exports.setStrokeWidth = setStrokeWidth;

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -44,7 +44,7 @@ define(function (require, exports) {
      *  bubble (default) or capture phase
      * @return {Promise}
      */
-    var addShortcutCommand = function (key, modifiers, fn, id, capture) {
+    var addShortcut = function (key, modifiers, fn, id, capture) {
         var shortcutStore = this.flux.store("shortcut");
         if (shortcutStore.getByID(id)) {
             return Promise.reject("Shortcut already exists: " + id);
@@ -71,6 +71,8 @@ define(function (require, exports) {
                 return policyID;
             });
     };
+    addShortcut.reads = [];
+    addShortcut.writes = [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY];
 
     /**
      * Remove a keyboard shortcut command. Unregisters the handler function and unsets
@@ -79,7 +81,7 @@ define(function (require, exports) {
      * @param {!string} id Name of shortcut to remove
      * @return {Promise}
      */
-    var removeShortcutCommand = function (id) {
+    var removeShortcut = function (id) {
         var shortcutStore = this.flux.store("shortcut"),
             shortcut = shortcutStore.getByID(id);
 
@@ -95,6 +97,8 @@ define(function (require, exports) {
                 });
             });
     };
+    removeShortcut.reads = [];
+    removeShortcut.writes = [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY];
 
     /**
      * Blur the active element on KEYBOARDFOCUS_CHANGED adapter events.
@@ -128,7 +132,7 @@ define(function (require, exports) {
      * 
      * @return {Promise}
      */
-    var beforeStartupCommand = function () {
+    var beforeStartup = function () {
         var shortcutStore = this.flux.store("shortcut"),
             controller = this.controller;
 
@@ -164,6 +168,8 @@ define(function (require, exports) {
 
         return Promise.resolve();
     };
+    beforeStartup.reads = [locks.JS_SHORTCUT];
+    beforeStartup.writes = [];
 
     /**
      * Remove event handlers.
@@ -171,7 +177,7 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var onResetCommand = function () {
+    var onReset = function () {
         os.removeListener(os.notifierKind.KEYBOARDFOCUS_CHANGED, _keyboardFocusChangedHandler);
 
         window.removeEventListener("adapterKeydown", _keydownHandlerCapture, true);
@@ -179,30 +185,8 @@ define(function (require, exports) {
 
         return Promise.resolve();
     };
-
-    var addShortcut = {
-        command: addShortcutCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY]
-    };
-
-    var removeShortcut = {
-        command: removeShortcutCommand,
-        reads: [],
-        writes: [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY]
-    };
-
-    var beforeStartup = {
-        command: beforeStartupCommand,
-        reads: [locks.JS_SHORTCUT],
-        writes: []
-    };
-
-    var onReset = {
-        command: onResetCommand,
-        reads: [],
-        writes: []
-    };
+    onReset.reads = [];
+    onReset.writes = [];
 
     exports.addShortcut = addShortcut;
     exports.removeShortcut = removeShortcut;

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -84,7 +84,7 @@ define(function (require, exports) {
      * @param {string} style The type face style name, e.g., "Oblique"
      * @return {Promise}
      */
-    var setPostScriptCommand = function (document, layers, postscript, family, style) {
+    var setPostScript = function (document, layers, postscript, family, style) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
 
@@ -112,6 +112,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setPostScript.reads = [];
+    setPostScript.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the type face (in terms of a type family and type style) of the given
@@ -123,7 +125,7 @@ define(function (require, exports) {
      * @param {string} style The type face style name, e.g., "Oblique"
      * @return {Promise}
      */
-    var setFaceCommand = function (document, layers, family, style) {
+    var setFace = function (document, layers, family, style) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
 
@@ -150,6 +152,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setFace.reads = [];
+    setFace.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the type of the given layers in the given document. The alpha value of
@@ -163,7 +167,7 @@ define(function (require, exports) {
      *  given color and only update the opaque color value.
      * @return {Promise}
      */
-    var setColorCommand = function (document, layers, color, coalesce, ignoreAlpha) {
+    var setColor = function (document, layers, color, coalesce, ignoreAlpha) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
             normalizedColor = color.normalizeAlpha(),
@@ -196,6 +200,8 @@ define(function (require, exports) {
 
         return Promise.join(dispatchPromise, setColorPromise);
     };
+    setColor.reads = [];
+    setColor.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the type size of the given layers in the given document. This triggers
@@ -206,7 +212,7 @@ define(function (require, exports) {
      * @param {number} size The type size in pixels, e.g., 72
      * @return {Promise}
      */
-    var setSizeCommand = function (document, layers, size) {
+    var setSize = function (document, layers, size) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
 
@@ -235,6 +241,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setSize.reads = [];
+    setSize.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the tracking value (aka letter-spacing) of the given layers in the given document.
@@ -245,7 +253,7 @@ define(function (require, exports) {
      * @param {number} tracking The tracking value
      * @return {Promise}
      */
-    var setTrackingCommand = function (document, layers, tracking) {
+    var setTracking = function (document, layers, tracking) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
             psTracking = tracking / 1000; // PS expects tracking values that are 1/1000 what is shown in the UI
@@ -272,6 +280,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setTracking.reads = [];
+    setTracking.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the leading value (aka line-spacing) of the given layers in the given document.
@@ -282,7 +292,7 @@ define(function (require, exports) {
      * @param {?number} leading The leading value in pixels, or if null then auto.
      * @return {Promise}
      */
-    var setLeadingCommand = function (document, layers, leading) {
+    var setLeading = function (document, layers, leading) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
             autoLeading = leading === null;
@@ -309,6 +319,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setLeading.reads = [];
+    setLeading.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the paragraph alignment of the given layers in the given document.
@@ -319,7 +331,7 @@ define(function (require, exports) {
      * @param {string} alignment The alignment kind
      * @return {Promise}
      */
-    var setAlignmentCommand = function (document, layers, alignment) {
+    var setAlignment = function (document, layers, alignment) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
 
@@ -345,6 +357,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
+    setAlignment.reads = [];
+    setAlignment.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Initialize the list of installed fonts from Photoshop.
@@ -352,83 +366,13 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var afterStartupCommand = function () {
+    var afterStartup = function () {
         return descriptor.getProperty("application", "fontList")
             .bind(this)
             .then(this.dispatch.bind(this, events.font.INIT_FONTS));
     };
-
-    /**
-     * @type {Action}
-     */
-    var setPostScript = {
-        command: setPostScriptCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setFace = {
-        command: setFaceCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setColor = {
-        command: setColorCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setSize = {
-        command: setSizeCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setTracking = {
-        command: setTrackingCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setLeading = {
-        command: setLeadingCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var setAlignment = {
-        command: setAlignmentCommand,
-        reads: [],
-        writes: [locks.PS_DOC, locks.JS_DOC]
-    };
-
-    /**
-     * @type {Action}
-     */
-    var afterStartup = {
-        command: afterStartupCommand,
-        reads: [locks.PS_APP],
-        writes: [locks.JS_TYPE]
-    };
+    afterStartup.reads = [locks.PS_APP];
+    afterStartup.writes = [locks.JS_TYPE];
 
     exports.setPostScript = setPostScript;
     exports.setFace = setFace;

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -202,7 +202,7 @@ define(function (require, exports, module) {
              */
             transfer: {
                 value: function (nextAction) {
-                    if (!nextAction) {
+                    if (!nextAction || (typeof nextAction !== "function")) {
                         throw new Error("Transfer passed an undefined action");
                     }
 


### PR DESCRIPTION
While setting up JSDoc, I've realized that our way of defining actions is very incompatible with JSDoc. This PR gets rid of all the pesky action objects defined at the end of each action file, and instead relies on the "command" function definitions to be the actions. 

The reads/writes/modal etc. like properties are directly defined next to the function object.

This will require rebase on every other branch if it goes in first, and I hope it does, because getting rid of all those objects was a pain.

I also had to make couple extra changes to make sure that our actions were named same as their exported names. And I alphabetized the action index.