### PR TITLE
Use boundingBox for type layers

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -79,6 +79,7 @@ define(function (require, exports) {
         "adjustment",
         "AGMStrokeStyleInfo",
         "textKey",
+        "boundingBox",
         "layerKind",
         "keyOriginType",
         "fillEnabled",
@@ -447,6 +448,8 @@ define(function (require, exports) {
                 property = "artboard";
             } else if (layer.kind === layer.layerKinds.VECTOR) {
                 property = "pathBounds";
+            } else if (layer.kind === layer.layerKinds.TEXT) {
+                property = "boundingBox";
             } else {
                 property = "boundsNoEffects";
             }

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -162,11 +162,15 @@ define(function (require, exports, module) {
                 case layerLib.layerKinds.GROUP:
                 case layerLib.layerKinds.GROUPEND:
                     return null;
+                case layerLib.layerKinds.TEXT:
+                    boundsObject = descriptor.boundingBox;
+                    break;
+                default:
+                    boundsObject = descriptor.boundsNoEffects;
+                    break;
             }
 
             var model = {};
-
-            boundsObject = descriptor.boundsNoEffects;
 
             model.top = boundsObject.top._value;
             model.left = boundsObject.left._value;


### PR DESCRIPTION
Will alleviate #1650 alonside with Jenkins build #370. We expose sheet bounds for type layers in layer descriptor in `boundingBox`