### PR TITLE
Disable adding / editing shadow effects when selected layers have different shadow counts

### DIFF
--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -246,7 +246,7 @@ define(function (require, exports) {
                 if (shadow && shadow.color) {
                     return { color: shadow.color.setOpaque(color) };
                 } else {
-                    return { color: Color.DEFAULT };
+                    return { color: Color.DEFAULT.setOpaque(color) };
                 }
             };
 

--- a/src/js/jsx/sections/style/Shadow.jsx
+++ b/src/js/jsx/sections/style/Shadow.jsx
@@ -445,10 +445,20 @@ define(function (require, exports) {
             if (layers.isEmpty()) {
                 return null;
             }
-
-            // Group into arrays of dropShadows, by position in each layer
-            var dropShadowGroups = collection.zip(collection.pluck(layers, "dropShadows")),
-                dropShadowList = dropShadowGroups.map(function (dropShadows, index) {
+                
+            var shadowCountsUnmatch = !layers.every(function (l) {
+                    return l.dropShadows.size === layers.first().dropShadows.size;
+                }),
+                reachMaximumShadows = false,
+                shadowsContent;
+                
+            if (!shadowCountsUnmatch) {
+                // Group into arrays of dropShadows, by position in each layer
+                var shadowGroups = collection.zip(collection.pluck(layers, "dropShadows"));
+                
+                reachMaximumShadows = shadowGroups.size >= this.props.max;
+                
+                shadowsContent = shadowGroups.map(function (dropShadows, index) {
                     return (
                         <Shadow {...this.props}
                             layers={layers}
@@ -459,6 +469,13 @@ define(function (require, exports) {
                             type="dropShadow" />
                     );
                 }, this).toList();
+            } else {
+                shadowsContent = (
+                    <div className="shadow-list__list-container__mixed">
+                        <i>{strings.STYLE.DROP_SHADOW.MIXED}</i>
+                    </div>
+                );
+            }
 
             // we may want to gate the add dropshadow button to PS's max amout of drop shadows.
 
@@ -473,7 +490,7 @@ define(function (require, exports) {
                         <Button
                             title={strings.STYLE.DROP_SHADOW.ADD}
                             className="button-plus"
-                            disabled={dropShadowList.size >= this.props.max}
+                            disabled={shadowCountsUnmatch || reachMaximumShadows}
                             onClick={this._addDropShadow.bind(this, layers)}>
                             <SVGIcon
                                 viewbox="0 0 12 12"
@@ -481,7 +498,7 @@ define(function (require, exports) {
                         </Button>
                     </header>
                     <div className="shadow-list__list-container">
-                        {dropShadowList}
+                        {shadowsContent}
                     </div>
                 </div>
             );
@@ -516,10 +533,20 @@ define(function (require, exports) {
             if (layers.isEmpty()) {
                 return null;
             }
-
-            // Group into arrays of innerShadows, by position in each layer
-            var innerShadowGroups = collection.zip(collection.pluck(layers, "innerShadows")),
-                innerShadowList = innerShadowGroups.map(function (innerShadows, index) {
+            
+            var shadowCountsUnmatch = !layers.every(function (l) {
+                    return l.innerShadows.size === layers.first().innerShadows.size;
+                }),
+                reachMaximumShadows = false,
+                shadowsContent;
+                
+            if (!shadowCountsUnmatch) {
+                // Group into arrays of innerShadows, by position in each layer
+                var shadowGroups = collection.zip(collection.pluck(layers, "innerShadows"));
+                
+                reachMaximumShadows = shadowGroups.size >= this.props.max;
+                
+                shadowsContent = shadowGroups.map(function (innerShadows, index) {
                     return (
                         <Shadow {...this.props}
                             layers={layers}
@@ -530,6 +557,13 @@ define(function (require, exports) {
                             type = "innerShadow" />
                     );
                 }, this).toList();
+            } else {
+                shadowsContent = (
+                    <div className="shadow-list__list-container__mixed">
+                        <i><i>{strings.STYLE.INNER_SHADOW.MIXED}</i></i>
+                    </div>
+                );
+            }
 
             // we may want to gate the add dropshadow button to PS's max amout of drop shadows.
 
@@ -544,7 +578,7 @@ define(function (require, exports) {
                         <Button
                             title={strings.STYLE.INNER_SHADOW.ADD}
                             className="button-plus"
-                            disabled={innerShadowList.size >= this.props.max}
+                            disabled={shadowCountsUnmatch || reachMaximumShadows}
                             onClick={this._addInnerShadow.bind(this, layers)}>
                             <SVGIcon
                                 viewbox="0 0 12 12"
@@ -552,7 +586,7 @@ define(function (require, exports) {
                         </Button>
                     </header>
                     <div className="shadow-list__list-container">
-                        {innerShadowList}
+                        {shadowsContent}
                     </div>
                 </div>
             );

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -535,7 +535,8 @@ define(function (require, exports, module) {
                 X_POSITION: "X",
                 Y_POSITION: "Y",
                 BLUR: "Blur",
-                SPREAD: "Spread"
+                SPREAD: "Spread",
+                MIXED: "Mixed Appearances"
             },
             INNER_SHADOW: {
                 TITLE: "Inner Shadows",
@@ -543,7 +544,8 @@ define(function (require, exports, module) {
                 X_POSITION: "X",
                 Y_POSITION: "Y",
                 BLUR: "Blur",
-                SPREAD: "Spread"
+                SPREAD: "Spread",
+                MIXED: "Mixed Appearances"
             },
             TYPE: {
                 TITLE: "Type",

--- a/src/style/sections/style/shadow.less
+++ b/src/style/sections/style/shadow.less
@@ -39,3 +39,11 @@
 .shadow-list__shadow__disabled {
     color: @color-number-input-disabled;
 }
+
+.shadow-list__list-container__mixed {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    text-align: center;
+    color: @color-label;
+    font-style: italic;
+}


### PR DESCRIPTION
This PR is the result of our discussion on adding / editing effects for multiple layers. The conclusion is that adding / editing only works when selected layers have same shadow counts (see Seth's comments below for the cases to consider if want to support any mixed effects). When the counts don't match, the panel displays "Mixed Appearances". Example:

![screen shot 2015-07-17 at 5 11 20 pm](https://cloud.githubusercontent.com/assets/118264/8759451/a171b634-2ca8-11e5-843e-02c29bfad4ba.png)

Pasting Seth's comments for reference

```
Small scoping this would say if effects do not match, then we do to not allow editing of effects for that selection. That’s kind of annoying, but it is the smallest, simplest thing.

If we want to allow that kind of editing, here’s the  cases I’m thinking about:

1) user selects two layers for the purpose of adding effects to both at the same time.

2) user selects layers with mismatched effects, and changes an effect that is  shared.

3) user selects layers with mismatched effects and changes an effect that is NOT shared.

4) users selects layers with the same effects, but the effects are in different order on each layer. The user then changes an effect value.

5) user selects layers with different effects applied. Adds a new effect to both, and changes values

* I would think for the small scoping scenario: If the effect types match but not the effect's values —it would still work. For instance layers that have a shadow that have different values, but are the same effect order, would be allowed
```