### PR TITLE
Correctly set the first color of CharacterStyle

### DIFF
--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
             color = Color.DEFAULT;
 
         if (Color.isValidPhotoshopColorObj(rawColor)) {
-            model.color = Color.fromPhotoshopColorObj(rawColor, opacity);
+            color = Color.fromPhotoshopColorObj(rawColor, opacity);
         } else {
             log.warn("Could not parse charstyle color because photoshop did not supply a valid RGB color");
         }


### PR DESCRIPTION
Before this change, we were defaulting the color and showing the wrong value.

@pineapplespatula, this was your code, so please review.