### PR TITLE
Fixes for misplacement of dragged layers

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -226,7 +226,7 @@ define(function (require, exports, module) {
                 isLastInGroup = false,
                 dragStyle;
 
-            if (isDragTarget) {
+            if (isDragTarget && this.props.dragStyle) {
                 dragStyle = this.props.dragStyle;
             } else {
                 // We can skip some rendering calculations if dragging
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
                 "face__select_immediate": isSelected,
                 "face__select_child": isChildOfSelected,
                 "face__select_descendant": isStrictDescendantOfSelected,
-                "face__drag_target": isDragTarget,
+                "face__drag_target": isDragTarget && this.props.dragStyle,
                 "face__drop_target": isDropTarget,
                 "face__drop_target_above": isDropTarget && isDropTargetAbove,
                 "face__drop_target_below": isDropTarget && isDropTargetBelow,


### PR DESCRIPTION
Couple of issues that arose:

1. 1 bug was caused by the fact that handleDragStart is where we defined the initial position of the dragged elements. However, if an element was never clicked on, this never ran. So moved it all into when the drag is actually moving
2. Similarly, the elements need to make sure to clear their state, otherwise there can be a slightly flicker in position when a second drag operation starts.

@chadrolfs : Could you give this a quick check for placement issues?
@iwehrman : Don't think I hurt performance with this, but would you give it a once over?