### PR TITLE
Dialog bugfix extravaganza

### DIFF
--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -117,6 +117,7 @@ define(function (require, exports, module) {
                     <div>
                         <div className="formline">
                             <LibraryList
+                                document={this.props.document}
                                 libraries={libraries}
                                 selected={currentLibrary}
                                 onLibraryChange={this._handleLibraryChange} />

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -83,9 +83,11 @@ define(function (require, exports, module) {
                 libraryName = this.props.selected.name;
             }
 
+            var listID = "libraries-" + this.props.document.id;
+
             return (
                 <Datalist
-                    list={"libraries"}
+                    list={listID}
                     disabled={false}
                     className="dialog-libraries"
                     options={libraryOptions}

--- a/src/js/jsx/sections/style/BlendMode.jsx
+++ b/src/js/jsx/sections/style/BlendMode.jsx
@@ -223,9 +223,11 @@ define(function (require, exports, module) {
                 title = null;
             }
 
+            var listID = "blendmodes-" + this.props.id + "-" + this.props.document.id;
+
             return (
                 <Datalist
-                    list={"blendmodes-" + this.props.id}
+                    list={listID}
                     disabled={this.props.disabled}
                     className="dialog-blendmodes"
                     options={modesToShow}

--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -186,12 +186,14 @@ define(function (require, exports) {
                 );
             };
 
+            var colorInputID = "fill-" + this.props.index + "-" + this.props.document.id;
+
             return (
                 <div className={fillClasses}>
                     <div className="formline">
                         <Gutter />
                         <ColorInput
-                            id={"fill-" + this.props.index}
+                            id={colorInputID}
                             className="fill"
                             context={collection.pluck(this.props.layers, "id")}
                             title={strings.TOOLTIPS.SET_FILL_COLOR}

--- a/src/js/jsx/sections/style/Shadow.jsx
+++ b/src/js/jsx/sections/style/Shadow.jsx
@@ -309,12 +309,15 @@ define(function (require, exports) {
                     );
             };
 
+            var colorInputID = "shadow-" + this.props.type + "-" +
+                this.props.index + "-" + this.props.document.id;
+
             return (
                 <div className={shadowClasses}>
                     <div className="formline">
                         <Gutter />
                         <ColorInput
-                            id={"shadow-" + this.props.type + "-" + this.props.index}
+                            id={colorInputID}
                             className={"shadow"}
                             context={collection.pluck(this.props.layers, "id")}
                             title={shadowColorTooltip}

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -207,12 +207,14 @@ define(function (require, exports) {
                 );
             };
 
+            var colorInputID = "stroke-" + this.props.index + "-" + this.props.document.id;
+
             return (
                 <div className={strokeClasses}>
                     <div className="formline">
                         <Gutter />
                         <ColorInput
-                            id={"stroke-" + this.props.index}
+                            id={colorInputID}
                             className="stroke"
                             context={collection.pluck(this.props.layers, "id")}
                             title={strings.TOOLTIPS.SET_STROKE_COLOR}

--- a/src/js/jsx/sections/style/StrokeAlignment.jsx
+++ b/src/js/jsx/sections/style/StrokeAlignment.jsx
@@ -100,9 +100,11 @@ define(function (require, exports, module) {
                 alignmentTitle = null;
             }
 
+            var listID = "alignment-" + this.props.id + "-" + this.props.document.id;
+
             return (
                 <Datalist
-                    list={"alignment-" + this.props.id}
+                    list={listID}
                     disabled={this.props.readOnly}
                     className="dialog-stroke-alignment"
                     options={_alignmentModesList}

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -492,6 +492,10 @@ define(function (require, exports, module) {
                 );
             }.bind(this);
 
+            var colorPickerID = "type-" + this.props.document.id,
+                typefaceListID = "typefaces-" + this.props.document.id,
+                weightListID = "weights-" + this.props.document.id;
+
             return (
                 <div ref="type" className="type sub-section">
                     <header className="sub-header">
@@ -514,7 +518,7 @@ define(function (require, exports, module) {
                             className="dialog-type-typefaces"
                             sorted={true}
                             disabled={this.props.disabled}
-                            list="typefaces"
+                            list={typefaceListID}
                             value={familyName || strings.STYLE.TYPE.MISSING}
                             defaultSelected={postScriptName}
                             options={this.state.typefaces}
@@ -534,7 +538,7 @@ define(function (require, exports, module) {
                             className="dialog-type-weights"
                             sorted={true}
                             title={styleTitle}
-                            list="weights"
+                            list={weightListID}
                             disabled={this.props.disabled || !styleTitle}
                             value={styleTitle}
                             defaultSelected={postScriptName}
@@ -547,7 +551,7 @@ define(function (require, exports, module) {
                     <div className="formline">
                         <Gutter />
                         <ColorInput
-                            id="type"
+                            id={colorPickerID}
                             className="type"
                             context={collection.pluck(this.props.document.layers.selected, "id")}
                             title={strings.TOOLTIPS.SET_TYPE_COLOR}

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -82,8 +82,10 @@ define(function (require, exports, module) {
             }
 
             // Update autofill here so that can check options based on the updated filter
-            if (this.state.filter !== nextState.filter || this.state.active !== nextState.active ||
-                    this.state.suggestTitle !== nextState.suggestTitle) {
+            if (this.props.options !== nextProps.options ||
+                this.state.filter !== nextState.filter ||
+                this.state.active !== nextState.active ||
+                this.state.suggestTitle !== nextState.suggestTitle) {
                 var iconCount = nextProps.filterIcons ? nextProps.filterIcons.length : 0;
                 this._updateAutofill(nextState.filter, iconCount);
                 return true;

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -49,6 +49,14 @@ define(function (require, exports, module) {
     var Dialog = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("dialog")],
 
+        /**
+         * The target of the event that opened the Dialog.
+         *
+         * @private
+         * @type {?DOMElement}
+         */
+        _target: null,
+
         propTypes: {
             id: React.PropTypes.string.isRequired,
             onOpen: React.PropTypes.func,
@@ -124,11 +132,10 @@ define(function (require, exports, module) {
                 id = this.props.id;
 
             if (this.state.open) {
+                this._target = null;
                 flux.actions.dialog.closeDialog(id);
             } else if (!this.props.disabled) {
-                this.setState({
-                    target: event.target
-                });
+                this._target = event.target;
                 flux.actions.dialog.openDialog(id, this._getDismissalPolicy());
             }
 
@@ -181,7 +188,7 @@ define(function (require, exports, module) {
          */
         _positionDialog: function (dialogEl) {
             if (this.props.position === POSITION_METHODS.TARGET) {
-                if (this.state.target) {
+                if (this._target) {
                     var dialogBounds = dialogEl.getBoundingClientRect(),
                         clientHeight = window.document.documentElement.clientHeight,
 
@@ -191,8 +198,8 @@ define(function (require, exports, module) {
                         dialogMarginBottom = math.pixelDimensionToNumber(dialogComputedStyle.marginBottom),
                      
                         // Adjust the position of the opened dialog according to the target
-                        targetBounds = this.state.target.getBoundingClientRect(),
-                        offsetParentBounds = this.state.target.offsetParent.getBoundingClientRect(),
+                        targetBounds = this._target.getBoundingClientRect(),
+                        offsetParentBounds = this._target.offsetParent.getBoundingClientRect(),
                         placedDialogTop = targetBounds.bottom - offsetParentBounds.top,
                         placedDialogBottom = placedDialogTop + dialogBounds.height;
 
@@ -209,7 +216,7 @@ define(function (require, exports, module) {
 
                     dialogEl.style.top = placedDialogTop + "px";
                 } else {
-                    throw new Error("Could not determine target by which to render this dialog: " + this.displayName());
+                    throw new Error("Could not determine target by which to render this dialog: " + this.displayName);
                 }
             }
         },

--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -128,13 +128,15 @@ define(function (require, exports, module) {
          * @param {object} dismissalPolicy
          */
         registerDialog: function (id, dismissalPolicy) {
-            var state = {
-                    policy: Immutable.Map(dismissalPolicy)
-                };
+            if (this._registeredDialogs.has(id)) {
+                throw new Error("Failed to register dialog: " + id + " already exists.");
+            }
 
-            this._registeredDialogs = this._registeredDialogs.update(id, Immutable.Map(), function (val) {
-                return val.merge(state);
+            var state = Immutable.Map({
+                policy: Immutable.Map(dismissalPolicy)
             });
+
+            this._registeredDialogs = this._registeredDialogs.set(id, state);
         },
 
         /**
@@ -145,6 +147,10 @@ define(function (require, exports, module) {
          * @param {string} id
          */
         deregisterDialog: function (id) {
+            if (!this._registeredDialogs.has(id)) {
+                throw new Error("Failed to deregister dialog: " + id + " does not exist.");
+            }
+
             this._registeredDialogs = this._registeredDialogs.delete(id);
             if (this._openDialogs.has(id)) {
                 this._openDialogs = this._openDialogs.delete(id);


### PR DESCRIPTION
1. Require at registration time that `Dialog`s all have unique IDs. If we don't require that then actions invocations like `openDialog(id)` and `closeDialog(id)` have unintended, negative consequences.
2. Elaborate all `Dialog` IDs in the app to be unique, mostly by jamming the document ID into the IDs of `ColorInput`s and `Datalist`s.
3. Fix a race in `Dialog` in which the `openDialog` action could execute before an asynchronous setState call was complete. (This could cause the target DOMElement to be null in some cases when computing the position of the dialog.)
4. Fix a bug in a `Dialog` error handler: `displayName` is a `ReactElement` property, not a method. (Thanks @volfied!)
5. Fix an unrelated `Datalist` bug that prevented re-rendering when options are updated (e.g., from an empty font list to a non-empty font list).

Addresses #1738 and I think #1797.