### PR TITLE
Only parse RGB Colors, warn otherwise

### DIFF
--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -28,7 +28,8 @@ define(function (require, exports, module) {
 
     var Color = require("./color"),
         objUtil = require("js/util/object"),
-        unitUtil = require("js/util/unit");
+        unitUtil = require("js/util/unit"),
+        log = require("js/util/log");
 
     /**
      * Represents the character style used by a run of text in a text layer.
@@ -88,7 +89,12 @@ define(function (require, exports, module) {
             textStyle.color :
             baseParentStyle.color;
 
-        model.color = Color.fromPhotoshopColorObj(rawColor, opacity);
+        if (Color.isValidPhotoshopColorObj(rawColor)) {
+            model.color = Color.fromPhotoshopColorObj(rawColor, opacity);
+        } else {
+            model.color = Color.DEFAULT;
+            log.warn("Could not parse charstyle color because photoshop did not supply a valid RGB color");
+        }
 
         var rawSize = textStyle.hasOwnProperty("size") ?
             textStyle.size :

--- a/src/js/models/color.js
+++ b/src/js/models/color.js
@@ -66,6 +66,16 @@ define(function (require, exports, module) {
     Color.DEFAULT = new Color();
 
     /**
+     * Test that a color object supplied by Ps is a valid RGB color object
+     *
+     * @param {object} obj
+     * @return {boolean} true if the supplied object is of type RGBColor
+     */
+    Color.isValidPhotoshopColorObj = function (obj) {
+        return obj && (typeof obj === "object") && (obj._obj === "RGBColor");
+    };
+
+    /**
      * Construct a new Color object from a Photoshop color descriptor and
      * opacity percentage.
      * 

--- a/src/js/models/fill.js
+++ b/src/js/models/fill.js
@@ -96,9 +96,13 @@ define(function (require, exports, module) {
                 }
 
                 // Color - Only popluate for solidColor fills
-                if (model.type === contentLayerLib.contentTypes.SOLID_COLOR && typeof color === "object") {
-                    var fillOpacity = layerDescriptor.fillOpacity;
-                    model.color = Color.fromPhotoshopColorObj(color, (fillOpacity / 255) * 100);
+                if (model.type === contentLayerLib.contentTypes.SOLID_COLOR) {
+                    if (Color.isValidPhotoshopColorObj(color)) {
+                        var fillOpacity = layerDescriptor.fillOpacity;
+                        model.color = Color.fromPhotoshopColorObj(color, (fillOpacity / 255) * 100);
+                    } else {
+                        log.warn("Could not parse fill color because photoshop did not supply a valid RGB color");
+                    }
                 }
 
                 var fill = new Fill(model);

--- a/src/js/models/shadow.js
+++ b/src/js/models/shadow.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
         _ = require("lodash");
 
     var Color = require("./color"),
-        objUtil = require("js/util/object");
+        objUtil = require("js/util/object"),
+        log = require("js/util/log");
 
     /**
      * Maximum Photoshop-supported shadow distance
@@ -210,7 +211,11 @@ define(function (require, exports, module) {
         var opacity = objUtil.getPath(shadowDescriptor, "opacity._value"),
             rawColor = objUtil.getPath(shadowDescriptor, "color");
 
-        model.color = Color.fromPhotoshopColorObj(rawColor, opacity);
+        if (Color.isValidPhotoshopColorObj(rawColor)) {
+            model.color = Color.fromPhotoshopColorObj(rawColor, opacity);
+        } else {
+            log.warn("Could not parse shadow color because photoshop did not supply a valid RGB color");
+        }
 
         var angle = objUtil.getPath(shadowDescriptor, "localLightingAngle._value"),
             distance = objUtil.getPath(shadowDescriptor, "distance._value");

--- a/src/js/models/stroke.js
+++ b/src/js/models/stroke.js
@@ -134,9 +134,13 @@ define(function (require, exports, module) {
             throw new Error("Stroke width not provided");
         }
 
-        // Color - Only populate for solidColor strokes
-        if (model.type === contentLayerLib.contentTypes.SOLID_COLOR && colorValue && _.isObject(colorValue)) {
-            model.color = Color.fromPhotoshopColorObj(colorValue, opacityPercentage);
+        // Color - Only populate for solidColor RGB strokes
+        if (model.type === contentLayerLib.contentTypes.SOLID_COLOR) {
+            if (Color.isValidPhotoshopColorObj(colorValue)) {
+                model.color = Color.fromPhotoshopColorObj(colorValue, opacityPercentage);
+            } else {
+                log.warn("Could not parse stroke color because photoshop did not supply a valid RGB color");
+            }
         }
 
         // Alignment Type - seems to not populate on new strokes. 


### PR DESCRIPTION
Avoid a gang of errors when opening CMYK files, per #1732