### PR TITLE
Immutilate application state

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -171,8 +171,8 @@ define(function (require, exports) {
                 return Promise.all(docPromises);
             })
             .then(function (documentIDs) {
-                if (openDocumentIDs.length !== documentIDs.length) {
-                    throw new Error("Incorrect open document count: " + openDocumentIDs.length +
+                if (openDocumentIDs.size !== documentIDs.length) {
+                    throw new Error("Incorrect open document count: " + openDocumentIDs.size +
                         " instead of " + documentIDs.length);
                 } else {
                     openDocumentIDs.forEach(function (openDocumentID, index) {

--- a/src/js/jsx/sections/nodoc/RecentFiles.jsx
+++ b/src/js/jsx/sections/nodoc/RecentFiles.jsx
@@ -27,7 +27,8 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React);
+        FluxMixin = Fluxxor.FluxMixin(React),
+        Immutable = require("immutable");
 
     var strings = require("i18n!nls/strings"),
         pathUtil = require("js/util/path"),
@@ -43,7 +44,7 @@ define(function (require, exports, module) {
     var RecentFiles = React.createClass({
         mixins: [FluxMixin],
         propTypes: {
-            recentFiles: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
+            recentFiles: React.PropTypes.instanceOf(Immutable.Iterable).isRequired
         },
 
         /**
@@ -61,7 +62,7 @@ define(function (require, exports, module) {
             var recentFilesLimited = this.props.recentFiles.slice(0, MAX_RECENT_FILES),
                 shortenedPaths = pathUtil.getShortestUniquePaths(recentFilesLimited),
                 recentFilelinks = shortenedPaths.map(function (shortPath, index) {
-                    var filePath = this.props.recentFiles[index];
+                    var filePath = this.props.recentFiles.get(index);
                     return (
                         <li
                             key={index}

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -380,7 +380,7 @@ define(function (require, exports, module) {
     /**
      * Replaces the current recent files menu with passed in file list
      *
-     * @param {Array.<string>} files List of recently opened file paths
+     * @param {Immutable.List.<string>} files List of recently opened file paths
      * @return {MenuBar}
      */
     MenuBar.prototype.updateRecentFiles = function (files) {
@@ -393,7 +393,7 @@ define(function (require, exports, module) {
             shortestPathNames = pathUtil.getShortestUniquePaths(files),
             recentFileItems = files.slice(0, 20).map(function (filePath, index) {
                 var id = recentFileMenuID + "." + index,
-                    name = shortestPathNames[index],
+                    name = shortestPathNames.get(index),
                     label = name.length < 60 ? name :
                         name.substr(0, 30) + "\u2026" + name.substr(-29),
                     itemDescriptor = {
@@ -412,8 +412,8 @@ define(function (require, exports, module) {
             }),
             // Update FILE.RECENT to have the recent files as it's submenu
             newRecentFilesMenu = recentFilesMenu.merge({
-                "submenu": Immutable.List(recentFileItems),
-                "enabled": files.length > 0
+                "submenu": recentFileItems,
+                "enabled": files.size > 0
             }),
             // Update FILE to have the new recent files menus
             newFileMenu = fileMenu.update(function (menu) {

--- a/src/js/util/path.js
+++ b/src/js/util/path.js
@@ -61,9 +61,8 @@ define(function (require, exports) {
      * "two"
      * "foo/one"
      *
-     * @param {Array.<string>} paths List of file paths to reduce
-     *
-     * @return {Array.<string>} Unique path for each file that's as short as possible
+     * @param {Immutable.Iterable.<string>} paths List of file paths to reduce
+     * @return {Immutable.Iterable.<string>} Unique path for each file that's as short as possible
      */
     var getShortestUniquePaths = function (paths) {
         // Helper function, finds paths that match in subpaths to a particular path
@@ -87,7 +86,7 @@ define(function (require, exports) {
                     currentKey = path[keyIndex];
                     matchingPaths = _getMatchingPaths(matchingPaths, currentKey, keyIndex);
 
-                    if (matchingPaths.length === 1) {
+                    if (matchingPaths.size === 1) {
                         unique = true;
                     }
                     
@@ -98,7 +97,7 @@ define(function (require, exports) {
 
         // After finding the shortest subpaths, reverse and re-stringify
         return allPathComponents.map(function (parts, index) {
-            return _.take(parts, shortestPathLengths[index]).reverse().join(sep);
+            return _.take(parts, shortestPathLengths.get(index)).reverse().join(sep);
         });
     };
 


### PR DESCRIPTION
This replaces all the mutable `ApplicationStore` data structures with `Immutable` ones. This fixes one untracked [bug](https://github.com/adobe-photoshop/spaces-design/blob/063ed2575864b429e258e9e2ea753e78b9db2061/src/js/jsx/Properties.jsx#L94), and is necessary for an upcoming performance optimzation.

Please test things like switching among open documents and going to and from a no-doc state, and also the recent files list.