### PR TITLE
HOTFIX: Disallow reordering groups below themselves

### DIFF
--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -239,11 +239,6 @@ define(function (require, exports, module) {
                 return false;
             }
 
-            // Dropping on the dummy layer at the bottom of the index is always valid
-            if (target.key === "dummy") {
-                return true;
-            }
-
             // Do not let reorder exceed nesting limit
             // When we drag artboards, this limit is 1
             // because we can't nest artboards in any layers
@@ -309,13 +304,17 @@ define(function (require, exports, module) {
                 };
             }
 
-            // Dropping on the dummy layer is always valid because it only exists
+            // Dropping on the dummy layer is valid as long as a group is not
+            // being dropped below itself. The dummy layer only exists
             // when there is a bottom group layer. Drop position is fixed.
             var dropKey = dropInfo.key;
             if (dropKey === "dummy") {
+                var bottom = this.props.document.layers.top.last(),
+                    isGroup = bottom.kind === bottom.layerKinds.GROUP;
+
                 return {
                     compatible: true,
-                    valid: true
+                    valid: !isGroup || !draggedLayers.contains(bottom)
                 };
             }
 

--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -148,7 +148,10 @@ define(function (require, exports, module) {
          */
         deregisterDialog: function (id) {
             if (!this._registeredDialogs.has(id)) {
-                throw new Error("Failed to deregister dialog: " + id + " does not exist.");
+                // This a warning instead of an error because the store's state
+                // may be reset as a result of a controller reset, which would 
+                // explain the missing dialog. Hence, this is most likely benign.
+                log.warn("Failed to deregister dialog: " + id + " does not exist.");
             }
 
             this._registeredDialogs = this._registeredDialogs.delete(id);


### PR DESCRIPTION
**NOTE: This is a PR against the release branch!**

1. Work around a Photoshop issue (again) which causes reordering a group below itself to fail.
2. Demote the missing-dialog error in `stores.dialog.deregisterDialog` to warnings. When the controller resets (e.g., because of the failure above), the first thing that happens is that stores are reset. Hence, failure to deregister a dialog is in that case benign. It could indicate a problem otherwise, so I'm leaving the warning in.

Addresses #1819.

I'll prepare a separate PR against master. There would be conflicts applying this diff because `LayersPanel` has changed significantly since `release` was updated.