### PR TITLE
CC Libraries: support contextual "Add" buttons

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -60,7 +60,7 @@ define(function (require, exports) {
             currentLibrary = libStore.getCurrentLibrary(),
             currentLayers = currentDocument.layers.selected;
 
-        if (!currentLibrary || currentLayers.size !== 1) {
+        if (!currentLibrary) {
             return Promise.resolve();
         }
 

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -145,7 +145,7 @@ define(function (require, exports) {
             currentLayer = currentLayers.first();
 
         if (!currentLibrary || currentLayers.size !== 1 ||
-            !currentLayer || currentLayer.kind !== currentLayer.layerKinds.TEXT) {
+            !currentLayer || currentLayer.isTextLayer()) {
             return Promise.resolve();
         }
 

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -39,7 +39,7 @@ define(function (require, exports) {
         layerActions = require("./layers");
 
     /**
-     * Uploads the selected single layer to the current library
+     * Uploads the selected layer(s) to the current library
      *
      * Achieves this by:
      *  - Creates a new element in the library
@@ -48,8 +48,8 @@ define(function (require, exports) {
      *  - Tells Photoshop the location of the content
      *  - Updates the document
      *
-     * Eventually, we'll need this to accept layer(s), library, and be more flexible
-     * Also, we definitely need to get rid of the update document call, but this is 0.1
+     * @todo Eventually, we'll need this to accept layer(s), library, and be more flexible
+     * @todo Also, we definitely need to get rid of the update document call, but this is 0.1
      *
      * @return {Promise}
      */
@@ -145,7 +145,7 @@ define(function (require, exports) {
             currentLayer = currentLayers.first();
 
         if (!currentLibrary || currentLayers.size !== 1 ||
-            !currentLayer || currentLayer.isTextLayer()) {
+            !currentLayer || !currentLayer.isTextLayer()) {
             return Promise.resolve();
         }
 

--- a/src/js/jsx/Properties.jsx
+++ b/src/js/jsx/Properties.jsx
@@ -129,6 +129,7 @@ define(function (require, exports, module) {
                 <LibrariesPanel
                     disabled={disabled}
                     visible={true}
+                    document={document}
                     visibleSibling={this.state.styleVisible} />
             ) : null;
 

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -132,7 +132,8 @@ define(function (require, exports, module) {
                         </div>
                         <Library addElement={this._handleAddElement} library={currentLibrary} />
                         <LibraryBar
-                            selectedLayers={selectedLayers}/>
+                            selectedLayers={selectedLayers}
+                            disabled={!currentLibrary}/>
                     </div>
                 );
             } else {

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -100,12 +100,55 @@ define(function (require, exports, module) {
             this.getFlux().actions.libraries.removeCurrentLibrary();
         },
 
-        render: function () {
+        _containerContents: function () {
             var libraryStore = this.getFlux().store("library"),
-                connected = libraryStore.getConnectionStatus(),
-                libraries = this.state.libraries,
-                currentLibrary = libraries.get(this.state.selectedLibrary);
+                connected = libraryStore.getConnectionStatus();
 
+            var containerContents;
+            if (connected) {
+                var libraries = this.state.libraries,
+                    currentLibrary = libraries.get(this.state.selectedLibrary);
+
+                containerContents = this.props.visible && !this.props.disabled && (
+                    <div>
+                        <div className="formline">
+                            <LibraryList
+                                ref="libraryList"
+                                libraries={libraries}
+                                selected={currentLibrary}
+                                onLibraryChange={this._handleLibraryChange} />
+                            <SplitButtonList>
+                                <SplitButtonItem
+                                    title={"CREATE LIBRARY"}
+                                    className="button-plus"
+                                    iconId="plus"
+                                    onClick={this._handleLibraryAdd} />
+                                <SplitButtonItem
+                                    title={"DELETE LIBRARY"}
+                                    className="button-plus"
+                                    iconId="libraries-delete"
+                                    onClick={this._handleLibraryRemove} />
+                            </SplitButtonList>
+                        </div>
+                        <Library addElement={this._handleAddElement} library={currentLibrary} />
+                        <LibraryBar/>
+                    </div>
+                );
+            } else {
+                containerContents = (
+                    <div>
+                        Can't connect to local library process!
+                        <Button title="Refresh" className="button-plus" onClick={this._handleRefresh}>
+                            <SVGIcon viewbox="0 0 12 12" CSSID="plus" />
+                        </Button>
+                    </div>
+                );
+            }
+
+            return containerContents;
+        },
+
+        render: function () {
             var containerClasses = classnames({
                 "section-container": true,
                 "section-container__collapsed": !this.props.visible
@@ -117,55 +160,6 @@ define(function (require, exports, module) {
                 "section__sibling-collapsed": !this.props.visibleSibling
             });
 
-            var containerContents;
-
-            if (connected) {
-                containerContents = this.props.visible && !this.props.disabled && (
-                <div>
-                    <div className="formline">
-                        <LibraryList
-                            ref="libraryList"
-                            libraries={libraries}
-                            selected={currentLibrary}
-                            onLibraryChange={this._handleLibraryChange}
-                        />
-                        <SplitButtonList>
-                            <SplitButtonItem
-                                title={"CREATE LIBRARY"}
-                                className="button-plus"
-                                iconId="plus"
-                                onClick={this._handleLibraryAdd}
-                                />
-                            <SplitButtonItem
-                                title={"DELETE LIBRARY"}
-                                className="button-plus"
-                                iconId="libraries-delete"
-                                onClick={this._handleLibraryRemove}
-                                />
-                        </SplitButtonList>
-                    </div>
-                    <Library
-                        addElement={this._handleAddElement}
-                        library={currentLibrary}
-                    />
-                    <LibraryBar />
-                </div>);
-            } else {
-                containerContents = (
-                    <div>
-                        Can't connect to local library process!
-                         <Button
-                            title="Refresh"
-                            className="button-plus"
-                            onClick={this._handleRefresh}>
-                            <SVGIcon
-                                viewbox="0 0 12 12"
-                                CSSID="plus" />
-                        </Button>
-                    </div>
-                );
-            }
-
             return (
                 <section
                     className={sectionClasses}>
@@ -175,7 +169,7 @@ define(function (require, exports, module) {
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle} />
                     <div className={containerClasses}>
-                        {containerContents}
+                        {this._containerContents()}
                     </div>
                 </section>
             );

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -99,16 +99,19 @@ define(function (require, exports, module) {
         _handleLibraryRemove: function () {
             this.getFlux().actions.libraries.removeCurrentLibrary();
         },
-
+        
+        /**
+         * Return library panel content based on the connection status of CC Library.
+         * @return {ReactComponent}
+         */
         _containerContents: function () {
             var libraryStore = this.getFlux().store("library"),
-                connected = libraryStore.getConnectionStatus();
-
-            var containerContents;
+                connected = libraryStore.getConnectionStatus(),
+                containerContents;
+                
             if (connected) {
                 var libraries = this.state.libraries,
-                    currentLibrary = libraries.get(this.state.selectedLibrary),
-                    selectedLayers = this.props.document.layers.selected;
+                    currentLibrary = libraries.get(this.state.selectedLibrary);
 
                 containerContents = this.props.visible && !this.props.disabled && (
                     <div>
@@ -130,9 +133,11 @@ define(function (require, exports, module) {
                                     onClick={this._handleLibraryRemove} />
                             </SplitButtonList>
                         </div>
-                        <Library addElement={this._handleAddElement} library={currentLibrary} />
+                        <Library
+                            addElement={this._handleAddElement}
+                            library={currentLibrary} />
                         <LibraryBar
-                            selectedLayers={selectedLayers}
+                            document={this.props.document}
                             disabled={!currentLibrary}/>
                     </div>
                 );
@@ -161,6 +166,8 @@ define(function (require, exports, module) {
                 "section": true,
                 "section__sibling-collapsed": !this.props.visibleSibling
             });
+            
+            var containerContents = this._containerContents();
 
             return (
                 <section
@@ -171,7 +178,7 @@ define(function (require, exports, module) {
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle} />
                     <div className={containerClasses}>
-                        {this._containerContents()}
+                        {containerContents}
                     </div>
                 </section>
             );

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -113,11 +113,10 @@ define(function (require, exports, module) {
                     <div>
                         <div className="formline">
                             <LibraryList
-                                ref="libraryList"
                                 libraries={libraries}
                                 selected={currentLibrary}
                                 onLibraryChange={this._handleLibraryChange} />
-                            <SplitButtonList>
+                            <SplitButtonList className="libraries__split-button-list">
                                 <SplitButtonItem
                                     title={"CREATE LIBRARY"}
                                     className="button-plus"

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -107,7 +107,8 @@ define(function (require, exports, module) {
             var containerContents;
             if (connected) {
                 var libraries = this.state.libraries,
-                    currentLibrary = libraries.get(this.state.selectedLibrary);
+                    currentLibrary = libraries.get(this.state.selectedLibrary),
+                    selectedLayers = this.props.document.layers.selected;
 
                 containerContents = this.props.visible && !this.props.disabled && (
                     <div>
@@ -130,7 +131,8 @@ define(function (require, exports, module) {
                             </SplitButtonList>
                         </div>
                         <Library addElement={this._handleAddElement} library={currentLibrary} />
-                        <LibraryBar/>
+                        <LibraryBar
+                            selectedLayers={selectedLayers}/>
                     </div>
                 );
             } else {

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -31,8 +31,9 @@ define(function (require, exports, module) {
 
     var Gutter = require("jsx!js/jsx/shared/Gutter"),
         SplitButton = require("jsx!js/jsx/shared/SplitButton"),
-        SplitButtonItem = SplitButton.SplitButtonItem,
-        strings = require("i18n!nls/strings");
+        SplitButtonItem = SplitButton.SplitButtonItem;
+        
+    // strings = require("i18n!nls/strings");
 
     var LibraryBar = React.createClass({
         mixins: [FluxMixin],
@@ -41,7 +42,7 @@ define(function (require, exports, module) {
          * Uploads the selected layer(s) as a graphic asset to CC Libraries
          * @private
          */
-        addImageAsset: function () {
+        addGraphic: function () {
             this.getFlux().actions.libraries.createElementFromSelectedLayer();
         },
 
@@ -75,41 +76,39 @@ define(function (require, exports, module) {
         },
 
         render: function () {
+            /*TODO: move button text to strings */
+            
             return (
                 <div className="formline">
                     <ul className="button-radio">
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.FLIP_HORIZONTAL}
+                            title={"Add Graphic"}
                             iconId="libraries-addGraphic"
-                            onClick={this.addImageAsset}
-                            replaceWith="Next five are likely to be a new control"
+                            onClick={this.addGraphic}
+                            disabled={!this._canAddGraphic()}
                              />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.FLIP_VERTICAL}
+                            title={"Add Character Style"}
                             onClick={this.addCharacterStyle}
                             iconId="libraries-addCharStyle"
+                            disabled={!this._canAddCharacterStyle()}
                             />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.SWAP_POSITION}
+                            title={"Add Layer Style"}
                             iconId="libraries-addLayerStyle"
                             onClick={this.addLayerStyle}
-                            />
-                        <SplitButtonItem
-                            title={strings.TOOLTIPS.SWAP_POSITION}
-                            iconId="swap"
-                            FIXME="Will have multiple with different sources, refer to Color.jsx for rendering"
-                            onClick={this.addColorAsset}
+                            disabled={!this._canAddLayerStyle()}
                             />
                         <Gutter />
                         <Gutter />
                         <Gutter />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.SWAP_POSITION}
+                            title={"Search Adobe Stock"}
                             iconId="swap"
                             FIXME="Adobe Stock Image link"
                             />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.SWAP_POSITION}
+                            title={"Sync Libraries"}
                             iconId="libraries-CC"
                             FIXME="syncIcon, also make sure these last two are right aligned"
                             />
@@ -117,8 +116,27 @@ define(function (require, exports, module) {
                     <Gutter />
                 </div>
             );
+        },
+        
+        _canAddGraphic: function () {
+            return !this.props.selectedLayers.isEmpty();
+        },
+        
+        _canAddCharacterStyle: function () {
+            return !this.props.selectedLayers.isEmpty() &&
+                   this.props.selectedLayers.filter(nonTextLayer).isEmpty();
+        },
+        
+        _canAddLayerStyle: function () {
+            return this.props.selectedLayers.size === 1 &&
+                   this.props.selectedLayers.first().hasLayerEffect();
         }
+        
     });
+    
+    var nonTextLayer = function (layer) {
+        return layer.kind !== layer.layerKinds.TEXT;
+    };
 
     module.exports = LibraryBar;
 });

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -28,7 +28,6 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        collection = require("js/util/collection"),
         Immutable = require("immutable"),
         strings = require("i18n!nls/strings");
         
@@ -122,22 +121,18 @@ define(function (require, exports, module) {
             );
         },
         
-        _createColorButton: function (colorName, buttonText) {
-            var colors = this.props.selectedLayers.map(function (layer) {
-                var colors = layer[colorName];
-                return colors.isEmpty() ? null : colors.first().color;
-            });
-            var uniqueColors = collection.unique(colors);
-            
-            if (uniqueColors.size !== 1 || uniqueColors.first() === null) {
+        _createColorButton: function (attr, buttonText) {
+            var layer = this.props.selectedLayers.first();
+            if (this.props.selectedLayers.size !== 1 || layer[attr].isEmpty()) {
                 return null;
             }
             
+            var color = layer[attr].first().color;
             return (
                 <SplitButtonItem title={buttonText} disabled={this.props.disabled}>
                     <div className="split-button__item__color-icon"
-                         style={{ backgroundColor: uniqueColors.first().toCssRGB() }}
-                         onClick={this.addColorAsset.bind(this, uniqueColors.first())} />
+                         style={{ backgroundColor: color.toCssRGB() }}
+                         onClick={this.addColorAsset.bind(this, color)} />
                 </SplitButtonItem>
             );
         },
@@ -147,13 +142,9 @@ define(function (require, exports, module) {
         },
         
         _canAddCharacterStyle: function () {
-            var nonTextLayer = function (layer) {
-                return layer.kind !== layer.layerKinds.TEXT;
-            };
-            
             return !this.props.disabled &&
-                   !this.props.selectedLayers.isEmpty() &&
-                   this.props.selectedLayers.filter(nonTextLayer).isEmpty();
+                   this.props.selectedLayers.size === 1 &&
+                   this.props.selectedLayers.first().isTextLayer();
         },
         
         _canAddLayerStyle: function () {

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -27,22 +27,19 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
-        Immutable = require("immutable"),
-        strings = require("i18n!nls/strings");
-        
+        FluxMixin = Fluxxor.FluxMixin(React);
 
     var Gutter = require("jsx!js/jsx/shared/Gutter"),
         SplitButton = require("jsx!js/jsx/shared/SplitButton"),
-        SplitButtonItem = SplitButton.SplitButtonItem;
-        
-    // strings = require("i18n!nls/strings");
+        SplitButtonItem = SplitButton.SplitButtonItem,
+        strings = require("i18n!nls/strings"),
+        Document = require("js/models/document");
 
     var LibraryBar = React.createClass({
         mixins: [FluxMixin],
         
         propTypes: {
-            selectedLayers: React.PropTypes.instanceOf(Immutable.List).isRequired,
+            document: React.PropTypes.instanceOf(Document).isRequired,
             disabled: React.PropTypes.bool
         },
 
@@ -73,10 +70,90 @@ define(function (require, exports, module) {
         /**
          * Uploads a color asset to the library
          * @private
+         * 
+         * @param {Color} color
          */
         addColorAsset: function (color) {
             // FIXME: We may also need to extend to other color spaces/representations here, check other uses of colors
             this.getFlux().actions.libraries.createColorAsset(color);
+        },
+        
+        /**
+         * Helper function to create color button based on the layer attribute (fills or strokes)
+         * @private
+         * 
+         * @param {string} attr name of the color attribute ("fills" or "strokes")
+         * @param {string} buttonTitle title of the button
+         * 
+         * @return {SplitButtonItem}
+         */
+        _createColorButton: function (attr, buttonTitle) {
+            var layer = this.props.document.layers.selected.first();
+            
+            if (this.props.document.layers.selected.size !== 1 || layer[attr].isEmpty()) {
+                return null;
+            }
+            
+            var color = layer[attr].first().color;
+            
+            return (
+                <SplitButtonItem title={buttonTitle} disabled={this.props.disabled}>
+                    <div className="split-button__item__color-icon"
+                         style={{ backgroundColor: color.toCssRGB() }}
+                         onClick={this.addColorAsset.bind(this, color)} />
+                </SplitButtonItem>
+            );
+        },
+        
+        /**
+         * True if user can add the selected layer(s) as graphic into the libraries.
+         * @private
+         * 
+         * @return {boolean}
+         */
+        _canAddGraphic: function () {
+            if (this.props.disabled || this.props.document.layers.selected.isEmpty()) {
+                return false;
+            }
+
+            var layersAreAllEmpty = this.props.document.layers.selected.every(function (layer) {
+                return layer.kind === layer.layerKinds.GROUP && this.props.document.layers.isEmptyGroup(layer);
+            }.bind(this));
+        
+            return !layersAreAllEmpty;
+        },
+        
+        /**
+         * True if user can add the selected text layer into the libraries.
+         * @private
+         * 
+         * @return {boolean}
+         */
+        _canAddCharacterStyle: function () {
+            if (this.props.disabled ||
+                this.props.document.layers.selected.size !== 1 ||
+                !this.props.document.layers.selected.first().isTextLayer()) {
+                return false;
+            }
+            
+            var fontStore = this.getFlux().store("font"),
+                text = this.props.document.layers.selected.first().text,
+                characterStyle = text.characterStyles.first(),
+                textHasMissingFont = !fontStore.getFontFamilyFromPostScriptName(characterStyle.postScriptName);
+            
+            return !textHasMissingFont;
+        },
+        
+        /**
+         * True if user can add the style of the selected layer into the libraries.
+         * @private
+         * 
+         * @return {boolean}
+         */
+        _canAddLayerStyle: function () {
+            return !this.props.disabled &&
+                   this.props.document.layers.selected.size === 1 &&
+                   this.props.document.layers.selected.first().hasLayerEffect();
         },
 
         render: function () {
@@ -119,38 +196,6 @@ define(function (require, exports, module) {
                     <Gutter />
                 </div>
             );
-        },
-        
-        _createColorButton: function (attr, buttonText) {
-            var layer = this.props.selectedLayers.first();
-            if (this.props.selectedLayers.size !== 1 || layer[attr].isEmpty()) {
-                return null;
-            }
-            
-            var color = layer[attr].first().color;
-            return (
-                <SplitButtonItem title={buttonText} disabled={this.props.disabled}>
-                    <div className="split-button__item__color-icon"
-                         style={{ backgroundColor: color.toCssRGB() }}
-                         onClick={this.addColorAsset.bind(this, color)} />
-                </SplitButtonItem>
-            );
-        },
-        
-        _canAddGraphic: function () {
-            return !this.props.disabled && !this.props.selectedLayers.isEmpty();
-        },
-        
-        _canAddCharacterStyle: function () {
-            return !this.props.disabled &&
-                   this.props.selectedLayers.size === 1 &&
-                   this.props.selectedLayers.first().isTextLayer();
-        },
-        
-        _canAddLayerStyle: function () {
-            return !this.props.disabled &&
-                   this.props.selectedLayers.size === 1 &&
-                   this.props.selectedLayers.first().hasLayerEffect();
         }
     });
 

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         collection = require("js/util/collection"),
+        Immutable = require("immutable"),
         strings = require("i18n!nls/strings");
         
 
@@ -40,6 +41,11 @@ define(function (require, exports, module) {
 
     var LibraryBar = React.createClass({
         mixins: [FluxMixin],
+        
+        propTypes: {
+            selectedLayers: React.PropTypes.instanceOf(Immutable.List).isRequired,
+            disabled: React.PropTypes.bool
+        },
 
         /**
          * Uploads the selected layer(s) as a graphic asset to CC Libraries
@@ -128,7 +134,7 @@ define(function (require, exports, module) {
             }
             
             return (
-                <SplitButtonItem title={buttonText}>
+                <SplitButtonItem title={buttonText} disabled={this.props.disabled}>
                     <div className="split-button__item__color-icon"
                          style={{ backgroundColor: uniqueColors.first().toCssRGB() }}
                          onClick={this.addColorAsset.bind(this, uniqueColors.first())} />
@@ -137,7 +143,7 @@ define(function (require, exports, module) {
         },
         
         _canAddGraphic: function () {
-            return !this.props.selectedLayers.isEmpty();
+            return !this.props.disabled && !this.props.selectedLayers.isEmpty();
         },
         
         _canAddCharacterStyle: function () {
@@ -145,12 +151,14 @@ define(function (require, exports, module) {
                 return layer.kind !== layer.layerKinds.TEXT;
             };
             
-            return !this.props.selectedLayers.isEmpty() &&
+            return !this.props.disabled &&
+                   !this.props.selectedLayers.isEmpty() &&
                    this.props.selectedLayers.filter(nonTextLayer).isEmpty();
         },
         
         _canAddLayerStyle: function () {
-            return this.props.selectedLayers.size === 1 &&
+            return !this.props.disabled &&
+                   this.props.selectedLayers.size === 1 &&
                    this.props.selectedLayers.first().hasLayerEffect();
         }
     });

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
                     className="dialog-libraries"
                     options={libraryOptions}
                     value={libraryName}
-                    size="column-12"
+                    size="column-24"
                     live={false}
                     onChange={this._handleChange} />
             );

--- a/src/js/jsx/shared/SplitButton.jsx
+++ b/src/js/jsx/shared/SplitButton.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         classnames = require("classnames");
 
     var SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
-
+    
     /**
      * A Component which represents an individual button within a SplitButtonList
      */
@@ -48,11 +48,10 @@ define(function (require, exports, module) {
                     "split-button__item__disabled": this.props.disabled,
                     "split-button__item": true
                 }, this.props.className);
-                
             
             var buttonIcon;
             if (this.props.iconId) {
-                buttonIcon = <SVGIcon viewBox="0 0 24 24" CSSID={this.props.iconId} />;
+                buttonIcon = (<SVGIcon viewBox="0 0 24 24" CSSID={this.props.iconId} />);
             } else {
                 buttonIcon = this.props.children;
             }

--- a/src/js/jsx/shared/SplitButton.jsx
+++ b/src/js/jsx/shared/SplitButton.jsx
@@ -34,22 +34,20 @@ define(function (require, exports, module) {
      */
     var SplitButtonItem = React.createClass({
         mixins: [React.addons.PureRenderMixin],
-        
+
         propTypes: {
             id: React.PropTypes.string,
             onChange: React.PropTypes.func,
             selected: React.PropTypes.bool,
             disabled: React.PropTypes.bool
         },
-        
+
         render: function () {
             var buttonClasses = classnames({
                     "split-button__item__selected": this.props.selected,
                     "split-button__item__disabled": this.props.disabled,
                     "split-button__item": true
-                });
-
-            buttonClasses += " " + (this.props.className || "");
+                }, this.props.className);
 
             return (
                 <li className={buttonClasses}
@@ -72,14 +70,14 @@ define(function (require, exports, module) {
 
         render: function () {
             var numberOfItems = React.Children.count(this.props.children);
-            
+
             // TODO make this more readable and move complexity to LESS
             var buttonWrapperClasses = classnames({
                 "column-12": numberOfItems < 4,
                 "column-14": numberOfItems >= 4,
                 "button-radio": true
-            });
-            
+            }, this.props.className);
+
             return (
                 <ul className={buttonWrapperClasses} >
                     {this.props.children}

--- a/src/js/jsx/shared/SplitButton.jsx
+++ b/src/js/jsx/shared/SplitButton.jsx
@@ -48,15 +48,21 @@ define(function (require, exports, module) {
                     "split-button__item__disabled": this.props.disabled,
                     "split-button__item": true
                 }, this.props.className);
+                
+            
+            var buttonIcon;
+            if (this.props.iconId) {
+                buttonIcon = <SVGIcon viewBox="0 0 24 24" CSSID={this.props.iconId} />;
+            } else {
+                buttonIcon = this.props.children;
+            }
 
             return (
                 <li className={buttonClasses}
                     id={this.props.id}
                     title={this.props.title}
                     onClick={this.props.disabled ? null : this.props.onClick}>
-                    <SVGIcon
-                        viewBox="0 0 24 24"
-                        CSSID={this.props.iconId} />
+                    {buttonIcon}
                 </li>
             );
         }

--- a/src/js/models/color.js
+++ b/src/js/models/color.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
     
     /**
      * Return string representation in CSS RGB format. 
-     * @return {string}
+     * @return {string} Example: rgb(100, 100, 0)
      */
     Color.prototype.toCssRGB = function () {
         return "rgb(" + [Math.round(this.r), Math.round(this.g), Math.round(this.b)].join(", ") + ")";

--- a/src/js/models/color.js
+++ b/src/js/models/color.js
@@ -169,6 +169,10 @@ define(function (require, exports, module) {
         return this.delete("a");
     };
     
+    /**
+     * Return string representation in CSS RGB format. 
+     * @return {string}
+     */
     Color.prototype.toCssRGB = function () {
         return "rgb(" + [Math.round(this.r), Math.round(this.g), Math.round(this.b)].join(", ") + ")";
     };

--- a/src/js/models/color.js
+++ b/src/js/models/color.js
@@ -168,6 +168,10 @@ define(function (require, exports, module) {
     Color.prototype.opaque = function () {
         return this.delete("a");
     };
+    
+    Color.prototype.toCssRGB = function () {
+        return "rgb(" + [Math.round(this.r), Math.round(this.g), Math.round(this.b)].join(", ") + ")";
+    };
 
     module.exports = Color;
 });

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -446,8 +446,20 @@ define(function (require, exports, module) {
         return this.merge(model);
     };
     
+    /**
+     * True if the layer has layer effect.
+     * @return {boolean}  
+     */
     Layer.prototype.hasLayerEffect = function () {
         return !this.innerShadows.isEmpty() || !this.dropShadows.isEmpty();
+    };
+
+    /**
+     * True if the layer is text layer.
+     * @return {boolean}  
+     */
+    Layer.prototype.isTextLayer = function () {
+        return this.kind === this.layerKinds.TEXT;
     };
 
     module.exports = Layer;

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -445,6 +445,10 @@ define(function (require, exports, module) {
 
         return this.merge(model);
     };
+    
+    Layer.prototype.hasLayerEffect = function () {
+        return !this.innerShadows.isEmpty() || !this.dropShadows.isEmpty();
+    };
 
     module.exports = Layer;
 });

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -91,6 +91,16 @@ define(function (require, exports, module) {
 
             return fontObj && fontObj.postScriptName;
         },
+        
+        /**
+         * Get the font-family name of a given postScritName. 
+         *
+         * @param {string} postScriptName
+         * @return {?{family: string, font: string}}
+         */
+        getFontFamilyFromPostScriptName: function (postScriptName) {
+            return this._postScriptMap.get(postScriptName);
+        },
 
         /**
          * Given a layer, builds a type object acceptable by cc libraries

--- a/src/js/util/collection.js
+++ b/src/js/util/collection.js
@@ -169,7 +169,7 @@ define(function (require, exports) {
      */
     var unique = function (iterable) {
         return iterable.reduce(function (result, value) {
-            if (!result.has(value)) {
+            if (!result.includes(value)) {
                 result = result.push(value);
             }
             return result;

--- a/src/js/util/collection.js
+++ b/src/js/util/collection.js
@@ -160,21 +160,6 @@ define(function (require, exports) {
             return !collection.contains(elem);
         });
     };
-    
-    /**
-     * 
-     * 
-     * @param {Immutable.Iterable} iterable
-     * @return {Immutable.Iterable}
-     */
-    var unique = function (iterable) {
-        return iterable.reduce(function (result, value) {
-            if (!result.includes(value)) {
-                result = result.push(value);
-            }
-            return result;
-        }, Immutable.List());
-    };
 
     exports.uniformValue = uniformValue;
     exports.zip = zip;
@@ -182,5 +167,4 @@ define(function (require, exports) {
     exports.pluckAll = pluckAll;
     exports.intersection = intersection;
     exports.difference = difference;
-    exports.unique = unique;
 });

--- a/src/js/util/collection.js
+++ b/src/js/util/collection.js
@@ -160,6 +160,21 @@ define(function (require, exports) {
             return !collection.contains(elem);
         });
     };
+    
+    /**
+     * 
+     * 
+     * @param {Immutable.Iterable} iterable
+     * @return {Immutable.Iterable}
+     */
+    var unique = function (iterable) {
+        return iterable.reduce(function (result, value) {
+            if (!result.has(value)) {
+                result = result.push(value);
+            }
+            return result;
+        }, Immutable.List());
+    };
 
     exports.uniformValue = uniformValue;
     exports.zip = zip;
@@ -167,4 +182,5 @@ define(function (require, exports) {
     exports.pluckAll = pluckAll;
     exports.intersection = intersection;
     exports.difference = difference;
+    exports.unique = unique;
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -444,7 +444,14 @@ define(function (require, exports, module) {
             SECTION_COLLAPSE: ": double-click to collapse",
             SECTION_EXPAND: ": double-click to expand",
             GRID_MODE: "Show items as icons",
-            LIST_MODE: "Show items in a list"
+            LIST_MODE: "Show items in a list",
+            ADD_GRAPHIC: "Add Graphic",
+            ADD_CHARACTER_STYLE: "Add Character Style",
+            ADD_LAYER_STYLE: "Add Layer Style",
+            ADD_FILL_COLOR: "Add Fill Color",
+            ADD_STROKE_COLOR: "Add Stroke Color",
+            SEARCH_ADOBE_STOCK: "Search Adobe Stock",
+            SYNC_LIBRARIES: "Sync Libraries"
         },
         LAYER_KIND: {
             0: "Any Layer",

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -197,6 +197,10 @@ input {
     -webkit-font-feature-settings: "calt", "liga", "clig", "kern", "tnum";
 }
 
+.hide {
+    display: none;
+}
+
 
 // Standard def displays
 @media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 801px) and (max-device-width: 1280px) {

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -22,13 +22,13 @@
  */
 
 .libraries {
-    min-height: 7.5rem;
+    min-height: 17.5rem;
     flex-grow: 0;
     flex-shrink: 0;
 }
 
 .libraries .section-container {
-    flex-basis: 7.5rem;
+    flex-basis: 17.5rem;
 }
 
 .libraries .section-container__collapsed {
@@ -60,4 +60,20 @@
 .libraries .split-button__item svg {
     width: 1.4rem;
     height: 1.4rem;
+}
+
+.split-button__item__color-icon {
+    width: 1.2rem;
+    height: 1.2rem;
+    border: 1px solid white;    
+    border-radius: 1px;
+}
+
+.libraries-bar{
+    ul {
+        flex-grow: 0;
+        .split-button__item {
+            width: 30px;
+        }
+    }
 }

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -56,3 +56,8 @@
 .libraries__split-button-list{
     display: none;
 }
+
+.libraries .split-button__item svg {
+    width: 1.4rem;
+    height: 1.4rem;
+}

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -52,3 +52,7 @@
     justify-content: center;
     overflow: hidden;
 }
+
+.libraries__split-button-list{
+    display: none;
+}

--- a/src/style/sections/style/style-section.less
+++ b/src/style/sections/style/style-section.less
@@ -28,7 +28,7 @@
 }
 
 .style .section-container {
-    flex-basis: 41.5rem;
+    flex-basis: 31.5rem;
 }
 
 .style .section-container__collapsed {


### PR DESCRIPTION
this PR implements the following "add" buttons:

1 - Add Graphic: layer / multiple layers
2 - Add Character Layer: text layer only
3 - Add Stye Layer: layer with shadow effects
4 - Add Fill / Stroke Color: layer with fills / strokes attribute

*I hide the other buttons (search stock, sync, create/delete library) temporarily until they get supported*

@volfied please review. A complete UI of the asset list will be in the next PR.