### PR TITLE
Enable dropping at the bottom of the index directly below a group

### DIFF
--- a/src/js/jsx/sections/layers/DummyLayerFace.jsx
+++ b/src/js/jsx/sections/layers/DummyLayerFace.jsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        classnames = require("classnames");
+
+    var Draggable = require("jsx!js/jsx/shared/Draggable"),
+        Droppable = require("jsx!js/jsx/shared/Droppable");
+
+    /**
+     * Function for checking whether React component should update
+     * Passed to Droppable composed component in order to save on extraneous renders
+     *
+     * @param {object} nextProps - Next set of properties for this component
+     * @return {boolean}
+     */
+    var shouldComponentUpdate = function (nextProps) {
+        // Only drop states are compared
+        return this.props.dropPosition !== nextProps.dropPosition ||
+            this.props.dropTarget !== nextProps.dropTarget;
+    };
+
+    var DummyLayerFace = React.createClass({
+        render: function () {
+            var dummyClassNames = classnames({
+                layer: true,
+                "layer__dummy": true,
+                "layer__dummy_drop": this.props.dropTarget
+            });
+
+            // The dummy layer only has enough structure to support styling of
+            // drops at the bottom of the layer index.
+            return (
+                <li className={dummyClassNames} />
+            );
+        }
+    });
+
+    // Create a Droppable from a Draggable from a DummyLayerFace.
+    var draggedVersion = Draggable.createWithComponent(DummyLayerFace, "y"),
+        isEqual = function (layerA, layerB) {
+            return layerA.key === layerB.key;
+        },
+        droppableSettings = function (props) {
+            return {
+                zone: props.document.id,
+                key: "dummy",
+                keyObject: { key: "dummy" },
+                isValid: props.isValid,
+                handleDrop: props.onDrop
+            };
+        };
+
+    module.exports = Droppable.createWithComponent(draggedVersion, droppableSettings, isEqual, shouldComponentUpdate);
+});

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
         svgUtil = require("js/util/svg"),
         strings = require("i18n!nls/strings");
 
-    /*
+    /**
      * Function for checking whether React component should update
      * Passed to Droppable composed component in order to save on extraneous renders
      *

--- a/src/js/jsx/shared/Droppable.jsx
+++ b/src/js/jsx/shared/Droppable.jsx
@@ -94,18 +94,14 @@ define(function (require, exports, module) {
             },
 
             componentDidMount: function () {
-                if (this.props.registerOnMount) {
-                    this._register();
-                }
+                this._register();
             },
 
             componentWillUnmount: function () {
-                var options = getProps(this.props);
-                if (this.props.deregisterOnUnmount) {
-                    var flux = this.getFlux();
+                var options = getProps(this.props),
+                    flux = this.getFlux();
 
-                    flux.store("draganddrop").deregisterDroppable(options.zone, options.key);
-                }
+                flux.store("draganddrop").deregisterDroppable(options.zone, options.key);
             },
 
             componentDidUpdate: function (prevProps) {

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -101,13 +101,12 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Add a list of droppables to the given zone.
-         * 
-         * @private
+         * Add a drop target to the given drop zone.
+         *
          * @param {number} zone
-         * @param {Array.<object>} droppables
+         * @param {object} droppable
          */
-        _addDroppables: function (zone, droppables) {
+        registerDroppable: function (zone, droppable) {
             var dropTargets = this._dropTargetsByZone.get(zone);
             if (!dropTargets) {
                 dropTargets = new Map();
@@ -120,68 +119,11 @@ define(function (require, exports, module) {
                 this._dropTargetOrderingsByZone.set(zone, dropTargetOrderings);
             }
 
-            droppables.forEach(function (droppable) {
-                var key = droppable.key;
-                dropTargets.set(key, droppable);
-                dropTargetOrderings.push(key);
-            });
+            var key = droppable.key;
+            dropTargets.set(key, droppable);
+            dropTargetOrderings.push(key);
         },
-
-        /**
-         * Remove a list of droppables from the given zone.
-         * 
-         * @private
-         * @param {number} zone
-         * @param {Array.<number>} keys
-         */
-        _removeDroppables: function (zone, keys) {
-            var dropTargets = this._dropTargetsByZone.get(zone),
-                dropTargetOrderings = this._dropTargetOrderingsByZone.get(zone);
-
-            if (!dropTargets || !dropTargetOrderings) {
-                throw new Error("Unable to remove droppables from an empty drop target zone");
-            }
-
-            keys.forEach(function (key) {
-                dropTargets.delete(key);
-
-                var index = dropTargetOrderings.indexOf(key);
-                if (index > -1) {
-                    dropTargetOrderings.splice(index, 1);
-                }
-            });
-        },
-
-        /**
-         * Clear all droppables from the given zone.
-         * 
-         * @private
-         * @param {number} zone
-         */
-        _clearDroppables: function (zone) {
-            this._dropTargetsByZone.delete(zone);
-            this._dropTargetOrderingsByZone.delete(zone);
-        },
-
-        /**
-         * Add a drop target to the given drop zone.
-         *
-         * @param {number} zone
-         * @param {object} droppable
-         */
-        registerDroppable: function (zone, droppable) {
-            this._addDroppables(zone, [droppable]);
-        },
-        
-        /**
-         * Add a list of drop targets to the given drop zone.
-         *
-         * @param {number} zone
-         * @param {Array.<object>} droppables
-         */
-        batchRegisterDroppables: function (zone, droppables) {
-            this._addDroppables(zone, droppables);
-        },
+    
 
         /**
          * Remove a drop target (by key) from the given drop zone.
@@ -190,33 +132,19 @@ define(function (require, exports, module) {
          * @param {number} key
          */
         deregisterDroppable: function (zone, key) {
-            this._removeDroppables(zone, [key]);
-        },
-        
-        /**
-         * Remove a list of drop targets (by key) from the given drop zone.
-         * If no key list is provided, all droppables are removed from the zone.
-         *
-         * @param {number} zone
-         * @param {Array.<number>=} keys
-         */
-        batchDeregisterDroppables: function (zone, keys) {
-            if (keys) {
-                this._removeDroppables(zone, keys);
-            } else {
-                this._clearDroppables(zone);
-            }
-        },
+            var dropTargets = this._dropTargetsByZone.get(zone),
+                dropTargetOrderings = this._dropTargetOrderingsByZone.get(zone);
 
-        /**
-         * Remove all drop targets from the given zone and replace them.
-         *
-         * @param {number} zone
-         * @param {Array.<object>} droppables
-         */
-        resetDroppables: function (zone, droppables) {
-            this._clearDroppables(zone);
-            this._addDroppables(zone, droppables);
+            if (!dropTargets || !dropTargetOrderings) {
+                throw new Error("Unable to remove droppables from an empty drop target zone");
+            }
+
+            dropTargets.delete(key);
+
+            var index = dropTargetOrderings.indexOf(key);
+            if (index > -1) {
+                dropTargetOrderings.splice(index, 1);
+            }
         },
         
         /**

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -29,6 +29,15 @@
     margin-right: 2rem;  
 }
 
+.layer__dummy {
+    min-height: 0.25rem;
+    max-height: 0.25rem;
+}
+
+.layer__dummy_drop {
+    border-top: .25rem inset @highlight;
+}
+
 .layer__group_start.layer__select {
     background-color: @selected-layer-group-background;
 }


### PR DESCRIPTION
![drop](https://s3.amazonaws.com/f.cl.ly/items/3F031Y282r2L2q0Y1w0w/Screen%20Recording%202015-07-18%20at%2003.41%20PM.gif)

1. Adds an invisible dummy layer face at the bottom of the layer index (when the last top-level layer is a group), which exists only as an index-0 drop target.
2. Removes the "batch" draganddrop registration infrastructure. It was no longer useful in a world in which not all document layers are mounted upfront. When the registration calls went through the action system it made sense to batch them, but now it doesn't make any real difference.

Addresses #1695.