### PR TITLE
Check for selection artboard count

### DIFF
--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -99,7 +99,9 @@ define(function (require, exports, module) {
          */
         _disabled: function (document, layers) {
             var layerTree = document.layers,
-                artboardLayers = layerTree.artboards;
+                artboardLayers = layers.filter(function (layer) {
+                    return layer.isArtboard;
+                });
 
             return document.unsupported ||
                 layers.isEmpty() ||

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -121,7 +121,9 @@ define(function (require, exports, module) {
          */
         _disabled: function (document, layers, boundsShown) {
             var layerTree = document.layers,
-                artboardLayers = layerTree.artboards;
+                artboardLayers = layers.filter(function (layer) {
+                    return layer.isArtboard;
+                });
 
             return document.unsupported ||
                 (layers.isEmpty() && document.layers.hasArtboard) ||


### PR DESCRIPTION
When I added the "artboards" property to layerstructure, I mistakenly started calculating the overall artboards count in position/size enablers. Oops.

Fixes https://github.com/adobe-photoshop/spaces-design/issues/1794