### PR TITLE
Expand/collapse groups

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -538,6 +538,7 @@ define(function (require, exports) {
         // eventually remove SELECT_LAYERS_BY_INDEX.
         var dispatchPromise,
             revealPromise;
+            
         if (!modifier || modifier === "select") {
             payload.selectedIDs = collection.pluck(layerSpec, "id");
             dispatchPromise = this.dispatchAsync(events.document.SELECT_LAYERS_BY_ID, payload);
@@ -1231,14 +1232,14 @@ define(function (require, exports) {
 
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.SET_LAYERS_PROPORTIONAL, payload),
             layerPlayObjects = layerSpec.map(function (layer) {
-            var layerRef = layerLib.referenceBy.id(layer.id),
-            proportionalObj = layerLib.setProportionalScaling(layerRef, proportional);
+                var layerRef = layerLib.referenceBy.id(layer.id),
+                proportionalObj = layerLib.setProportionalScaling(layerRef, proportional);
 
-            return {
-                layer: layer,
-                playObject: proportionalObj
-            };
-        }, this);
+                return {
+                    layer: layer,
+                    playObject: proportionalObj
+                };
+            }, this);
 
         var sizePromise = layerActionsUtil.playLayerActions(document, layerPlayObjects, true, options);
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -91,7 +91,8 @@ define(function (require, exports) {
         "artboardEnabled",
         "pathBounds",
         "smartObject",
-        "globalAngle"
+        "globalAngle",
+        "layerSectionExpanded"
     ];
 
     /**
@@ -535,10 +536,15 @@ define(function (require, exports) {
 
         // TODO: Dispatch optimistically here for the other modifiers, and
         // eventually remove SELECT_LAYERS_BY_INDEX.
-        var dispatchPromise = Promise.resolve();
+        var dispatchPromise,
+            revealPromise;
         if (!modifier || modifier === "select") {
             payload.selectedIDs = collection.pluck(layerSpec, "id");
             dispatchPromise = this.dispatchAsync(events.document.SELECT_LAYERS_BY_ID, payload);
+            revealPromise = this.transfer(revealLayers, document, layerSpec);
+        } else {
+            dispatchPromise = Promise.resolve();
+            revealPromise = Promise.resolve();
         }
 
         var layerRef = layerSpec
@@ -553,11 +559,14 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     if (modifier && modifier !== "select") {
-                        return this.transfer(resetSelection, document);
+                        var resetPromise = this.transfer(resetSelection, document),
+                            revealPromise = this.transfer(revealLayers, document, layerSpec);
+
+                        return Promise.join(resetPromise, revealPromise);
                     }
                 });
 
-        return Promise.join(dispatchPromise, selectPromise);
+        return Promise.join(dispatchPromise, selectPromise, revealPromise);
     };
     select.reads = [locks.PS_DOC, locks.JS_DOC];
     select.writes = [locks.PS_DOC, locks.JS_DOC];
@@ -1220,11 +1229,8 @@ define(function (require, exports) {
                 }
             };
 
-        var dispatchPromise = Promise.bind(this).then(function () {
-            this.dispatch(events.document.history.optimistic.SET_LAYERS_PROPORTIONAL, payload);
-        });
-
-        var layerPlayObjects = layerSpec.map(function (layer) {
+        var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.SET_LAYERS_PROPORTIONAL, payload),
+            layerPlayObjects = layerSpec.map(function (layer) {
             var layerRef = layerLib.referenceBy.id(layer.id),
             proportionalObj = layerLib.setProportionalScaling(layerRef, proportional);
 
@@ -1387,6 +1393,80 @@ define(function (require, exports) {
     };
     duplicate.reads = [locks.PS_DOC, locks.JS_DOC];
     duplicate.writes = [locks.PS_DOC, locks.JS_DOC];
+
+    /**
+     * Expand or collapse the given group layers in the layers panel.
+     *
+     * @param {Document} document
+     * @param {Layer|Immutable.Iterable.<Layer>} layers
+     * @param {boolean} expand If true, expand the groups. Otherwise, collapse them.
+     * @return {Promise}
+     */
+    var setGroupExpansion = function (document, layers, expand) {
+        if (layers instanceof Layer) {
+            layers = Immutable.List.of(layers);
+        }
+
+        var layerRefs = layers
+            .filter(function (layer) {
+                return layer.kind === layer.layerKinds.GROUP;
+            });
+
+        if (layerRefs.isEmpty()) {
+            return Promise.resolve();
+        }
+
+        var documentRef = documentLib.referenceBy.id(document.id);
+
+        layerRefs = layerRefs
+            .map(function (layer) {
+                return layerLib.referenceBy.id(layer.id);
+            })
+            .unshift(documentRef)
+            .toArray();
+
+        var expandPlayObject = layerLib.setGroupExpansion(layerRefs, !!expand),
+            expansionPromise = descriptor.playObject(expandPlayObject),
+            dispatchPromise = this.dispatchAsync(events.document.SET_GROUP_EXPANSION, {
+                documentID: document.id,
+                layerIDs: collection.pluck(layers, "id"),
+                expanded: expand
+            });
+
+        return Promise.join(expansionPromise, dispatchPromise);
+    };
+    setGroupExpansion.reads = [];
+    setGroupExpansion.writes = [locks.PS_DOC, locks.JS_DOC];
+
+    /**
+     * Reveal the given layers in the layers panel by ensuring their ancestors
+     * are expanded.
+     *
+     * @param {Document} document
+     * @param {Immutable.Iterable.<Layer>} layers
+     * @return {Promise}
+     */
+    var revealLayers = function (document, layers) {
+        if (layers instanceof Layer) {
+            layers = Immutable.List.of(layers);
+        }
+
+        var collapsedAncestorSet = layers.reduce(function (collapsedAncestors, layer) {
+            if (document.layers.hasCollapsedAncestor(layer)) {
+                document.layers.strictAncestors(layer).forEach(function (ancestor) {
+                    if (!ancestor.expanded) {
+                        collapsedAncestors.add(ancestor);
+                    }
+                });
+            }
+            return collapsedAncestors;
+        }, new Set(), this),
+        collapsedAncestors = Immutable.Set(collapsedAncestorSet).toList();
+
+        return this.transfer(setGroupExpansion, document, collapsedAncestors, true);
+    };
+    revealLayers.reads = [];
+    revealLayers.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Event handlers initialized in beforeStartup.
@@ -1649,6 +1729,8 @@ define(function (require, exports) {
     exports.createArtboard = createArtboard;
     exports.resetLinkedLayers = resetLinkedLayers;
     exports.duplicate = duplicate;
+    exports.setGroupExpansion = setGroupExpansion;
+    exports.revealLayers = revealLayers;
     exports.getLayerOrder = getLayerOrder;
 
     exports.beforeStartup = beforeStartup;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -77,6 +77,7 @@ define(function (require, exports, module) {
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",
             SELECT_LAYERS_BY_ID: "selectLayersByID",
             SELECT_LAYERS_BY_INDEX: "selectLayersByIndex",
+            SET_GROUP_EXPANSION: "setGroupExpansion",
             VISIBILITY_CHANGED: "layerVisibilityChanged",
             REORDER_LAYERS: "reorderLayersNoHistory",
             LAYER_BOUNDS_CHANGED: "layerBoundsChanged",

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -91,6 +91,12 @@ define(function (require, exports, module) {
         kind: null,
 
         /**
+         * Indicates whether this group layer is expanded or collapsed.
+         * @type {boolean}
+         */
+        expanded: false,
+
+        /**
          * Bounding rectangle for this layer
          * @type {Bounds}
          */
@@ -209,10 +215,11 @@ define(function (require, exports, module) {
             return new Immutable.Map({
                 id: self.id,
                 name: self.name,
+                kind: self.kind,
                 visible: self.visible,
                 locked: self.locked,
+                expanded: self.expanded,
                 selected: self.selected,
-                kind: self.kind,
                 isArtboard: self.isArtboard,
                 isBackground: self.isBackground
             });
@@ -290,6 +297,17 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Determine whether the given layer is expanded or collapsed.
+     * 
+     * @param {object} layerDescriptor
+     * @return {boolean}
+     */
+    var _extractExpanded = function (layerDescriptor) {
+        return !layerDescriptor.hasOwnProperty("layerSectionExpanded") ||
+            layerDescriptor.layerSectionExpanded;
+    };
+
+    /**
      * Determine the layer opacity as a percentage.
      *
      * @param {object} layerDescriptor
@@ -347,6 +365,7 @@ define(function (require, exports, module) {
             kind: isGroupEnd ? layerLib.layerKinds.GROUPEND : layerLib.layerKinds.GROUP,
             visible: true,
             locked: false,
+            expanded: true,
             isBackground: false,
             opacity: 100,
             selected: true, // We'll set selected after moving layers
@@ -390,6 +409,7 @@ define(function (require, exports, module) {
             name: layerDescriptor.name,
             kind: layerDescriptor.layerKind,
             visible: layerDescriptor.visible,
+            expanded: _extractExpanded(layerDescriptor),
             locked: _extractLocked(layerDescriptor),
             isBackground: layerDescriptor.background,
             opacity: _extractOpacity(layerDescriptor),
@@ -426,6 +446,7 @@ define(function (require, exports, module) {
                 kind: layerDescriptor.layerKind,
                 visible: layerDescriptor.visible,
                 locked: _extractLocked(layerDescriptor),
+                expanded: _extractExpanded(layerDescriptor),
                 isBackground: layerDescriptor.background,
                 opacity: _extractOpacity(layerDescriptor),
                 bounds: Bounds.fromLayerDescriptor(layerDescriptor),

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -577,6 +577,19 @@ define(function (require, exports, module) {
     }));
 
     /**
+     * Determine whether the given layer has a collapsed ancestor, and hence
+     * should be hidden in the layers panel.
+     *
+     * @param {Layer} layer
+     * @return {boolean}
+     */
+    Object.defineProperty(LayerStructure.prototype, "hasCollapsedAncestor", objUtil.cachedLookupSpec(function (layer) {
+        return this.strictAncestors(layer).some(function (layer) {
+            return !layer.expanded;
+        });
+    }));
+
+    /**
      * Find all descendants of the given layer, including itself.
      *
      * @param {Layer} layer

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -59,6 +59,7 @@ define(function (require, exports, module) {
                 events.document.SELECT_LAYERS_BY_INDEX, this._handleLayerSelectByIndex,
                 events.document.VISIBILITY_CHANGED, this._handleVisibilityChanged,
                 events.document.history.optimistic.LOCK_CHANGED, this._handleLockChanged,
+                events.document.SET_GROUP_EXPANSION, this._handleGroupExpansion,
                 events.document.history.optimistic.OPACITY_CHANGED, this._handleOpacityChanged,
                 events.document.history.optimistic.BLEND_MODE_CHANGED, this._handleBlendModeChanged,
                 events.document.history.optimistic.RENAME_LAYER, this._handleLayerRenamed,
@@ -355,7 +356,7 @@ define(function (require, exports, module) {
          * When a layer locking is changed, updates the corresponding layer object
          *
          * @private
-         * @param {{documentID: number, layerID: number, locked: boolean }} payload
+         * @param {{documentID: number, layerID: number, locked: boolean}} payload
          */
         _handleLockChanged: function (payload) {
             var documentID = payload.documentID,
@@ -364,6 +365,20 @@ define(function (require, exports, module) {
                 locked = payload.locked;
 
             this._updateLayerProperties(documentID, layerIDs, { locked: locked });
+        },
+
+        /**
+         * Update layer models when groups are expanded or collapsed.
+         *
+         * @private
+         * @param {{documentID: number, layerIDs: Immutable.Iterable.<number>, expanded: boolean}} payload
+         */
+        _handleGroupExpansion: function (payload) {
+            var documentID = payload.documentID,
+                layerIDs = payload.layerIDs,
+                expanded = payload.expanded;
+
+            this._updateLayerProperties(documentID, layerIDs, { expanded: expanded });
         },
 
         /**

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -202,14 +202,17 @@ input[type="text"].face__name {
 
 // Drop state
 .face__drop_target_above {
-    border-top: .5rem inset @highlight;
+    border-top: .25rem inset @highlight;
     border-top-left-radius: 0;
     border-top-right-radius: 0;    
 }
 .face__drop_target_below {
-    border-bottom: .5rem inset @highlight;
+    border-bottom: .25rem inset @highlight;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;    
+}
+.face__drop_target_on {
+    border: .25rem inset @highlight;
 }
 
 // Drag state
@@ -224,15 +227,13 @@ input[type="text"].face__name {
 }
 
 // Group collapsed state
-.face__group_collapsed {
-    height: 0;
-    visibility: hidden;
-    border-bottom: none;
-}
-.face__group_expanded {
-    visibility: visible;
+.layer__ancestor_collapsed {
+    display: none;
 }
 
+.layer__group_start.layer__select.layer__group_collapsed {
+    background-color: inherit;
+}
 
 // Layer name focus/blur state
 .face__input_focus {


### PR DESCRIPTION
1. Groups can be expanded or collapsed in the panel by single-clicking their icon using the new `layers.setGroupExpansion` action. This might not be the final interaction, but it works for now. Descendant layers are not mounted until they're first visible, and hidden layers are not rendered when models change until their visible again. (This is the same pattern we're using for the per-document `Properties` components.) This provides a significant load-time speed up for big documents when their top-level groups are collapsed.
2. When a layer is selected on canvas, it is revealed in the panel by expanding its ancestor groups using the new `layers.revealLayers` action.
2. It's now possible to drop dragged layers onto groups, instead of just above or below a particular layer.
3. This also fixes a regression my last panel work caused by suppressing the virtual render after the drop and before the model has updated.

Note that this does _not_ address #1695. I'll tackle that in a separate PR.

Depends on adobe-photoshop/spaces-adapter#121.