### PR TITLE
Use modifier symbols instead of strings for menu commands in search

### DIFF
--- a/src/js/actions/search/documents.js
+++ b/src/js/actions/search/documents.js
@@ -47,7 +47,6 @@ define(function (require, exports) {
                     id: doc.toString(),
                     name: docStore.getDocument(doc).name,
                     category: ["CURRENT_DOC"],
-                    pathInfo: "",
                     iconID: "tool-rectangle"
                 };
             });
@@ -110,7 +109,8 @@ define(function (require, exports) {
             "type": "CURRENT_DOC",
             "getOptions": _currDocSearchOptions.bind(this),
             "filters": Immutable.List.of("CURRENT_DOC"),
-            "handleExecute": _confirmCurrDocSearch.bind(this)
+            "handleExecute": _confirmCurrDocSearch.bind(this),
+            "shortenPaths": false
         };
 
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, currentDocPayload);
@@ -124,7 +124,8 @@ define(function (require, exports) {
             "type": "RECENT_DOC",
             "getOptions": _recentDocSearchOptions.bind(this),
             "filters": Immutable.List.of("RECENT_DOC"),
-            "handleExecute": _confirmRecentDocSearch.bind(this)
+            "handleExecute": _confirmRecentDocSearch.bind(this),
+            "shortenPaths": true
         };
 
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, recentDocPayload);

--- a/src/js/actions/search/layers.js
+++ b/src/js/actions/search/layers.js
@@ -137,7 +137,8 @@ define(function (require, exports) {
             "type": "LAYER",
             "getOptions": _getLayerSearchOptions.bind(this),
             "filters": filters,
-            "handleExecute": _confirmSearch.bind(this)
+            "handleExecute": _confirmSearch.bind(this),
+            "shortenPaths": true
         };
         
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, payload);

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -27,6 +27,7 @@ define(function (require, exports) {
     var _ = require("lodash"),
         Immutable = require("immutable"),
         keyUtil = require("js/util/key"),
+        system = require("js/util/system"),
         strings = require("i18n!nls/strings");
 
     var events = require("js/events");
@@ -76,12 +77,19 @@ define(function (require, exports) {
             modifierStrings = strings.SEARCH.MODIFIERS,
             shortcut = "";
 
+        var modifierChars = {
+            "command": "\u2318",
+            "control": system.isMac ? "^" : modifierStrings.CONTROL,
+            "alt": system.isMac ? "\u2325" : modifierStrings.ALT,
+            "shift": "\u21E7"
+        };
+
         if (modifierBits) {
             var modifiers = keyUtil.bitsToModifiers(modifierBits);
             
             _.forEach(Object.keys(modifiers), function (key) {
                 if (modifiers[key]) {
-                    shortcut += modifierStrings[key.toUpperCase()] + "+";
+                    shortcut += modifierChars[key];
                 }
             });
         }
@@ -162,7 +170,8 @@ define(function (require, exports) {
             "type": "MENU_COMMAND",
             "getOptions": _menuCommandSearchOptions.bind(this),
             "filters": Immutable.List.of("MENU_COMMAND"),
-            "handleExecute": _confirmMenuCommand.bind(this)
+            "handleExecute": _confirmMenuCommand.bind(this),
+            "shortenPaths": false
         };
 
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, menuCommandPayload);

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
      * @property {string} id ID used to perform action if item is selected
      * @property {string} name Displayable title
      * @property {Array.<string>} category Subset of filters that apply to item. All are keys of SEARCH.CATEGORIES
-     * @property {string} pathInfo A path separated by '/', or ""
+     * @property {string} pathInfo Optional path separated by '/'
      * @property {string} iconID Class for corresponding SVG
     */
 
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
          * Search modules
          *
          * @type {{searchTypes: Array.<string>, searchItems: Immutable.List.<Immutable.List.<object>>,
-         * filters: Array.<Array.<string>>}}
+         * filters: Array.<Array.<string>>, shortenPaths: {boolean}}}
          */
         _registeredSearches: {},
 
@@ -178,13 +178,15 @@ define(function (require, exports, module) {
          * Possible categories for items in this search type. Each string is a key of SEARCH.CATEGORIES
          * {Immutable.List.<string>} payload.filters
          * {handleExecuteCB} payload.handleExecute
+         * {boolean} payload.shortenPaths Whether path info should be shortened or not
          *
          */
         _registerSearchType: function (payload) {
             this._registeredSearchTypes[payload.type] = {
                 "getOptions": payload.getOptions,
                 "filters": payload.filters,
-                "handleExecute": payload.handleExecute
+                "handleExecute": payload.handleExecute,
+                "shortenPaths": payload.shortenPaths
             };
         },
 
@@ -224,10 +226,11 @@ define(function (require, exports, module) {
                 
                 // Get shortest unique paths
                 var ancestors = collection.pluck(items, "pathInfo"),
-                    shortenedPaths = pathUtil.getShortestUniquePaths(ancestors).toJS();
+                    shortenedPaths = searchTypeInfo.shortenPaths ?
+                        pathUtil.getShortestUniquePaths(ancestors).toJS() : ancestors.toJS();
 
                 var itemMap = items.map(function (item, index) {
-                    var newPathInfo = shortenedPaths[index] || item.pathInfo;
+                    var newPathInfo = shortenedPaths[index] || "";
                     // Don't show the path info if it is just the same as the item name 
                     if (item.name === newPathInfo) {
                         newPathInfo = "";

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -614,8 +614,7 @@ define(function (require, exports, module) {
                 COMMAND: "Cmd",
                 SHIFT: "Shift",
                 ALT: "Alt",
-                CONTROL: "Ctrl",
-                ESCAPE: "Escape"
+                CONTROL: "Ctrl"
             }
         },
         ERR: {


### PR DESCRIPTION
Issue #1804. It seems like standard on Windows is to use the abbreviations "Ctrl," "Alt," etc. and the shift symbol.

This also fixes that the shortcut for flip vertical/horizontal wasn't showing up by adding an option to not shorten the paths of search type items.