### PR TITLE
Simplify overlay code, fix redraw issues with move/transform

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -659,7 +659,6 @@ define(function (require, exports) {
                             descriptor.addListener("moveToArtboard", _moveToArtboardListener);
 
                             _moveListener = function () {
-                                this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
                                 if (copyDrag) {
                                     // For now, we have to update the document when we drag copy, since we don't get
                                     // information on the new layers

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1080,28 +1080,27 @@ define(function (require, exports) {
 
     var beforeStartup = function () {
         _artboardTransformHandler = synchronization.debounce(function () {
-            this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-            
             // After each action we call, document model changes
             // so we re-get it
             var appStore = this.flux.store("application"),
                 nextDoc = appStore.getCurrentDocument();
 
-            return this.flux.actions.layers.getLayerOrder(nextDoc, true)
+            return this.flux.actions.layers.resetBounds(nextDoc, nextDoc.layers.allSelected)
                 .bind(this)
                 .then(function () {
                     nextDoc = appStore.getCurrentDocument();
                     this.flux.actions.layers.resetSelection(nextDoc);
                 }).then(function () {
                     nextDoc = appStore.getCurrentDocument();
-                    this.flux.actions.layers.resetBounds(nextDoc, nextDoc.layers.allSelected);
+                    this.flux.actions.layers.getLayerOrder(nextDoc, true);
                 });
         }, this);
 
         _layerTransformHandler = synchronization.debounce(function (event) {
-            // If it was a simple click/didn't move anything, there is no need to update bounds
+            // If it was a simple click/didn't move anything, there is no need to update bounds,
+            // just redraw the overlay
             if (event.trackerEndedWithoutBreakingHysteresis) {
-                return Promise.resolve();
+                return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
             }
 
             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
     var DEBOUNCE_DELAY = 200;
 
     var SuperselectOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("document", "application", "ui", "modifier")],
+        mixins: [FluxMixin, StoreWatchMixin("tool", "document", "application", "ui", "modifier")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -137,9 +137,7 @@ define(function (require, exports, module) {
             this._currentMouseY = null;
             this._marqueeResult = [];
 
-            if (!this.state.modalState) {
-                this._drawDebounced();
-            }
+            this._drawDebounced();
             
             // Marquee mouse handlers
             window.addEventListener("mousemove", this.marqueeUpdater);
@@ -149,13 +147,13 @@ define(function (require, exports, module) {
         },
 
         componentDidUpdate: function (prevProps, prevState) {
-            if (!this.state.modalState) {
-                if (this.state.leafBounds !== prevState.leafBounds) {
-                    // Redraw immediately when the leaf modifier key changes
-                    this.drawOverlay();
-                } else {
-                    this._drawDebounced();
-                }
+            // Redraw immediately when the leaf modifier key changes
+            // or when we're in a modal state
+            if (this.state.leafBounds !== prevState.leafBounds ||
+                this.state.modalState) {
+                this.drawOverlay();
+            } else {
+                this._drawDebounced();
             }
         },
 
@@ -210,7 +208,7 @@ define(function (require, exports, module) {
             svg.selectAll(".superselect-marquee").remove();
             svg.selectAll(".artboard-adder").remove();
 
-            if (!currentDocument) {
+            if (!currentDocument || this.state.modalState) {
                 return null;
             }
 

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -180,6 +180,8 @@ define(function (require, exports, module) {
          */
         _handleModalStateChange: function (payload) {
             this._inModalToolState = payload.modalState;
+
+            this.emit("change");
         },
 
         /**


### PR DESCRIPTION
Couple changes:

 - Remove couple enable overlay calls that caused wrong re-draws
 - Change "editArtboardEvent" handler, so we reset bounds first, and then get layer order
 - During layer moves, if the hysteresis wasn't broken (0,0 move), we re-enable the overlay
 - Emit change events from tool store when tool modal state changes
 - Listen to tool store changes in SueprselectOverlay, so we can redraw overlay when modal state changes - this should be safe, as Toolbar, Scrim and SuperselectOverlay are the only listeners of tool store
 - If modal state is true, immediately clear the overlay, otherwise, debounce draw
 - Clean up the code to always clean things, but not draw anything in modal states


Addresses #1683, and probably also couple more transform/overlay bugs.