### PR TITLE
Minor layer drag tweaks

### DIFF
--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -203,6 +203,8 @@ define(function (require, exports, module) {
                 foundDropTargetIndex = index;
                 if (valid) {
                     this._dropTarget = dropTarget;
+                } else {
+                    this._dropTarget = null;
                 }
 
                 return true;

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -30,8 +30,8 @@
 }
 
 .layer__dummy {
-    min-height: 0.25rem;
-    max-height: 0.25rem;
+    min-height: 1.5rem;
+    max-height: 1.5rem;
 }
 
 .layer__dummy_drop {


### PR DESCRIPTION
Slightly expands the dummy layer area, and also makes the drop separator a little more responsive when dragging around invalid drop areas.

Addresses #1695, and to a lesser extent #1771. 