### PR TITLE
Load the font list lazily

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -366,13 +366,13 @@ define(function (require, exports) {
      * @private
      * @return {Promise}
      */
-    var afterStartup = function () {
+    var initFontList = function () {
         return descriptor.getProperty("application", "fontList")
             .bind(this)
             .then(this.dispatch.bind(this, events.font.INIT_FONTS));
     };
-    afterStartup.reads = [locks.PS_APP];
-    afterStartup.writes = [locks.JS_TYPE];
+    initFontList.reads = [locks.PS_APP];
+    initFontList.writes = [locks.JS_TYPE];
 
     exports.setPostScript = setPostScript;
     exports.setFace = setFace;
@@ -381,6 +381,5 @@ define(function (require, exports) {
     exports.setTracking = setTracking;
     exports.setLeading = setLeading;
     exports.setAlignment = setAlignment;
-
-    exports.afterStartup = afterStartup;
+    exports.initFontList = initFontList;
 });

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -62,9 +62,9 @@ define(function (require, exports, module) {
                 return collection.pluck(document.layers.selected, "opacity");
             };
 
-            return !Immutable.is(getTexts(this.props.document), getTexts(nextProps.document)) ||
-                !Immutable.is(getOpacities(this.props.document), getOpacities(nextProps.document)) ||
-                !Immutable.is(this.state.typefaces, nextState.typefaces);
+            return !Immutable.is(this.state.typefaces, nextState.typefaces) ||
+                !Immutable.is(getTexts(this.props.document), getTexts(nextProps.document)) ||
+                !Immutable.is(getOpacities(this.props.document), getOpacities(nextProps.document));
         },
 
         getStateFromFlux: function () {
@@ -92,6 +92,29 @@ define(function (require, exports, module) {
                 .toList();
 
             return fontState;
+        },
+
+        /**
+         * Lazily loads the the font list one time only.
+         *
+         * @private
+         */
+        _loadFontListIfNecessary: function () {
+            if (!this.refs.type) {
+                return;
+            }
+
+            if (!this.state.initialized) {
+                this.getFlux().actions.type.initFontList();
+            }
+        },
+
+        componentDidMount: function () {
+            this._loadFontListIfNecessary();
+        },
+
+        componentDidUpdate: function () {
+            this._loadFontListIfNecessary();
         },
 
         /**
@@ -470,7 +493,7 @@ define(function (require, exports, module) {
             }.bind(this);
 
             return (
-                <div className="type sub-section">
+                <div ref="type" className="type sub-section">
                     <header className="sub-header">
                         <h3>
                             {strings.STYLE.TYPE.TITLE}

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -33,6 +33,14 @@ define(function (require, exports, module) {
     var FontStore = Fluxxor.createStore({
 
         /**
+         * Whether or not the font list has been initialized.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _initialized: false,
+
+        /**
          * Map of family names to a map of font names to style-postScriptName records.
          *
          * @private
@@ -61,12 +69,20 @@ define(function (require, exports, module) {
          * @private
          */
         _handleReset: function () {
+            this._initialized = false;
             this._familyMap = Immutable.Map();
             this._postScriptMap = Immutable.Map();
         },
 
+        /**
+         * The familyMap maps family names to maps from font names to style/postscript-name pairs.
+         * The postScriptMap maps postscript names to family/font-name pairs.
+         *
+         * @return {{initialized: boolean, familyMap: Immutable.Map, postScriptMap: Immutable.Map}}
+         */
         getState: function () {
             return {
+                initialized: this._initialized,
                 familyMap: this._familyMap,
                 postScriptMap: this._postScriptMap
             };
@@ -262,6 +278,7 @@ define(function (require, exports, module) {
                 }));
             }, new Map()));
 
+            this._initialized = true;
             this.emit("change");
         }
     });


### PR DESCRIPTION
To improve startup performance, and to more evenly distribute load on the UI thread in some cases, this moves the loading of the font list from startup time until it's first necessary. Luckily, loading the font list doesn't seem to be quite as slow as it used to be, but in some cases this could shave at least a few hundred ms off of startup time.

Side note: it's kind of weird that we mount the `Type` component even when there are no type layers. I guess this is a consequence of having all the type-related logic in one component. That makes sense, but it also kind of seems like the `Type` component should only be mounted when there are selected `Type` layers. Maybe I'm over-thinking this.