### PR TITLE
Add debug menu items for postCond and PolicyVis toggling

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -35,7 +35,8 @@ define(function (require, exports) {
         system = require("js/util/system"),
         log = require("js/util/log"),
         global = require("js/util/global"),
-        headlights = require("js/util/headlights");
+        headlights = require("js/util/headlights"),
+        preferencesActions = require("./preferences");
 
     var macMenuJSON = require("text!static/menu-mac.json"),
         winMenuJSON = require("text!static/menu-win.json"),
@@ -201,6 +202,44 @@ define(function (require, exports) {
     };
 
     /**
+     * Debug only method to toggle pointer policy area visualization
+     *
+     * @return {Promise}
+     */
+    var togglePolicyFrames = function () {
+        if (!global.debug) {
+            return Promise.resolve();
+        }
+
+        var preferencesStore = this.flux.store("preferences"),
+            preferences = preferencesStore.getState(),
+            enabled = preferences.get("policyFramesEnabled");
+
+        return this.transfer(preferencesActions.setPreference, "policyFramesEnabled", !enabled);
+    };
+    togglePolicyFrames.reads = [];
+    togglePolicyFrames.writes = [locks.JS_PREF];
+
+    /**
+     * Debug only method to toggle post condition verification
+     *
+     * @return {Promise}
+     */
+    var togglePostconditions = function () {
+        if (!global.debug) {
+            return Promise.resolve();
+        }
+
+        var preferencesStore = this.flux.store("preferences"),
+            preferences = preferencesStore.getState(),
+            enabled = preferences.get("postConditionsEnabled");
+
+        return this.transfer(preferencesActions.setPreference, "postConditionsEnabled", !enabled);
+    };
+    togglePostconditions.reads = [];
+    togglePostconditions.writes = [locks.JS_PREF];
+
+    /**
      * Event handlers initialized in beforeStartup.
      *
      * @private
@@ -306,6 +345,9 @@ define(function (require, exports) {
     exports.resetFailure = resetFailure;
     exports.corruptModel = corruptModel;
     exports.resetRecess = resetRecess;
+
+    exports.togglePolicyFrames = togglePolicyFrames;
+    exports.togglePostconditions = togglePostconditions;
 
     exports.beforeStartup = beforeStartup;
     exports.onReset = onReset;

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -293,7 +293,9 @@ define(function (require, exports, module) {
             post = action.post,
             parentActionName = actionReceiver.actionName,
             actionName = action.id,
-            actionTitle = "action " + parentActionName;
+            actionTitle = "action " + parentActionName,
+            preferences = this.flux.store("preferences").getState(),
+            checkPost = preferences.get("postConditionsEnabled");
 
         if (parentActionName !== actionName) {
             actionTitle = "sub-action " + actionName + " of " + actionTitle;
@@ -313,7 +315,7 @@ define(function (require, exports, module) {
         return actionPromise
             .bind(this)
             .tap(function () {
-                if (global.debug && post && post.length > 0) {
+                if (global.debug && checkPost && post && post.length > 0) {
                     var postStart = Date.now(),
                         postTitle = post.length + " postcondition" + (post.length > 1 ? "s" : "");
 

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
     var PolicyOverlay = require("jsx!js/jsx/tools/PolicyOverlay");
 
     var Scrim = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("tool", "ui", "application")],
+        mixins: [FluxMixin, StoreWatchMixin("tool", "ui", "application", "preferences")],
 
         /**
          * Dispatches (synthetic) click events from the scrim to the currently
@@ -169,14 +169,17 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 toolState = flux.store("tool").getState(),
                 uiState = flux.store("ui").getState(),
+                preferenceStore = flux.store("preferences"),
                 applicationStore = flux.store("application"),
                 applicationState = applicationStore.getState(),
+                policyFrames = preferenceStore.getState().get("policyFramesEnabled"),
                 document = applicationStore.getCurrentDocument();
 
             return {
                 current: toolState.current,
                 transform: uiState.inverseTransformMatrix,
                 overlaysEnabled: uiState.overlaysEnabled,
+                policyFrames: policyFrames,
                 document: document,
                 activeDocumentInitialized: applicationState.activeDocumentInitialized,
                 recentFilesInitialized: applicationState.recentFilesInitialized
@@ -249,7 +252,7 @@ define(function (require, exports, module) {
                 overlays = !disabled && this.state.overlaysEnabled,
                 transformString = this._getTransformString(transform),
                 toolOverlay = (overlays && transform) ? this._renderToolOverlay(transformString) : null,
-                policyOverlay = false ? (<PolicyOverlay/>) : null;
+                policyOverlay = this.state.policyFrames ? (<PolicyOverlay/>) : null;
 
             // Only the mouse event handlers are attached to the scrim
             return (

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
 
     var MenuItem = require("./menuitem"),
         keyutil = require("js/util/key"),
+        global = require("js/util/global"),
         pathUtil = require("js/util/path"),
         system = require("js/util/system");
     
@@ -350,10 +351,19 @@ define(function (require, exports, module) {
      * @param {Immutable.Map.<string, *>} preferences
      * @return {MenuBar}
      */
-    MenuBar.prototype.updateNonDocWindowMenuItems = function (preferences) {
-        return this.updateSubmenuItems("WINDOW", {
+    MenuBar.prototype.updatePreferenceBasedMenuItems = function (preferences) {
+        var updatedMenu = this.updateSubmenuItems("WINDOW", {
             "TOGGLE_TOOLBAR": { "checked": (preferences.get("toolbarPinned", true) ? 1 : 0) }
         });
+
+        if (global.debug) {
+            return updatedMenu.updateSubmenuItems("HELP", {
+                "TOGGLE_POLICY_FRAMES": { "checked": (preferences.get("policyFramesEnabled", false) ? 1 : 0) },
+                "TOGGLE_POSTCONDITIONS": { "checked": (preferences.get("postConditionsEnabled", false) ? 1 : 0) }
+            });
+        } else {
+            return updatedMenu;
+        }
     };
     
     /**

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
                 events.history.LOAD_HISTORY_STATE_REVERT, this._updateMenuItems,
 
                 events.document.GUIDES_VISIBILITY_CHANGED, this._updateViewMenu,
-                events.preferences.SET_PREFERENCE, this._updateNonDocWindowMenu
+                events.preferences.SET_PREFERENCE, this._updatePreferencesBasedMenuItems
             );
 
             this._handleReset();
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
             // Alternately, we could build this logic into the menubar.updateMenuItems process,
             // but that's non-trivial
             this._applicationMenu = this._applicationMenu.updateViewMenuItems(document);
-            this._applicationMenu = this._applicationMenu.updateNonDocWindowMenuItems(preferences);
+            this._applicationMenu = this._applicationMenu.updatePreferenceBasedMenuItems(preferences);
 
             if (!Immutable.is(oldMenu, this._applicationMenu)) {
                 this.emit("change");
@@ -234,15 +234,15 @@ define(function (require, exports, module) {
         },
         
         /**
-         * Updates the Non-Document entries of the Window menu only
+         * Updates the entries reliant on preferences
          * @private
          */
-        _updateNonDocWindowMenu: function () {
+        _updatePreferencesBasedMenuItems: function () {
             this.waitFor(["preferences"], function (preferencesStore) {
                 var preferences = preferencesStore.getState(),
                     oldMenu = this._applicationMenu;
                     
-                this._applicationMenu = this._applicationMenu.updateNonDocWindowMenuItems(preferences);
+                this._applicationMenu = this._applicationMenu.updatePreferenceBasedMenuItems(preferences);
 
                 if (!Immutable.is(oldMenu, this._applicationMenu)) {
                     this.emit("change");

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -264,6 +264,8 @@ define(function (require, exports, module) {
                 CORRUPT_MODEL: "Test Model Corruption…",
                 UPDATE_CURRENT_DOCUMENT: "Update Current Document",
                 RESET_RECESS: "Reset Design Space",
+                TOGGLE_POLICY_FRAMES: "Show Policy Frames",
+                TOGGLE_POSTCONDITIONS: "Verify Postconditions",
                 OPEN_FIRST_LAUNCH: "Design Space Introduction",
                 SHORTCUTS: "Keyboard Shortcuts",
                 TWITTER: "Design Space on Twitter",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -409,6 +409,14 @@
             "$action": "menu.resetRecess",
             "$enable-rule": "always-except-modal"
         },
+        "TOGGLE_POLICY_FRAMES": {
+            "$action": "menu.togglePolicyFrames",
+            "$enable-rule": "always-except-modal"
+        },
+        "TOGGLE_POSTCONDITIONS": {
+            "$action": "menu.togglePostconditions",
+            "$enable-rule": "always-except-modal"
+        },
         "OPEN_FIRST_LAUNCH": {
             "$action": "help.openFirstLaunch",
             "$enable-rule": "always-except-modal"

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -601,6 +601,10 @@
                     "debug": true
                 },
                 {
+                    "separator": true,
+                    "debug": true
+                },
+                {
                     "id": "UPDATE_CURRENT_DOCUMENT",
                     "shortcut": {
                         "keyChar": ";",
@@ -623,6 +627,18 @@
                             "option": true
                         }
                     },
+                    "debug": true
+                },
+                {
+                    "separator": true,
+                    "debug": true
+                },
+                {
+                    "id": "TOGGLE_POLICY_FRAMES",
+                    "debug": true
+                },
+                {
+                    "id": "TOGGLE_POSTCONDITIONS",
                     "debug": true
                 }
             ]

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -580,6 +580,10 @@
                     "debug": true
                 },
                 {
+                    "separator": true,
+                    "debug": true
+                },
+                {
                     "id": "UPDATE_CURRENT_DOCUMENT",
                     "shortcut": {
                         "keyChar": ";",
@@ -601,6 +605,18 @@
                             "alt": true
                         }
                     },
+                    "debug": true
+                },
+                {
+                    "separator": true,
+                    "debug": true
+                },
+                {
+                    "id": "TOGGLE_POLICY_FRAMES",
+                    "debug": true
+                },
+                {
+                    "id": "TOGGLE_POSTCONDITIONS",
                     "debug": true
                 }
             ]


### PR DESCRIPTION
Under help menu, now we have better organization, and toggle items for postcondition verification and policy visualization, to help with debugging.

Addresses #1711, and couple other dev needs.


