### PR TITLE
Make sure to wait for acquireFocus to finish on _beginEdit

### DIFF
--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -53,16 +53,16 @@ define(function (require, exports, module) {
 
     module.exports = {
         acquireFocus: function () {
-            OS.acquireKeyboardFocus().catch(function (err) {
-                var message = err instanceof Error ? (err.stack || err.message) : err;
-
-                log.error("Failed to acquire keyboard focus:", message);
-            });
-
             this.getFlux().actions.policy.addKeyboardPolicies(keyboardPolicyList)
                 .then(function (policy) {
                     _keyboardPolicy = policy;
                 });
+
+            return OS.acquireKeyboardFocus().catch(function (err) {
+                var message = err instanceof Error ? (err.stack || err.message) : err;
+
+                log.error("Failed to acquire keyboard focus:", message);
+            });
         },
         releaseFocus: function () {
             if (_keyboardPolicy) {

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -111,9 +111,16 @@ define(function (require, exports, module) {
         },
 
         componentDidUpdate: function () {
+            var node = React.findDOMNode(this.refs.input);
+
+            if (this.state.editing) {
+                node.removeAttribute("readOnly");
+                node.removeAttribute("disabled");
+                node.focus();
+            }
+
             if (!this.state.selectDisabled) {
                 // If the component updated and there is selection state, restore it
-                var node = React.findDOMNode(this.refs.input);
                 if (window.document.activeElement === node) {
                     node.setSelectionRange(0, node.value.length);
                 }
@@ -278,12 +285,7 @@ define(function (require, exports, module) {
                     this.setState({
                         editing: true,
                         selectDisabled: selectDisabled
-                    }, function () {
-                        var node = React.findDOMNode(this.refs.input);
-                        node.removeAttribute("readOnly");
-                        node.removeAttribute("disabled");
-                        node.focus();
-                    }.bind(this));
+                    });
                 });
         },
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -272,16 +272,19 @@ define(function (require, exports, module) {
             }
             selectDisabled = selectDisabled || false;
 
-            var node = React.findDOMNode(this.refs.input);
-            node.removeAttribute("readOnly");
-            node.removeAttribute("disabled");
-            node.focus();
-
-            this.setState({
-                editing: true,
-                selectDisabled: selectDisabled
-            });
-            this.acquireFocus();
+            this.acquireFocus()
+                .bind(this)
+                .then(function () {
+                    this.setState({
+                        editing: true,
+                        selectDisabled: selectDisabled
+                    }, function () {
+                        var node = React.findDOMNode(this.refs.input);
+                        node.removeAttribute("readOnly");
+                        node.removeAttribute("disabled");
+                        node.focus();
+                    }.bind(this));
+                });
         },
 
         /**


### PR DESCRIPTION
Addresses #1682 
Problem was, textinput would call _beginEdit, which would call acquireFocus, and we'd have a race condition between acqurieFocus of Focusable and setState of React.

Now we make sure acquireFocus returns the promise, and in _beginEdit we wait for that promise to first set the state, and then use the callback of `React.setState`to actually do DOM editing, which is what React suggests we should do.

@iwehrman Can you review, since I bugged you about this.
@hamburge Please be an observer/reviewer as this is important for your work