### PR TITLE
Search bugs: don't close dialog on click; fix for text jumbling when highlighted

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -347,6 +347,10 @@ define(function (require, exports, module) {
             }, Immutable.List());
         },
 
+        _handleDialogClick: function (event) {
+            event.stopPropagation();
+        },
+
         _handleKeyDown: function (event) {
             switch (event.key) {
                 case "Return":
@@ -381,7 +385,7 @@ define(function (require, exports, module) {
 
             return (
                 <div
-                    onClick={this.props.dismissDialog}>
+                    onClick={this._handleDialogClick}>
                    <Datalist
                         ref="datalist"
                         live={false}

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -164,7 +164,6 @@ input[list]:focus {
 }
 
 *::selection {
-    color: @warm-black;
     background: @highlight;
     border-radius: .2rem;
 }


### PR DESCRIPTION
for issues #1742 and #1720 

For #1742, I replaced dismissing the dialog with `event.stopPropagation()` because otherwise the item that was last selected (which doesn't necessarily match what you've inputted) will be set as the input value when you click on the dialog.