### PR TITLE
Update selected state for toolbar icons

### DIFF
--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -48,8 +48,9 @@
     }
 }
 
-.tool-selected svg {    
-    border-bottom: @hairline solid @warm-white;    
+.tool-selected svg {
+    fill: @highlight;
+    stroke: @highlight;
 }
 
 .toolbar__backToPs.button-simple{


### PR DESCRIPTION
This relates to #1390. As part of the UI update, the selection state for the tools will be the highlight blue. Rather than fix the underline, I just switched to the blue