### PR TITLE
Expand/collapse all descendants

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1402,30 +1402,34 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Layer|Immutable.Iterable.<Layer>} layers
      * @param {boolean} expand If true, expand the groups. Otherwise, collapse them.
+     * @param {boolean=} descendants Whether to expand all descendants of the given layers.
      * @return {Promise}
      */
-    var setGroupExpansion = function (document, layers, expand) {
+    var setGroupExpansion = function (document, layers, expand, descendants) {
         if (layers instanceof Layer) {
             layers = Immutable.List.of(layers);
         }
 
-        var layerRefs = layers
+        if (descendants) {
+            layers = layers.flatMap(document.layers.descendants, document.layers);
+        }
+
+        layers = layers
             .filter(function (layer) {
                 return layer.kind === layer.layerKinds.GROUP;
             });
 
-        if (layerRefs.isEmpty()) {
+        if (layers.isEmpty()) {
             return Promise.resolve();
         }
 
-        var documentRef = documentLib.referenceBy.id(document.id);
-
-        layerRefs = layerRefs
-            .map(function (layer) {
-                return layerLib.referenceBy.id(layer.id);
-            })
-            .unshift(documentRef)
-            .toArray();
+        var documentRef = documentLib.referenceBy.id(document.id),
+            layerRefs = layers
+                .map(function (layer) {
+                    return layerLib.referenceBy.id(layer.id);
+                })
+                .unshift(documentRef)
+                .toArray();
 
         var expandPlayObject = layerLib.setGroupExpansion(layerRefs, !!expand),
             expansionPromise = descriptor.playObject(expandPlayObject),

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -112,6 +112,9 @@ define(function (require, exports, module) {
             TOGGLE_OVERLAYS: "toggleOverlays",
             SUPERSELECT_MARQUEE: "superselectMarquee"
         },
+        modifiers: {
+            MODIFIERS_CHANGED: "modifiersChanged"
+        },
         shortcut: {
             ADD_SHORTCUT: "addShortcut",
             REMOVE_SHORTCUT: "removeShortcut"

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -42,13 +42,7 @@ define(function (require, exports, module) {
     var DEBOUNCE_DELAY = 200;
 
     var SuperselectOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("document", "application", "ui")],
-
-        /**
-         * Flag to tell us whether to render leaf rectangles or super select rectangles
-         * @type {boolean}
-         */
-        _leafBounds: false,
+        mixins: [FluxMixin, StoreWatchMixin("document", "application", "ui", "modifier")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -113,23 +107,25 @@ define(function (require, exports, module) {
                 uiStore = flux.store("ui"),
                 uiState = uiStore.getState(),
                 modalState = toolStore.getModalToolState(),
-                currentDocument = applicationStore.getCurrentDocument();
+                currentDocument = applicationStore.getCurrentDocument(),
+                modifierStore = flux.store("modifier"),
+                modifiers = modifierStore.getState(),
+                leafModifier = system.isMac ? modifiers.command : modifiers.control;
 
             return {
                 document: currentDocument,
                 marqueeEnabled: uiState.marqueeEnabled,
                 marqueeStart: uiState.marqueeStart,
-                modalState: modalState
+                modalState: modalState,
+                leafBounds: leafModifier
             };
         },
 
         componentWillMount: function () {
-            window.addEventListener("adapterFlagsChanged", this._handleExternalKeyEvent);
             this._drawDebounced = _.debounce(this.drawOverlay, DEBOUNCE_DELAY);
         },
 
         componentWillUnmount: function () {
-            window.removeEventListener("adapterFlagsChanged", this._handleExternalKeyEvent);
             window.removeEventListener("mousemove", this.marqueeUpdater);
             window.removeEventListener("mouseup", this.mouseUpHandler);
             window.removeEventListener("mousedown", this.mouseDownHandler);
@@ -152,9 +148,14 @@ define(function (require, exports, module) {
             OS.addListener("externalMouseMove", this.mouseMoveHandler);
         },
 
-        componentDidUpdate: function () {
+        componentDidUpdate: function (prevProps, prevState) {
             if (!this.state.modalState) {
-                this._drawDebounced();
+                if (this.state.leafBounds !== prevState.leafBounds) {
+                    // Redraw immediately when the leaf modifier key changes
+                    this.drawOverlay();
+                } else {
+                    this._drawDebounced();
+                }
             }
         },
 
@@ -248,7 +249,7 @@ define(function (require, exports, module) {
                 scale = this._scale,
                 renderLayers;
 
-            if (this._leafBounds) {
+            if (this.state.leafBounds) {
                 renderLayers = layerTree.leaves.sortBy(indexOf);
 
                 // We add artboards here, so they are shown selectable
@@ -542,25 +543,6 @@ define(function (require, exports, module) {
             });
 
             this._marqueeResult = highlightedIDs;
-        },
-
-        /**
-         * Handles the cmd key press/depresses here to redraw overlay
-         *
-         * @private
-         * @param {OSEvent} event
-         */
-        _handleExternalKeyEvent: function (event) {
-            var modifiers = event.detail.modifiers,
-                leafModifier = system.isMac ? modifiers.command : modifiers.control;
-
-            if (leafModifier && !this._leafBounds) {
-                this._leafBounds = true;
-                this.drawOverlay();
-            } else if (!leafModifier && this._leafBounds) {
-                this._leafBounds = false;
-                this.drawOverlay();
-            }
         },
 
         /**

--- a/src/js/stores/index.js
+++ b/src/js/stores/index.js
@@ -37,6 +37,7 @@ define(function (require, exports) {
         "tool": require("./tool"),
         "policy": require("./policy"),
         "menu": require("./menu"),
+        "modifier": require("./modifier"),
         "preferences": require("./preferences"),
         "ui": require("./ui"),
         "shortcut": require("./shortcut"),

--- a/src/js/stores/modifier.js
+++ b/src/js/stores/modifier.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Fluxxor = require("fluxxor");
+
+    var events = require("js/events");
+
+    /**
+     * 
+     * @constructor
+     */
+    var ModifierStore = Fluxxor.createStore({
+        /**
+         * @private
+         * @type {{alt: boolean, command: boolean, control: boolean, shift: boolean}}
+         */
+        _modifiers: null,
+
+        initialize: function () {
+            this.bindActions(
+                events.RESET, this._handleReset,
+                events.modifiers.MODIFIERS_CHANGED, this._handleModifiersChanged
+            );
+
+            this._handleReset();
+        },
+
+        /**
+         * Reset or initialize store state.
+         *
+         * @private
+         */
+        _handleReset: function () {
+            this._modifiers = {
+                alt: false,
+                command: false,
+                control: false,
+                shift: false
+            };
+        },
+
+        /**
+         * Handler for the MODIFIERS_CHANGED event.
+         * 
+         * @private
+         * @param {{alt: boolean, command: boolean, control: boolean, shift: boolean}} payload
+         */
+        _handleModifiersChanged: function (payload) {
+            this._modifiers.alt = !!payload.alt;
+            this._modifiers.command = !!payload.command;
+            this._modifiers.control = !!payload.control;
+            this._modifiers.shift = !!payload.shift;
+
+            this.emit("change");
+        },
+
+        getState: function () {
+            return this._modifiers;
+        }
+    });
+
+    module.exports = ModifierStore;
+});


### PR DESCRIPTION
0. Add a `modifier` store that holds the current state of the modifier keys (alt, command, control, shift).
1. Refactor `SuperselectOverlay.jsx` to use the modifier store instead of directly listening to `adapterFlagsChanged` events.
2. Expand/collapse all descendants when alt/option modifier key is held, using the `modifier` store to determine key state.
3. Suppress click on expand/collapse to prevent selection change. I could swear that I was matching standard PS behavior on this previously, but I guess I'm crazy. In any case, not changing layer selection at the same time as these expand/collapse seems pretty preferable.

Addresses #1758. 