### PR TITLE
Reset bounds of selected layers after drag

### DIFF
--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -429,10 +429,14 @@ define(function (require, exports, module) {
                 var dragSource = collection.pluck(this.state.dragTargets, "id");
 
                 flux.actions.layers.reorder(doc, dragSource, dropIndex)
-                    .then(function () {
-                        flux.actions.layers.resetBounds(doc, doc.layers.allSelected);
-                    })
                     .bind(this)
+                    .then(function () {
+                        // The selected layers may have changed after the reorder.
+                        var documentStore = flux.store("document"),
+                            nextDocument = documentStore.getDocument(doc.id);
+
+                        flux.actions.layers.resetBounds(nextDocument, nextDocument.layers.allSelected);
+                    })
                     .finally(function () {
                         this.setState({
                             dropPosition: null,


### PR DESCRIPTION
This is a follow up to #1790. That PR resets the bounds of the selected layers after being dragged and dropped in the layers panel to account for on-canvas movement that results from auto-nesting. But, if you drag an unselected layers, it will be selected after the index is re-ordered. This patch fetches the most recent document model to ensure that the list of selected layers is current after the reorder operation.

Addresses #1690.