### PR TITLE
Reset cursor after drag and disable tooltips during drag

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -99,7 +99,7 @@ define(function (require, exports) {
             adapterOS.setTooltip("");
         });
     };
-    enableTooltips.writes = [locks.PS_APP];
+    disableTooltips.writes = [locks.PS_APP];
 
     /**
      * Toggle pinned toolbar

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -533,6 +533,9 @@ define(function (require, exports, module) {
                             dropPosition: null,
                             futureReorder: false
                         });
+
+                        // HACK: See explanation in _handleStop below.
+                        os.resetCursor();
                     });
             } else {
                 this.setState({
@@ -546,6 +549,14 @@ define(function (require, exports, module) {
          */
         _handleStop: function () {
             this._boundingClientRectCache = null;
+
+            // HACK: The cursor does not seem to revert from "grabbing" to "default"
+            // after the drag ends until the next mouse move, so we explicitly reset
+            // it. Mysteriously, this does not seem sufficient in case the drag
+            // succeeds and some reordering takes place. This may be a facet of the
+            // adapter bug that prevents mousemove events from being delivered while
+            // the main PS thread is busy.
+            os.resetCursor();
         },
 
         /**

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -506,6 +506,7 @@ define(function (require, exports, module) {
          */
         _handleStart: function () {
             this._boundingClientRectCache = new Map();
+            this.getFlux().actions.ui.disableTooltips();
         },
 
         /**
@@ -549,6 +550,7 @@ define(function (require, exports, module) {
          */
         _handleStop: function () {
             this._boundingClientRectCache = null;
+            this.getFlux().actions.ui.enableTooltips();
 
             // HACK: The cursor does not seem to revert from "grabbing" to "default"
             // after the drag ends until the next mouse move, so we explicitly reset


### PR DESCRIPTION
For some reason, the "grabbing" cursor does not automatically reset to the "default" cursor after a layer drag until the next mousemove event. This works correctly in modern web browsers, so perhaps this is a consequence of the details of the CEF integration provided by the Spaces plugin. The patch below hacks around the issue using the `os.resetCursor` API.

Ideally this would be part of the dragging infrastructure, but the comment below explains why that might not be sufficient. We can decide how to cross that bridge once @shaoshing and @volfied get to it with the drag-and-drop functionality of the CC Libraries panel.