### PR TITLE
Marquee select performance pt. 1

### DIFF
--- a/src/js/actions/dialog.js
+++ b/src/js/actions/dialog.js
@@ -28,42 +28,6 @@ define(function (require, exports) {
         locks = require("js/locks");
 
     /**
-     * Register a dialog with a given ID and dismissal policy.
-     *
-     * @private
-     * @param {string} id
-     * @param {object} dismissalPolicy
-     * @return {Promise}
-     */
-    var registerDialog = function (id, dismissalPolicy) {
-        var payload = {
-            id: id,
-            dismissalPolicy: dismissalPolicy
-        };
-
-        return this.dispatchAsync(events.dialog.REGISTER_DIALOG, payload);
-    };
-    registerDialog.reads = [];
-    registerDialog.writes = [locks.JS_DIALOG];
-
-    /**
-     * Deregister a dialog with a given ID
-     *
-     * @private
-     * @param {string} id
-     * @return {Promise}
-     */
-    var deregisterDialog = function (id) {
-        var payload = {
-            id: id
-        };
-
-        return this.dispatchAsync(events.dialog.DEREGISTER_DIALOG, payload);
-    };
-    deregisterDialog.reads = [];
-    deregisterDialog.writes = [locks.JS_DIALOG];
-
-    /**
      * Open a dialog with a given ID and optional dismissal policy.
      * Must pre-register if the dismissal policy is to be excluded
      *
@@ -112,8 +76,6 @@ define(function (require, exports) {
     closeAllDialogs.reads = [];
     closeAllDialogs.writes = [locks.JS_DIALOG];
 
-    exports.registerDialog = registerDialog;
-    exports.deregisterDialog = deregisterDialog;
     exports.openDialog = openDialog;
     exports.closeDialog = closeDialog;
     exports.closeAllDialogs = closeAllDialogs;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -115,8 +115,6 @@ define(function (require, exports, module) {
             REMOVE_SHORTCUT: "removeShortcut"
         },
         dialog: {
-            REGISTER_DIALOG: "registerDialog",
-            DEREGISTER_DIALOG: "deregisterDialog",
             OPEN_DIALOG: "openDialog",
             CLOSE_DIALOG: "closeDialog",
             CLOSE_ALL_DIALOGS: "closeAllDialogs"

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -50,6 +50,13 @@ define(function (require, exports, module) {
      */
     var THROTTLED_ACTION_SUFFIX = "Throttled";
 
+    /**
+     * Suffix used to name debounced actions.
+     *
+     * @const
+     * @type {String}
+     */
+    var DEBOUNCED_ACTION_SUFFIX = "Debounced";
 
     /**
      * Maximum delay after which reset retry will continue
@@ -374,6 +381,9 @@ define(function (require, exports, module) {
                 }
 
                 return modalPromise
+                    .catch(function () {
+                        // If modal state already ended, quietly continue
+                    })
                     .bind(this)
                     .then(function () {
                         log.debug("Executing action %s after waiting %dms; %d/%d",
@@ -425,11 +435,14 @@ define(function (require, exports, module) {
             }
 
             var throttledName = name + THROTTLED_ACTION_SUFFIX,
+                debouncedName = name + DEBOUNCED_ACTION_SUFFIX,
                 synchronizedAction = this._synchronize(namespace, module, name),
-                throttledAction = synchronization.throttle(synchronizedAction);
+                throttledAction = synchronization.throttle(synchronizedAction),
+                debouncedAction = synchronization.debounce(synchronizedAction);
 
             exports[name] = synchronizedAction;
             exports[throttledName] = throttledAction;
+            exports[debouncedName] = debouncedAction;
 
             return exports;
         }.bind(this), {});

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -98,7 +98,7 @@ define(function (require, exports, module) {
         },
 
         componentWillMount: function () {
-            this.getFlux().actions.dialog.registerDialog(this.props.id, this._getDismissalPolicy());
+            this.getFlux().store("dialog").registerDialog(this.props.id, this._getDismissalPolicy());
         },
 
         /**
@@ -309,7 +309,7 @@ define(function (require, exports, module) {
                 this._removeListeners();
                 this.getFlux().actions.dialog.closeDialog(this.props.id);
             }
-            this.getFlux().actions.dialog.deregisterDialog(this.props.id);
+            this.getFlux().store("dialog").deregisterDialog(this.props.id);
         },
 
         isOpen: function () {

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -202,7 +202,9 @@ define(function (require, exports, module) {
                 return;
             }
 
-            this.getFlux().actions.tools.resetBorderPoliciesThrottled();
+            if (!this.state.marqueeEnabled) {
+                this.getFlux().actions.tools.resetBorderPoliciesDebounced();
+            }
                 
             var currentDocument = this.state.document,
                 svg = d3.select(React.findDOMNode(this));

--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -59,8 +59,6 @@ define(function (require, exports, module) {
         initialize: function () {
             this.bindActions(
                 events.RESET, this._handleReset,
-                events.dialog.REGISTER_DIALOG, this._handleRegister,
-                events.dialog.DEREGISTER_DIALOG, this._handleDeregister,
                 events.dialog.OPEN_DIALOG, this._handleOpen,
                 events.dialog.CLOSE_DIALOG, this._handleClose,
                 events.dialog.CLOSE_ALL_DIALOGS, this._handleCloseAll,
@@ -124,17 +122,14 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Handle a registerDialog event
-         * (does not emit a change event)
-         * merges state if this event has already been registered
+         * Merges state if this event has already been registered
          *
-         * @private
-         * @param {{id: string, dismissalPolicy: object}} payload
+         * @param {string} id Dialog ID
+         * @param {object} dismissalPolicy
          */
-        _handleRegister: function (payload) {
-            var id = payload.id,
-                state = {
-                    policy: Immutable.Map(payload.dismissalPolicy)
+        registerDialog: function (id, dismissalPolicy) {
+            var state = {
+                    policy: Immutable.Map(dismissalPolicy)
                 };
 
             this._registeredDialogs = this._registeredDialogs.update(id, Immutable.Map(), function (val) {
@@ -143,14 +138,13 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Handle a deregisterDialog event
+         * Deregisters a dialog and
          * emits a change event if this dialog was open
          *
          * @private
-         * @param {{id: string, dismissalPolicy: object}} payload
+         * @param {string} id
          */
-        _handleDeregister: function (payload) {
-            var id = payload.id;
+        deregisterDialog: function (id) {
             this._registeredDialogs = this._registeredDialogs.delete(id);
             if (this._openDialogs.has(id)) {
                 this._openDialogs = this._openDialogs.delete(id);


### PR DESCRIPTION
Addresses general marquee performance issues.

 1. Register/deregister dialog actions each take about 100 ms, which delays marquee by a lot, now they directly edit the store
 1. Transform handlers in transform actions are now debounced, so we don't constantly reset selection/bounds and layer order. This helps in cases where the user is quickly drag/dropping layers
 1. Resetborderpolicies is debounced, and it does not get called if we're in a marquee select mode
 1. Removed post condition for deselectAll, because it was adding a 50ms delay to marquee select starting code
 1. If an action is not modal, and we're trying to end modal tool state, we no longer completely fail when the API fails. This happens if you transform layers too fast and we're in a modal state during resizing/rotating.

@iwehrman please review.