### PR TITLE
Suppress click after drag

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -109,11 +109,6 @@ define(function (require, exports, module) {
         _handleLayerClick: function (event) {
             event.stopPropagation();
 
-            // Don't select if this is the click that follows a drag operation
-            if (event.currentTarget.classList.contains("face__drag_target")) {
-                return;
-            }
-
             var modifier = "select";
             if (event.shiftKey) {
                 modifier = "addUpTo";
@@ -272,7 +267,6 @@ define(function (require, exports, module) {
                 "face__group_lastchildgroup": endOfGroupStructure
             };
 
-            faceClasses[this.props.dragClass] = true;
             faceClasses["face__depth-" + depth] = true;
 
             // Super Hack: If two tooltip regions are flush and have the same title,
@@ -353,7 +347,7 @@ define(function (require, exports, module) {
                 key: props.layer.key,
                 keyObject: props.layer,
                 isValid: props.isValid,
-                handleDrop: props.onDragStop
+                handleDrop: props.onDrop
             };
         };
 

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -438,18 +438,17 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Reset the boundingClientRect cache at the beginning of the drag.
+         * Initialize the boundingClientRect cache at the beginning of the drag.
          */
         _handleStart: function () {
             this._boundingClientRectCache = new Map();
         },
 
         /**
-         * Custom drag finish handler. Calculates the drop index through the target,
+         * Custom drop handler. Calculates the drop index through the target,
          * removes drop target properties, and calls the reorder action.
-         *
          */
-        _handleStop: function () {
+        _handleDrop: function () {
             if (this.state.dragTargets) {
                 var flux = this.getFlux(),
                     doc = this.props.document,
@@ -475,7 +474,12 @@ define(function (require, exports, module) {
                     dropAbove: null
                 });
             }
+        },
 
+        /**
+         * Nullify the boundingClientRect cache at the end of the drag.
+         */
+        _handleStop: function () {
             this._boundingClientRectCache = null;
         },
 
@@ -528,6 +532,7 @@ define(function (require, exports, module) {
                                 isValid={this._validDropTarget}
                                 onDragStart={this._handleStart}
                                 onDragStop={this._handleStop}
+                                onDrop={this._handleDrop}
                                 getDragItems={this._getDraggingLayers}
                                 dragTarget={isDragTarget}
                                 dragPosition={(isDropTarget || isDragTarget) &&


### PR DESCRIPTION
1. Internally suppress handlers for the click event that follows a drag operation. Draggables (like `LayerFace`) no longer need to provide special handling to ignore these clicks.
2. Add a proper `onDragStop` handler for draggables, renaming the existing handler to `onDrop`.

Addresses #1710. 