### PR TITLE
Find functions for queue / prevent type=>select tool on user initiated tool change

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -542,7 +542,7 @@ define(function (require, exports) {
                 var toolStore = this.flux.store("tool");
 
                 if (toolStore._currentTool === toolStore.getToolByID("superselectVector")) {
-                    this.flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+                    this.flux.actions.tools.selectTool(toolStore.getToolByID("newSelect"));
                 }
             })
             .then(function () {

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -283,7 +283,7 @@ define(function (require, exports) {
             tool = this.flux.store("tool").getToolByID("superselectVector");
         
             _logSuperselect("edit_vector");
-            resultPromise = this.transfer(toolActions.select, tool)
+            resultPromise = this.transfer(toolActions.selectTool, tool)
                 .bind(this)
                 .then(function () {
                     var eventKind = adapterOS.eventKind.LEFT_MOUSE_DOWN,
@@ -296,7 +296,7 @@ define(function (require, exports) {
             tool = this.flux.store("tool").getToolByID("superselectType");
             
             _logSuperselect("edit_text");
-            resultPromise = this.transfer(toolActions.select, tool)
+            resultPromise = this.transfer(toolActions.selectTool, tool)
                 .bind(this)
                 .then(function () {
                     var eventKind = adapterOS.eventKind.LEFT_MOUSE_DOWN,

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -462,7 +462,7 @@ define(function (require, exports) {
 
                 // Only select if it's not the case that the current document is unsupported
                 if (!currentDocument || !currentDocument.unsupported) {
-                    flux.actions.tools.select(tool);
+                    flux.actions.tools.selectTool(tool);
                 }
             };
 
@@ -514,7 +514,7 @@ define(function (require, exports) {
     exports.installShapeDefaults = installShapeDefaults;
     exports.resetSuperselect = resetSuperselect;
     exports.resetBorderPolicies = resetBorderPolicies;
-    exports.select = selectTool;
+    exports.selectTool = selectTool;
     exports.initTool = initTool;
     exports.changeModalState = changeModalState;
 

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -402,7 +402,7 @@ define(function (require, exports, module) {
                         this._reset(err);
                         throw err;
                     });
-            }.bind(self), reads, writes);
+            }.bind(self), reads, writes, actionName);
 
             return jobPromise;
         };
@@ -534,6 +534,28 @@ define(function (require, exports, module) {
         this.emit("lock");
 
         return this._invokeActionMethods("onShutdown");
+    };
+
+    /**
+     * Checks to see if an action with the given name is currently in queue
+     *
+     * @param {string} name module + action name e.g. "tools.selectTool"
+     *
+     * @return {Boolean} True if an instance of the action is in pending queue
+     */
+    FluxController.prototype.isActionQueued = function (name) {
+        return !!this._actionQueue.findPending(name);
+    };
+
+    /**
+     * Checks to see if an action with the given name is currently being processed
+     *
+     * @param {string} name module + action name e.g. "tools.selectTool"
+     *
+     * @return {Boolean} True if an instance of the action is running
+     */
+    FluxController.prototype.isActionActive = function (name) {
+        return !!this._actionQueue.findActive(name);
     };
 
     /**

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
                     currentTool = toolStore.getCurrentTool();
 
                 if (defaultTool !== currentTool) {
-                    flux.actions.tools.select(defaultTool);
+                    flux.actions.tools.selectTool(defaultTool);
                 }
             }
 
@@ -222,7 +222,7 @@ define(function (require, exports, module) {
         _handleToolbarButtonClick: function (tool) {
             if (this.state.expanded || this.state.pinned) {
                 if (tool) {
-                    this.getFlux().actions.tools.select(tool);
+                    this.getFlux().actions.tools.selectTool(tool);
                     
                     // HACK: These lines are to eliminate the blink that occurs when the toolbar changes state
                     var node = React.findDOMNode(this);

--- a/src/js/tools/ellipse.js
+++ b/src/js/tools/ellipse.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
             detail = event.detail;
 
         if (detail.keyChar === "u" && detail.modifiers.shift) {
-            flux.actions.tools.select(toolStore.getToolByID("rectangle"));
+            flux.actions.tools.selectTool(toolStore.getToolByID("rectangle"));
         }
     };
     module.exports = EllipseTool;

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
             detail = event.detail;
 
         if (detail.keyChar === "u" && detail.modifiers.shift) {
-            flux.actions.tools.select(toolStore.getToolByID("ellipse"));
+            flux.actions.tools.selectTool(toolStore.getToolByID("ellipse"));
         }
     };
 

--- a/src/js/tools/superselect/type.js
+++ b/src/js/tools/superselect/type.js
@@ -36,11 +36,13 @@ define(function (require, exports, module) {
 
     var _selectHandler = function () {
         var flux = this.flux,
+            controller = this.controller,
             toolStore = flux.store("tool");
 
         descriptor.once("set", function (event) {
-            if (event.null._ref === "textLayer" && event.to._obj === "textLayer") {
-                flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            if (event.null._ref === "textLayer" && event.to._obj === "textLayer" &&
+                !controller.isActionActive("tools.selectTool")) {
+                flux.actions.tools.selectTool(toolStore.getToolByID("newSelect"));
             }
         });
     };
@@ -72,7 +74,7 @@ define(function (require, exports, module) {
             toolStore = flux.store("tool");
 
         if (event.detail.keyCode === 27) { // Escape
-            flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            flux.actions.tools.selectTool(toolStore.getToolByID("newSelect"));
         }
     };
 

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -151,9 +151,9 @@ define(function (require, exports, module) {
 
         var detail = event.detail;
         if (detail.keyCode === 27) { // Escape
-            flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            flux.actions.tools.selectTool(toolStore.getToolByID("newSelect"));
         } else if (detail.keyCode === 13) { // Enter
-            flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            flux.actions.tools.selectTool(toolStore.getToolByID("newSelect"));
         }
     };
 


### PR DESCRIPTION
@iwehrman About f58a44e... I kept it in a separate commit so it's put under scrutiny. This is the only solution I could find to #1255.

The select caused by superselectTypeTool `deselectHandler` was being enqueued before rectangle tool switch happened, so it would enqueue a superselect switch as well, this prevents that.

Also renamed `tools.select` to `tools.selectTool` so exports matches function name
