### PR TITLE
handle moveToArtboard events by reordering layers, and amending the current history state

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1122,9 +1122,10 @@ define(function (require, exports) {
      *
      * @param {Document} document Document for which layers should be reordered
      * @param {boolean=} suppressHistory if truthy, dispatch a non-history-changing event.
+     * @param {boolean=} amendHistory if truthy, update the current state (requires suppressHistory)
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
      **/
-    var getLayerOrder = function (document, suppressHistory) {
+    var getLayerOrder = function (document, suppressHistory, amendHistory) {
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
                 return _getSelectedLayerIndices(document).then(function (selectedIndices) {
@@ -1134,7 +1135,11 @@ define(function (require, exports) {
             })
             .then(function (payload) {
                 if (suppressHistory) {
-                    return this.dispatchAsync(events.document.REORDER_LAYERS, payload);
+                    if (amendHistory) {
+                        return this.dispatchAsync(events.document.history.amendment.REORDER_LAYERS, payload);
+                    } else {
+                        return this.dispatchAsync(events.document.REORDER_LAYERS, payload);
+                    }
                 } else {
                     return this.dispatchAsync(events.document.history.optimistic.REORDER_LAYERS, payload);
                 }

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -630,25 +630,29 @@ define(function (require, exports) {
                             descriptor.removeListener("moveToArtboard", _moveToArtboardListener);
                         }
 
-                        var artboardNested = false;
                         _moveToArtboardListener = _.once(function () {
-                            artboardNested = true;
+                            this.flux.actions.layers.getLayerOrder(doc, true, true);
                         }.bind(this));
 
                         descriptor.addListener("moveToArtboard", _moveToArtboardListener);
 
                         _moveListener = function () {
                             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-                            if (copyDrag) {
+                            if (!copyDrag) {
+                                // Since finishing the click, the selected layers may have changed, so we'll get
+                                // the most current document model before proceeding.
+                                var documentStore = this.flux.store("document"),
+                                    nextDoc = documentStore.getDocument(doc.id);
+
+                                // FIXME: We used to listen to "move" event's translation and optimistically update
+                                // all selected layers, but due to a recent bug, "move" event sends us the displacement
+                                // of layers from the changing (0,0) coordinates, which causes bugs like
+                                // getting (650,0) when the move was actually (-100, 0) for a 750 px wide layer
+                                this.flux.actions.layers.resetBounds(nextDoc, nextDoc.layers.allSelected);
+                            } else {
                                 // For now, we have to update the document when we drag copy, since we don't get
                                 // information on the new layers
                                 this.flux.actions.documents.updateDocument(doc.id);
-                            } else { // if (artboardNested) {
-                                // FIX ME: Until we fix the moveToArtboard notifications, 
-                                // we're always going to re-order layers
-                                // 
-                                // In the case of artboards, we have to just ask Ps for the layer order
-                                this.flux.actions.layers.getLayerOrder(doc, true);
                             }
 
                             // We have another move listener that resets bounds of targeted layers

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -638,18 +638,7 @@ define(function (require, exports) {
 
                         _moveListener = function () {
                             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-                            if (!copyDrag) {
-                                // Since finishing the click, the selected layers may have changed, so we'll get
-                                // the most current document model before proceeding.
-                                var documentStore = this.flux.store("document"),
-                                    nextDoc = documentStore.getDocument(doc.id);
-
-                                // FIXME: We used to listen to "move" event's translation and optimistically update
-                                // all selected layers, but due to a recent bug, "move" event sends us the displacement
-                                // of layers from the changing (0,0) coordinates, which causes bugs like
-                                // getting (650,0) when the move was actually (-100, 0) for a 750 px wide layer
-                                this.flux.actions.layers.resetBounds(nextDoc, nextDoc.layers.allSelected);
-                            } else {
+                            if (copyDrag) {
                                 // For now, we have to update the document when we drag copy, since we don't get
                                 // information on the new layers
                                 this.flux.actions.documents.updateDocument(doc.id);

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -68,6 +68,9 @@ define(function (require, exports, module) {
                     ADD_LAYERS: "addLayers",
                     COMBINE_SHAPES: "combineShapes",
                     DELETE_LAYERS: "deleteLayersNonOptimistic" // eg: ps deletes the entire layer after last path del
+                },
+                amendment: {
+                    REORDER_LAYERS: "reorderLayersAmendment"
                 }
             },
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.history.optimistic.REORDER_LAYERS, this._handleLayerReorder,
+                events.document.history.amendment.REORDER_LAYERS, this._handleLayerReorder,
                 events.document.REORDER_LAYERS, this._handleLayerReorder,
                 events.document.SELECT_LAYERS_BY_ID, this._handleLayerSelectByID,
                 events.document.SELECT_LAYERS_BY_INDEX, this._handleLayerSelectByIndex,

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
             var binder = this.bindActions.bind(this);
             storeUtil.bindEvents(events.document.history.optimistic, this._handlePreHistoryEvent, binder);
             storeUtil.bindEvents(events.document.history.nonOptimistic, this._handlePostHistoryEvent, binder);
+            storeUtil.bindEvents(events.document.history.amendment, this._handleHistoryAmendment, binder);
 
             this.bindActions(
                 events.RESET, this._deleteAllHistory,
@@ -552,6 +553,25 @@ define(function (require, exports, module) {
                 }
 
                 return this._pushHistoryState.call(this, nextState, payload.coalesce);
+            });
+        },
+
+        /**
+         * Amend the current history state with the current document
+         *
+         * @param {object} payload
+         */
+        _handleHistoryAmendment: function (payload) {
+            this.waitFor(["document", "application"], function (documentStore) {
+                var documentID = this._getDocumentID(payload),
+                    document = documentStore.getDocument(documentID),
+                    nextState = new HistoryState({ document: document });
+
+                if (!document) {
+                    throw new Error("Could not push history state, document not found: " + documentID);
+                }
+
+                return this._pushHistoryState.call(this, nextState, true);
             });
         },
 


### PR DESCRIPTION
we now can guarantee that moveToArtboard (MTA) event notifications will always come after the corresponding "move" event.  This is not ideal, but its at least consistent.  If we get an MTA, that means we need to fetch the layer order from photoshop.  This needs to be updated on the newly created history state, which is a new concept in the history store that I call "amendment".  

I've also consolidated this "move" listener logic in transform.js.  We might be able to take this further, but baby steps.  Please check this out @volfied since we've talked about it some, and you are working in the same circus ring.