### PR TITLE
Explicitly provide false parameters when transferring to getLayerOrder

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1121,8 +1121,9 @@ define(function (require, exports) {
             reorderObj = layerLib.reorder(layerRef, targetRef),
             reorderPromise = descriptor.playObject(reorderObj);
       
-        return reorderPromise
-            .then(this.transfer.bind(this, getLayerOrder, document));
+        return reorderPromise.bind(this).then(function () {
+            return this.transfer(getLayerOrder, document, false, false);
+        });
     };
     reorderLayers.reads = [locks.PS_DOC, locks.JS_DOC];
     reorderLayers.writes = [locks.PS_DOC, locks.JS_DOC];


### PR DESCRIPTION
This addresses #1694.  We were previously passing only one argument when transferring to `getLayerOrder()` after reordering layers.  Because of a fluxor(?) quirk which passes its own second argument when none is supplied during transfer, getLayerOrder was misinterpreting its existence and fouling up the logic.  No history state was being captured, and the rest was... 