### PR TITLE
Add priority values to search options so we get a better ordering of options

### DIFF
--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -66,8 +66,7 @@ define(function (require, exports, module) {
                 active: false,
                 filter: null,
                 id: this.props.defaultSelected,
-                suggestTitle: "", // If using autofill, the title of the suggested option
-                width: 0 // If using autofill, the width of the hidden input, used to place the suggestion
+                suggestTitle: "" // If using autofill, the title of the suggested option
             };
         },
 
@@ -78,12 +77,18 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
+            if (this.props.live) {
+                return true;
+            }
+
             // Update autofill here so that can check options based on the updated filter
-            if (this.state.filter !== nextState.filter) {
+            if (this.state.filter !== nextState.filter || this.state.active !== nextState.active ||
+                    this.state.suggestTitle !== nextState.suggestTitle) {
                 var iconCount = nextProps.filterIcons ? nextProps.filterIcons.length : 0;
                 this._updateAutofill(nextState.filter, iconCount);
+                return true;
             }
-            return true;
+            return false;
         },
 
         /**
@@ -202,10 +207,12 @@ define(function (require, exports, module) {
             switch (event.key) {
             case "ArrowUp":
                 select.selectPrev();
+                event.preventDefault();
                 event.stopPropagation();
                 break;
             case "ArrowDown":
                 select.selectNext();
+                event.preventDefault();
                 event.stopPropagation();
                 break;
             case "Tab":
@@ -341,13 +348,14 @@ define(function (require, exports, module) {
          *
          * @private
          * @param {string} filter
+         * @param {bool} truncate Whether or not to restrict number of options
          * @return {Immutable.List.<object>}
          */
-        _filterOptions: function (filter) {
+        _filterOptions: function (filter, truncate) {
             var options = this.props.options;
 
             if (this.props.filterOptions) {
-                return this.props.filterOptions(options, filter);
+                return this.props.filterOptions(filter, this.state.id, truncate);
             }
 
             return options && options.filter(function (option) {
@@ -364,7 +372,7 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Update state for autofill. Finds the new width of the hidden input and new autofill suggestion
+         * Update state for autofill. Finds new suggestion and sets its position
          *
          * @private
          * @param {string} value The current value of the input
@@ -383,12 +391,14 @@ define(function (require, exports, module) {
                 
                 width += 20 * iconCount; // 20 pixels is the computed width + padding of an svg icon
 
+                React.findDOMNode(this.refs.autocomplete).style.left = width + "px";
+
                 // Find new autofill suggestion
                 // First check if there's anything based on the whole search value
                 // Otherwise suggest based on last word typed
                 var valueLowerCase = value ? value.toLowerCase() : "",
                     lastWord = valueLowerCase.split(" ").pop(),
-                    options = this._filterOptions(valueLowerCase),
+                    options = this._filterOptions(valueLowerCase, true),
 
                     suggestion = (options && valueLowerCase !== "") ? options.find(function (opt) {
                             return (opt.type === "item" && opt.title.toLowerCase().indexOf(valueLowerCase) === 0);
@@ -400,12 +410,11 @@ define(function (require, exports, module) {
                     }) : null;
                 }
 
-                var suggestionID = suggestion ? suggestion.id : this.state.id,
-                    suggestionTitle = suggestion ? suggestion.title : this.state.suggestTitle;
+                var suggestionID = suggestion ? suggestion.id : null,
+                    suggestionTitle = suggestion ? suggestion.title : "";
                
                 this.setState({
                     filter: value,
-                    width: width,
                     id: suggestionID,
                     suggestTitle: suggestionTitle
                 });
@@ -484,7 +493,7 @@ define(function (require, exports, module) {
                 filter = this.state.filter,
                 title = this.state.active && filter !== null ? filter : value,
                 searchableFilter = filter ? filter.toLowerCase() : "",
-                filteredOptions = this._filterOptions(searchableFilter),
+                filteredOptions = this._filterOptions(searchableFilter, false),
                 searchableOptions = filteredOptions;
 
             if (filteredOptions && collection.uniformValue(collection.pluck(filteredOptions, "type"))) {
@@ -501,11 +510,9 @@ define(function (require, exports, module) {
                     </div>
                 );
                 
-                // Adjust positioning of the suggestion to line up with text
-                var autocompStyle = { left: this.state.width + "px" },
-                    // Take substring of this.state.suggestTitle so that only display 
-                    // the remaining portion of the title that the user hasn't typed yet
-                    suggestTitle = this.state.suggestTitle,
+                // Take substring of this.state.suggestTitle so that only display 
+                // the remaining portion of the title that the user hasn't typed yet
+                var suggestTitle = this.state.suggestTitle,
                     suggestTitleLC = suggestTitle.toLowerCase(),
                     titleLC = title.toLowerCase(),
                     wordToComplete = titleLC.split(" ").pop(),
@@ -521,9 +528,8 @@ define(function (require, exports, module) {
                 }
 
                 autocomplete = (
-                    <div
-                        className="autocomplete"
-                        style={autocompStyle}>
+                    <div ref="autocomplete"
+                        className="autocomplete">
                         {suggestion}
                     </div>
                 );

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            if (this.props.live) {
+            if (this.props.live && this.state.id !== nextState.id) {
                 return true;
             }
 
@@ -348,7 +348,7 @@ define(function (require, exports, module) {
          *
          * @private
          * @param {string} filter
-         * @param {bool} truncate Whether or not to restrict number of options
+         * @param {boolean} truncate Whether or not to restrict number of options
          * @return {Immutable.List.<object>}
          */
         _filterOptions: function (filter, truncate) {

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -83,7 +83,8 @@ define(function (require, exports, module) {
         /**
          * Search modules
          *
-         * @type {{searchTypes: Array.<string>, searchItems: Immutable.List.<object>, filters: Array.<Array.<string>>}}
+         * @type {{searchTypes: Array.<string>, searchItems: Immutable.List.<Immutable.List.<object>>,
+         * filters: Array.<Array.<string>>}}
          */
         _registeredSearches: {},
 
@@ -123,12 +124,29 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Get the search items for the specified search module
+         * Get the search items for the specified search module as 
+         * a one dimensional list
          *
          * @param {string} id The search module ID 
          * @return {Immutable.Iterable.<object>}
          */
         getSearchItems: function (id) {
+            var groupedSearchItems = this._registeredSearches[id].searchItems,
+                flatSearchItems = groupedSearchItems.reduce(function (flatItems, itemGroup) {
+                    return flatItems.concat(itemGroup);
+                }.bind(this), Immutable.List());
+
+            return flatSearchItems;
+        },
+
+        /**
+         * Get the search items for the specified search module
+         * where items are grouped by search type within the list
+         *
+         * @param {string} id The search module ID 
+         * @return {Immutable.Iterable.<Immutable.Iterable.<object>>}
+         */
+        getGroupedSearchItems: function (id) {
             return this._registeredSearches[id].searchItems;
         },
 
@@ -214,7 +232,7 @@ define(function (require, exports, module) {
                         filters = this._getFiltersByItems(options, type);
                     
                     search.searchFilters.push(filters);
-                    return items.concat(options);
+                    return items.push(options);
                 }.bind(this), Immutable.List());
             }
         },

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -114,13 +114,18 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Update the search items for the specified search module
+         * Get state of a particular module.
          *
-         * @private
-         * @param {string} id The search module ID to update
-         */
-        _update: function (id) {
-            this._updateSearchItems(id);
+         * @param {string} id Search module ID
+         * @return {object}
+        */
+        getState: function (id) {
+            return {
+                searchItems: this.getSearchItems(id),
+                groupedSearchItems: this._registeredSearches[id].searchItems,
+                headers: this._registeredSearches[id].searchHeaders,
+                filters: this._registeredSearches[id].searchFilters
+            };
         },
 
         /**
@@ -137,37 +142,6 @@ define(function (require, exports, module) {
                 }.bind(this), Immutable.List());
 
             return flatSearchItems;
-        },
-
-        /**
-         * Get the search items for the specified search module
-         * where items are grouped by search type within the list
-         *
-         * @param {string} id The search module ID 
-         * @return {Immutable.Iterable.<Immutable.Iterable.<object>>}
-         */
-        getGroupedSearchItems: function (id) {
-            return this._registeredSearches[id].searchItems;
-        },
-
-        /**
-         * Get the filters for the specified search module
-         *
-         * @param {string} id The search module ID 
-         * @return {Array.<Array.<string>>}
-         */
-        getFilters: function (id) {
-            return this._registeredSearches[id].searchFilters;
-        },
-
-        /**
-         * Get the headers for the specified search module
-         *
-         * @param {string} id The search module ID
-         * @return {Array.<string>}
-         */
-        getHeaders: function (id) {
-            return this._registeredSearches[id].searchHeaders;
         },
         
         /**
@@ -216,7 +190,7 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Add all possible options for each of the search headers for the module
+         * Add all possible options and filters for each of the search headers for the module
          *
          * @param {string} id The search module ID
          */
@@ -235,6 +209,7 @@ define(function (require, exports, module) {
                     return items.push(options);
                 }.bind(this), Immutable.List());
             }
+            this.emit("change");
         },
 
         /**

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -113,4 +113,5 @@
     position: absolute;
     color: @color-section-rule;
     top: 1.2rem;
+    white-space: pre;
 }


### PR DESCRIPTION
A simple priority system to better predict options. This can definitely be finessed in the future, but as a first pass, it gives better results.

Now we get:
<img width="208" alt="screen shot 2015-07-17 at 12 40 53 pm" src="https://cloud.githubusercontent.com/assets/12618145/8755978/c0c2db8c-2c83-11e5-8093-71fa2577a7a1.png">
<img width="237" alt="screen shot 2015-07-17 at 12 41 19 pm" src="https://cloud.githubusercontent.com/assets/12618145/8755981/c0e60b34-2c83-11e5-9c6a-d489d8568ffb.png">

Instead of:
<img width="206" alt="screen shot 2015-07-17 at 12 41 40 pm" src="https://cloud.githubusercontent.com/assets/12618145/8755979/c0e31438-2c83-11e5-8807-8acfd1d22d61.png">
<img width="205" alt="screen shot 2015-07-17 at 12 41 54 pm" src="https://cloud.githubusercontent.com/assets/12618145/8755980/c0e551bc-2c83-11e5-82ef-4e0444be5249.png">



