### PR TITLE
Cavalcade of transform fixes

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -253,8 +253,9 @@ define(function (require, exports) {
 
         return Promise.join(createPromise, presetPromise);
     };
-    createNew.reads = [locks.PS_DOC, locks.PS_APP, locks.JS_PREF];
-    createNew.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_DOC, locks.JS_PREF];
+    createNew.reads = [locks.PS_DOC, locks.PS_APP, locks.JS_PREF, locks.JS_APP, locks.JS_TOOL];
+    createNew.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_DOC, locks.JS_PREF,
+        locks.PS_APP, locks.JS_POLICY];
     createNew.post = [_verifyActiveDocument, _verifyOpenDocuments];
 
     /**
@@ -324,8 +325,8 @@ define(function (require, exports) {
                 // the play command fails if the user cancels the close dialog
             });
     };
-    close.reads = [locks.PS_DOC, locks.PS_APP];
-    close.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI];
+    close.reads = [locks.PS_DOC, locks.PS_APP, locks.JS_APP, locks.JS_TOOL];
+    close.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
     close.lockUI = true;
     close.post = [_verifyActiveDocument, _verifyOpenDocuments];
 
@@ -478,8 +479,8 @@ define(function (require, exports) {
                 }
             }.bind(this));
     };
-    allocateDocument.reads = [locks.PS_DOC, locks.PS_APP];
-    allocateDocument.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI];
+    allocateDocument.reads = [locks.PS_DOC, locks.PS_APP, locks.JS_APP, locks.JS_TOOL];
+    allocateDocument.writes = [locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
     allocateDocument.lockUI = true;
 
     /**
@@ -558,8 +559,8 @@ define(function (require, exports) {
                     deselectPromise);
             });
     };
-    selectDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP];
-    selectDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI];
+    selectDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_APP, locks.JS_TOOL];
+    selectDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
     selectDocument.lockUI = true;
     selectDocument.post = [_verifyActiveDocument];
 
@@ -584,8 +585,8 @@ define(function (require, exports) {
                 return this.transfer(selectDocument, nextDocument);
             });
     };
-    selectNextDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP];
-    selectNextDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI];
+    selectNextDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_APP, locks.JS_TOOL];
+    selectNextDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
     selectNextDocument.lockUI = true;
 
     /**
@@ -609,8 +610,9 @@ define(function (require, exports) {
                 this.transfer(selectDocument, previousDocument);
             });
     };
-    selectPreviousDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP];
-    selectPreviousDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI];
+    selectPreviousDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_APP, locks.JS_TOOL];
+    selectPreviousDocument.writes = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_UI,
+        locks.PS_APP, locks.JS_POLICY];
     selectPreviousDocument.lockUI = true;
 
     /**

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -312,8 +312,8 @@ define(function (require, exports) {
             });
     };
     paste.modal = true;
-    paste.reads = [];
-    paste.writes = [locks.JS_DOC, locks.PS_DOC];
+    paste.reads = [locks.JS_APP, locks.JS_TOOL];
+    paste.writes = [locks.JS_DOC, locks.PS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Execute a select operation on the currently active HTML element.
@@ -363,8 +363,8 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
-    undo.reads = [locks.PS_DOC];
-    undo.writes = [locks.JS_DOC, locks.JS_HISTORY];
+    undo.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    undo.writes = [locks.JS_DOC, locks.JS_HISTORY, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Step Forward by transferring to the appropriate history action
@@ -385,8 +385,8 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
-    redo.reads = [locks.PS_DOC];
-    redo.writes = [locks.JS_DOC, locks.JS_HISTORY];
+    redo.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    redo.writes = [locks.JS_DOC, locks.JS_HISTORY, locks.PS_APP, locks.JS_POLICY];
 
     exports.nativeCut = nativeCut;
     exports.nativeCopy = nativeCopy;

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -31,6 +31,7 @@ define(function (require, exports) {
         documentLib = require("adapter/lib/document"),
         historyLib = require("adapter/lib/history"),
         layerActions = require("./layers"),
+        toolActions = require("./tools"),
         documentActions = require("./documents");
 
     var events = require("js/events"),
@@ -153,6 +154,9 @@ define(function (require, exports) {
                                 count: count,
                                 selectedIndices: selectedIndices
                             });
+                        })
+                        .then(function () {
+                            return this.transfer(toolActions.resetBorderPolicies);
                         });
                 });
         } else {
@@ -181,8 +185,8 @@ define(function (require, exports) {
     var incrementHistory = function (document) {
         return _navigateHistory.call(this, document, 1);
     };
-    incrementHistory.reads = [locks.PS_DOC];
-    incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC];
+    incrementHistory.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Navigate to the previous history state
@@ -193,8 +197,8 @@ define(function (require, exports) {
     var decrementHistory = function (document) {
         return _navigateHistory.call(this, document, -1);
     };
-    decrementHistory.reads = [locks.PS_DOC];
-    decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC];
+    decrementHistory.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Revert to the document's last saved state.
@@ -233,10 +237,13 @@ define(function (require, exports) {
             .bind(this)
             .then(function () {
                 return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
+            })
+            .then(function () {
+                return this.transfer(toolActions.resetBorderPolicies);
             });
     };
-    revertCurrentDocument.reads = [locks.PS_DOC];
-    revertCurrentDocument.writes = [locks.JS_HISTORY, locks.JS_DOC];
+    revertCurrentDocument.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    revertCurrentDocument.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
     revertCurrentDocument.post = [layerActions._verifyLayerIndex];
 
     /**

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -381,8 +381,8 @@ define(function (require, exports) {
             return this.transfer(layerActions.resetLayers, currentDocument, currentDocument.layers.selected);
         });
     };
-    applyLayerStyle.reads = [locks.JS_DOC, locks.PS_DOC];
-    applyLayerStyle.writes = [locks.JS_DOC, locks.PS_DOC];
+    applyLayerStyle.reads = [locks.JS_DOC, locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
+    applyLayerStyle.writes = [locks.JS_DOC, locks.PS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Applies the given character style element to the active layers

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -178,8 +178,8 @@ define(function (require, exports) {
         // the only problem with that is having to define a default color here if none can be derived
         return setStrokeColor.call(this, document, layers, strokeIndex, color, false, enabled);
     };
-    setStrokeEnabled.reads = [locks.PS_DOC, locks.JS_DOC];
-    setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeEnabled.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
+    setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the color of the stroke for the given layers of the given document
@@ -253,8 +253,8 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeColor.reads = [locks.PS_DOC, locks.JS_DOC];
-    setStrokeColor.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeColor.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
+    setStrokeColor.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the alignment of the stroke for all selected layers of the given document.
@@ -295,8 +295,8 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeAlignment.reads = [locks.PS_DOC, locks.JS_DOC];
-    setStrokeAlignment.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeAlignment.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
+    setStrokeAlignment.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the opacity of the stroke for all selected layers of the given document.
@@ -380,8 +380,8 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeWidth.reads = [locks.PS_DOC, locks.JS_DOC];
-    setStrokeWidth.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeWidth.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
+    setStrokeWidth.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Add a stroke from scratch

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -29,13 +29,13 @@ define(function (require, exports) {
         _ = require("lodash");
 
     var descriptor = require("adapter/ps/descriptor"),
-        system = require("js/util/system"),
         adapterOS = require("adapter/os"),
         adapterUI = require("adapter/ps/ui"),
         documentLib = require("adapter/lib/document"),
         hitTestLib = require("adapter/lib/hitTest");
 
     var keyUtil = require("js/util/key"),
+        system = require("js/util/system"),
         locks = require("js/locks"),
         events = require("js/events"),
         documentActions = require("./documents"),
@@ -432,7 +432,7 @@ define(function (require, exports) {
             });
     };
     click.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    click.writes = [locks.PS_DOC, locks.JS_DOC];
+    click.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Process a double click
@@ -681,7 +681,7 @@ define(function (require, exports) {
         }
     };
     drag.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    drag.writes = [locks.PS_DOC, locks.JS_DOC];
+    drag.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Selects the given layers by the marquee
@@ -710,7 +710,7 @@ define(function (require, exports) {
         }
     };
     marqueeSelect.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    marqueeSelect.writes = [locks.PS_DOC, locks.JS_DOC];
+    marqueeSelect.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     exports.click = click;
     exports.doubleClick = doubleClick;

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -112,8 +112,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setPostScript.reads = [];
-    setPostScript.writes = [locks.PS_DOC, locks.JS_DOC];
+    setPostScript.reads = [locks.JS_APP, locks.JS_TOOL];
+    setPostScript.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the type face (in terms of a type family and type style) of the given
@@ -152,8 +152,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setFace.reads = [];
-    setFace.writes = [locks.PS_DOC, locks.JS_DOC];
+    setFace.reads = [locks.JS_APP, locks.JS_TOOL];
+    setFace.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the type of the given layers in the given document. The alpha value of
@@ -241,8 +241,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setSize.reads = [];
-    setSize.writes = [locks.PS_DOC, locks.JS_DOC];
+    setSize.reads = [locks.JS_APP, locks.JS_TOOL];
+    setSize.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the tracking value (aka letter-spacing) of the given layers in the given document.
@@ -280,8 +280,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setTracking.reads = [];
-    setTracking.writes = [locks.PS_DOC, locks.JS_DOC];
+    setTracking.reads = [locks.JS_APP, locks.JS_TOOL];
+    setTracking.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the leading value (aka line-spacing) of the given layers in the given document.
@@ -319,8 +319,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setLeading.reads = [];
-    setLeading.writes = [locks.PS_DOC, locks.JS_DOC];
+    setLeading.reads = [locks.JS_APP, locks.JS_TOOL];
+    setLeading.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Set the paragraph alignment of the given layers in the given document.
@@ -357,8 +357,8 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setAlignment.reads = [];
-    setAlignment.writes = [locks.PS_DOC, locks.JS_DOC];
+    setAlignment.reads = [locks.JS_APP, locks.JS_TOOL];
+    setAlignment.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Initialize the list of installed fonts from Photoshop.

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -153,7 +153,7 @@ define(function (require, exports) {
                 };
 
                 this.dispatch(events.ui.TRANSFORM_UPDATED, payload);
-                return this.flux.actions.tools.resetBorderPolicies();
+                this.flux.actions.tools.resetBorderPolicies();
             });
     };
     updateTransform.reads = [locks.PS_APP];

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -36,7 +36,8 @@ define(function (require, exports) {
         locks = require("js/locks"),
         shortcuts = require("./shortcuts"),
         synchronization = require("js/util/synchronization"),
-        system = require("js/util/system");
+        system = require("js/util/system"),
+        tools = require("./tools");
 
 
     /**
@@ -152,6 +153,7 @@ define(function (require, exports) {
                 };
 
                 this.dispatch(events.ui.TRANSFORM_UPDATED, payload);
+                return this.flux.actions.tools.resetBorderPolicies();
             });
     };
     updateTransform.reads = [locks.PS_APP];
@@ -207,10 +209,12 @@ define(function (require, exports) {
                 };
 
                 this.dispatch(events.ui.TRANSFORM_UPDATED, payload);
+
+                return this.transfer(tools.resetBorderPolicies);
             });
     };
-    setTransform.reads = [];
-    setTransform.writes = [locks.JS_UI];
+    setTransform.reads = [locks.JS_APP, locks.JS_TOOL];
+    setTransform.writes = [locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
     setTransform.modal = true;
 
     /**
@@ -444,10 +448,7 @@ define(function (require, exports) {
         descriptor.addListener("scroll", _scrollHandler);
 
         var windowResizeDebounced = synchronization.debounce(function () {
-            var resetSuperselectPromise = this.flux.actions.tools.resetSuperselect(),
-                resetCloakPromise = this.flux.actions.ui.setOverlayCloaking();
-
-            return Promise.join(resetCloakPromise, resetSuperselectPromise);
+            return this.flux.actions.ui.setOverlayCloaking();
         }, this, DEBOUNCE_DELAY, false);
 
         // Handles window resize for resetting superselect tool policies
@@ -498,8 +499,8 @@ define(function (require, exports) {
             return Promise.resolve();
         }
     };
-    afterStartup.reads = [locks.PS_APP, locks.JS_DOC];
-    afterStartup.writes = [locks.JS_UI];
+    afterStartup.reads = [locks.PS_APP, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
+    afterStartup.writes = [locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
 
     /**
      * Remove event handlers.

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -151,6 +151,9 @@ define(function (require, exports, module) {
         },
         search: {
             REGISTER_SEARCH_PROVIDER: "registerSearchProvider"
+        },
+        policies: {
+            POLICIES_INSTALLED: "policiesInstalled"
         }
     };
 });

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -119,7 +119,6 @@ define(function (require, exports, module) {
                 };
 
                 this.getFlux().actions.ui.updatePanelSizes(payload);
-                this.getFlux().actions.tools.resetSuperselect();
             }
         },
 

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -249,7 +249,7 @@ define(function (require, exports, module) {
                 overlays = !disabled && this.state.overlaysEnabled,
                 transformString = this._getTransformString(transform),
                 toolOverlay = (overlays && transform) ? this._renderToolOverlay(transformString) : null,
-                policyOverlay = true ? (<PolicyOverlay/>) : null;
+                policyOverlay = false ? (<PolicyOverlay/>) : null;
 
             // Only the mouse event handlers are attached to the scrim
             return (

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -32,6 +32,8 @@ define(function (require, exports, module) {
 
     var adapterOS = require("adapter/os");
 
+    var PolicyOverlay = require("jsx!js/jsx/tools/PolicyOverlay");
+
     var Scrim = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("tool", "ui", "application")],
 
@@ -246,7 +248,8 @@ define(function (require, exports, module) {
                 transform = this.state.transform,
                 overlays = !disabled && this.state.overlaysEnabled,
                 transformString = this._getTransformString(transform),
-                toolOverlay = (overlays && transform) ? this._renderToolOverlay(transformString) : null;
+                toolOverlay = (overlays && transform) ? this._renderToolOverlay(transformString) : null,
+                policyOverlay = true ? (<PolicyOverlay/>) : null;
 
             // Only the mouse event handlers are attached to the scrim
             return (
@@ -261,6 +264,7 @@ define(function (require, exports, module) {
                     <svg width="100%" height="100%">
                         <g id="overlay" width="100%" height="100%">
                             {toolOverlay}
+                            {policyOverlay}
                         </g>
                     </svg>
                 </div>

--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -53,11 +53,7 @@ define(function (require, exports) {
         mixins: [FluxMixin],
 
         shouldComponentUpdate: function (nextProps) {
-            var sameLayerIDs = collection.pluck(this.props.layers, "id")
-                .equals(collection.pluck(nextProps.layers, "id"));
-
-            return !sameLayerIDs ||
-                !Immutable.is(this.props.fills, nextProps.fills) ||
+            return !Immutable.is(this.props.fills, nextProps.fills) ||
                 this.props.index !== nextProps.index ||
                 this.props.readOnly !== nextProps.readOnly;
         },

--- a/src/js/jsx/sections/style/Opacity.jsx
+++ b/src/js/jsx/sections/style/Opacity.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps) {
             var getRelevantProps = function (props) {
-                return collection.pluckAll(props.layers, ["id", "opacity"]);
+                return collection.pluck(props.layers, "opacity");
             };
 
             return !Immutable.is(getRelevantProps(this.props), getRelevantProps(nextProps));

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -54,11 +54,7 @@ define(function (require, exports) {
         mixins: [FluxMixin],
 
         shouldComponentUpdate: function (nextProps) {
-            var sameLayerIDs = collection.pluck(this.props.layers, "id")
-                .equals(collection.pluck(nextProps.layers, "id"));
-
-            return !sameLayerIDs ||
-                !Immutable.is(this.props.strokes, nextProps.strokes) ||
+            return !Immutable.is(this.props.strokes, nextProps.strokes) ||
                 this.props.index !== nextProps.index ||
                 this.props.readOnly !== nextProps.readOnly;
         },

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React),
+        StoreWatchMixin = Fluxxor.StoreWatchMixin,
+        d3 = require("d3"),
+        _ = require("lodash");
+
+    var UI = require("adapter/ps/ui");
+
+    var PolicyOverlay = React.createClass({
+        mixins: [FluxMixin, StoreWatchMixin("policy")],
+
+        getStateFromFlux: function () {
+            var flux = this.getFlux(),
+                policyStore = flux.store("policy"),
+                pointerPolicies = policyStore.getMasterPointerPolicyList();
+
+            return {
+                policies: pointerPolicies
+            };
+        },
+
+        /**
+         * D3 element where policies are being drawn
+         *
+         * @type {SVGElement}
+         */
+        _scrimGroup: null,
+
+        /**
+         * Debounced draw function, set in componentWillMount
+         *
+         * @type {function()}
+         */
+        _drawDebounced: null,
+
+        componentWillMount: function () {
+            this._drawDebounced = _.debounce(this.drawOverlay, 100, false);
+        },
+        
+        componentDidMount: function () {
+            this._drawDebounced();
+        },
+
+        componentDidUpdate: function () {
+            this._drawDebounced();
+        },
+
+        /**
+         * Draws the policy overlay showing where the pointer policies are
+         */
+        drawOverlay: function () {
+            if (!this.isMounted()) {
+                return;
+            }
+
+            var svg = d3.select(React.findDOMNode(this));
+
+            svg.selectAll(".policy-overlays").remove();
+            
+            this._scrimGroup = svg.insert("g", ".policy-group")
+                .classed("policy-overlays", true)
+                .attr("transform", this.props.transformString);
+
+            this.drawPolicies(this.state.policies);
+        },
+
+        /**
+         * Draws the pointer policies that have defined areas
+         * 
+         * @param {Array.<object>} policies
+         */
+        drawPolicies: function (policies) {
+            policies.forEach(function (policy) {
+                if (policy.area) {
+                    var area = policy.area,
+                        policyRect = this._scrimGroup
+                        .append("rect")
+                        .attr("x", area[0])
+                        .attr("y", area[1])
+                        .attr("width", area[2])
+                        .attr("height", area[3])
+                        .style("fill-opacity", "0.0")
+                        .style("stroke-opacity", "0.0");
+    
+                    if (policy.action === UI.policyAction.ALWAYS_PROPAGATE) {
+                        policyRect.style("stroke", "#008800")
+                            .style("stroke-opacity", "1.0");
+                    } else if (policy.action === UI.policyAction.NEVER_PROPAGATE) {
+                        policyRect.style("stroke", "#FF2200")
+                            .style("stroke-opacity", "1.0");
+                    }
+                }
+            }, this);
+        },
+
+        render: function () {
+            return (<g />);
+        }
+    });
+
+    module.exports = PolicyOverlay;
+});

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -202,10 +202,6 @@ define(function (require, exports, module) {
                 return;
             }
 
-            if (!this.state.marqueeEnabled) {
-                this.getFlux().actions.tools.resetBorderPoliciesDebounced();
-            }
-                
             var currentDocument = this.state.document,
                 svg = d3.select(React.findDOMNode(this));
 
@@ -273,7 +269,7 @@ define(function (require, exports, module) {
             renderLayers.forEach(function (layer) {
                 var bounds = layerTree.childBounds(layer);
                     
-                // Skip empty and selected bounds
+                // Skip empty bounds
                 if (!bounds || bounds.empty) {
                     return;
                 }

--- a/src/js/stores/policy.js
+++ b/src/js/stores/policy.js
@@ -62,10 +62,18 @@ define(function (require, exports, module) {
          */
         initialize: function () {
             this.bindActions(
-                events.RESET, this._handleReset
+                events.RESET, this._handleReset,
+                events.policies.POLICIES_INSTALLED, this._emitChange
             );
 
             this._handleReset();
+        },
+
+        /**
+         * Emits a change event - used by debug policy overlay
+         */
+        _emitChange: function () {
+            this.emit("change");
         },
 
         /**


### PR DESCRIPTION
 - Remove unnecessary plucks from SCUs of Fill, Opacity and Stroke.jsx
 - Clean up transform/move handlers to minimize time
 - Clean up overlay toggle (artifact)
 - Reset border policies immediately instead of as reaction to re-render

In addition, includes:

Policy visualizer: helps see where the mouse border policies are set

@chadrolfs Can you start testing and let me know if things are better in this branch? It would be very ideal to test these in a compiled build as post condition verifications etc. really slow things down.

@iwehrman Please review.