### PR TITLE
Get rid of topLayer highlighting during draw

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -335,23 +335,7 @@ define(function (require, exports, module) {
                 }
             }, this);
 
-            var uiStore = this.getFlux().store("ui"),
-                canvasCursor = uiStore.transformWindowToCanvas(this._currentMouseX, this._currentMouseY),
-                topLayer = renderLayers.findLast(function (layer) {
-                    var bounds = layerTree.childBounds(layer);
-                    if (!bounds) {
-                        return;
-                    }
-
-                    return !layer.isArtboard && !layer.selected && bounds.contains(canvasCursor.x, canvasCursor.y);
-                }, this);
-
-            if (topLayer) {
-                var layerID = "#layer-" + topLayer.id;
-                d3.select(layerID)
-                    .classed("layer-bounds-hover", true)
-                    .style("stroke-width", 1.0 * scale);
-            }
+            this.updateMouseOverHighlights();
         },
 
         /**


### PR DESCRIPTION
And instead let the actual function handle it.

This was a relic of D3 highlighting when we got the mouse events... but now that we have a complete control over highlighting function, we let it handle the highlight on draw.

Addresses #1760 @iwehrman since you opened this bug, can you review?