### PR TITLE
Search stylin'

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
         getInitialState: function () {
             return {
                 filter: [],
-                icons: []
+                icon: null
             };
         },
 
@@ -136,14 +136,14 @@ define(function (require, exports, module) {
             var idArray = id ? id.split("-") : [],
                 filterValues = _.drop(idArray),
                 updatedFilter = id ? _.uniq(this.state.filter.concat(filterValues)) : [],
-                filterIcons = svgUtil.getSVGClassesFromFilter(updatedFilter);
+                filterIcon = svgUtil.getSVGClassesFromFilter(updatedFilter);
 
             this.setState({
                 filter: updatedFilter,
-                icons: filterIcons
+                icon: filterIcon
             });
 
-            this.refs.datalist.resetInput(idArray, filterIcons.length);
+            this.refs.datalist.resetInput(idArray, filterIcon);
             this.refs.datalist.forceUpdate();
         },
         
@@ -204,13 +204,13 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Find the icons corresponding with the filter
+         * Find the icon corresponding with the filter
          *
          * @private
          * @param {Array.<string>} filter
-         * @return {Array.<string>}
+         * @return {string}
          */
-        _getFilterIcons: function (filter) {
+        _getFilterIcon: function (filter) {
             return svgUtil.getSVGClassesFromFilter(filter);
         },
 
@@ -343,6 +343,7 @@ define(function (require, exports, module) {
         },
 
         _handleDialogClick: function (event) {
+            this.refs.datalist.removeAutofillSuggestion();
             event.stopPropagation();
         },
 
@@ -361,7 +362,7 @@ define(function (require, exports, module) {
                 }
                 case "Backspace": {
                     if (this.refs.datalist.cursorAtBeginning() && this.state.filter.length > 0) {
-                        // Clear filter and icons
+                        // Clear filter and icon
                         this._updateFilter(null);
                     }
                     break;
@@ -389,7 +390,7 @@ define(function (require, exports, module) {
                         startFocused={true}
                         placeholderText={strings.SEARCH.PLACEHOLDER}
                         placeholderOption={noMatchesOption}
-                        filterIcons={this.state.icons}
+                        filterIcon={this.state.icon}
                         filterOptions={this._filterSearch}
                         useAutofill={true}
                         onChange={this._handleChange}

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -136,8 +136,7 @@ define(function (require, exports, module) {
                 icon: filterIcon
             });
 
-            this.refs.datalist.resetInput(idArray, filterIcon);
-            this.refs.datalist.forceUpdate();
+            this.refs.datalist.resetInput(idArray);
         },
         
         /**

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -34,14 +34,6 @@ define(function (require, exports, module) {
 
     var svgUtil = require("js/util/svg"),
         strings = require("i18n!nls/strings");
-    
-    /**
-     * Maximum number of options to show per category
-     *  
-     * @const
-     * @type {number} 
-    */
-    var MAX_OPTIONS = 5;
 
     /**
      * Strings for labeling search options
@@ -82,7 +74,8 @@ define(function (require, exports, module) {
         getDefaultProps: function () {
             return {
                 dismissDialog: _.identity,
-                searchID: ""
+                searchID: "",
+                maxOptions: 14
             };
         },
 
@@ -326,20 +319,22 @@ define(function (require, exports, module) {
                 return priorities;
             }.bind(this));
 
-            return filteredOptionGroups.reduce(function (filteredOptions, group) {
+            var optionList = filteredOptionGroups.reduce(function (filteredOptions, group) {
                 // Sort by priority, then only take the object, without the priority
                 var sortedOptions = group.sortBy(function (opt) {
                         return opt[1];
                     }).map(function (opt) {
                         return opt[0];
                     });
-
-                if (truncate) {
-                    return filteredOptions.concat(sortedOptions);
-                } else {
-                    return filteredOptions.concat(sortedOptions.take(MAX_OPTIONS));
-                }
+                
+                return filteredOptions.concat(sortedOptions);
             }, Immutable.List());
+
+            if (truncate) {
+                return optionList.take(this.props.maxOptions);
+            }
+
+            return optionList;
         },
 
         _handleDialogClick: function (event) {

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -443,7 +443,7 @@ define(function (require, exports, module) {
                 // Otherwise suggest based on last word typed
                 var valueLowerCase = value ? value.toLowerCase() : "",
                     lastWord = valueLowerCase.split(" ").pop(),
-                    options = this._filterOptions(valueLowerCase, true),
+                    options = this._filterOptions(valueLowerCase, false),
 
                     suggestion = (options && valueLowerCase !== "") ? options.find(function (opt) {
                             return (opt.type === "item" && opt.title.toLowerCase().indexOf(valueLowerCase) === 0);
@@ -475,6 +475,10 @@ define(function (require, exports, module) {
             }
         },
 
+        /**
+         * Sets autofill suggestion to empty string and re-renders
+         *
+         */
         removeAutofillSuggestion: function () {
             if (this.props.useAutofill) {
                 this.setState({
@@ -552,27 +556,35 @@ define(function (require, exports, module) {
                 filter = this.state.filter,
                 title = this.state.active && filter !== null ? filter : value,
                 searchableFilter = filter ? filter.toLowerCase() : "",
-                filteredOptions = this._filterOptions(searchableFilter, false),
+                filteredOptions = this._filterOptions(searchableFilter, true),
                 searchableOptions = filteredOptions;
 
             if (filteredOptions && collection.uniformValue(collection.pluck(filteredOptions, "type"))) {
                 searchableOptions = this.props.placeholderOption;
             }
             
-            var autocomplete,
-                hiddenTI,
-                hiddenSVG;
+            // Use hidden text input and hidden svg to find position of suggestion by updating their values and 
+            // getting width before calling render. Without using the hidden elements, in certain cases the 
+            // calculated position of suggestion would be one keystroke behind. 
+
+            // Hidden text input gets the value of the search input before rendering.
+            var hiddenTI,
+            // Hidden SVG is used to find width of a filter icon. It is just a div with the same width 
+            // (including margin) as the icons used for filters
+                hiddenSVG,
+                autocomplete;
+
  
             if (this.props.useAutofill) {
                 hiddenTI = (
                     <div ref="hiddenTextInput"
-                        className="hiddeninput">
+                        className="hidden-input">
                     </div>
                 );
 
                 hiddenSVG = (
                     <div ref="hiddenSVG"
-                        className="hiddenSVG">
+                        className="hidden-svg">
                     </div>
                 );
                 

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -54,23 +54,21 @@ define(function (require, exports) {
      *
      * @private
      * @param {Array.<string>} filter
-     * @return {Array.<string>}
+     * @return {string}
     */
     var getSVGClassesFromFilter = function (filter) {
         if (filter.length === 0) {
-            return [];
+            return null;
         }
         // currently only have icons for layers
         if (filter.length < 2 || filter.join(" ").indexOf("LAYER") === -1) {
-            return ["tool-rectangle"]; // standin for non-layers
+            return "tool-rectangle"; // standin for non-layers
         }
 
-        var iconIDs = [],
+        var iconID = "layer-",
             isLinked = _.has(filter, "linked");
-
+        
         _.forEach(filter, function (kind) {
-            var iconID = "layer-";
-
             if (kind === "ARTBOARD") {
                 iconID += "artboard";
             } else if (kind === "BACKGROUND") {
@@ -80,14 +78,17 @@ define(function (require, exports) {
             } else if (kind !== "LAYER") {
                 iconID += layerLib.layerKinds[kind.toUpperCase().replace(" ", "")];
             }
+<<<<<<< HEAD
 
             // If it is "ALL_LAYER" or "CURRENT_LAYER", don't need to add iconID
             if (kind.indexOf("LAYER") === -1) {
                 iconIDs.push(iconID);
             }
+=======
+>>>>>>> Search style: fix alignment of input and suggestion; Remove border on select header if at top of list
         });
 
-        return iconIDs;
+        return iconID;
     };
 
     exports.getSVGClassFromLayer = getSVGClassFromLayer;

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -75,17 +75,9 @@ define(function (require, exports) {
                 iconID += layerLib.layerKinds.PIXEL;
             } else if (kind === "SMARTOBJECT" && isLinked) {
                 iconID += layerLib.layerKinds.SMARTOBJECT + "-linked";
-            } else if (kind !== "LAYER") {
+            } else if (kind.indexOf("LAYER") === -1) { // check if kind is "ALL_LAYER" or "CURRENT_LAYER"
                 iconID += layerLib.layerKinds[kind.toUpperCase().replace(" ", "")];
             }
-<<<<<<< HEAD
-
-            // If it is "ALL_LAYER" or "CURRENT_LAYER", don't need to add iconID
-            if (kind.indexOf("LAYER") === -1) {
-                iconIDs.push(iconID);
-            }
-=======
->>>>>>> Search style: fix alignment of input and suggestion; Remove border on select header if at top of list
         });
 
         return iconID;

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -75,13 +75,6 @@
     visibility: hidden;
     white-space: pre;
 }
-.search-bar__dialog .drop-down .hidden-svg {
-    display: inline-block;
-    position: absolute;
-    visibility: hidden;
-    width: 2.0rem;
-    height: 1.5rem;
-}
 
 .search-bar__dialog::backdrop {
     position: fixed;

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -68,14 +68,14 @@
     background: rgba(0,0,0,0);
 }
 
-.search-bar__dialog .drop-down .hiddeninput {
+.search-bar__dialog .drop-down .hidden-input {
     display: inline-block;
     position: absolute;
     margin-left: .1rem;
     visibility: hidden;
     white-space: pre;
 }
-.search-bar__dialog .drop-down .hiddenSVG {
+.search-bar__dialog .drop-down .hidden-svg {
     display: inline-block;
     position: absolute;
     visibility: hidden;
@@ -117,13 +117,6 @@
     margin-right: 0.5rem;
     stroke:  @warm-gray;
     fill:  @warm-gray;
-}
-
-.search-bar__dialog .datalist__hiddensvg {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-right: 0.5rem;
-    display: none;
 }
 
 .search-bar__dialog .autocomplete {

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -49,6 +49,10 @@
     color: @warm-gray;
 }
 
+.search-bar__dialog .drop-down input{
+    border: none;
+}
+
 .search-bar__dialog .drop-down input:focus {
     background: rgba(0,0,0,0);
     color: @warm-white;
@@ -67,9 +71,16 @@
 .search-bar__dialog .drop-down .hiddeninput {
     display: inline-block;
     position: absolute;
-    left: 3.2rem;
+    margin-left: .1rem;
     visibility: hidden;
     white-space: pre;
+}
+.search-bar__dialog .drop-down .hiddenSVG {
+    display: inline-block;
+    position: absolute;
+    visibility: hidden;
+    width: 2.0rem;
+    height: 1.5rem;
 }
 
 .search-bar__dialog::backdrop {
@@ -108,10 +119,18 @@
     fill:  @warm-gray;
 }
 
+.search-bar__dialog .datalist__hiddensvg {
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 0.5rem;
+    display: none;
+}
+
 .search-bar__dialog .autocomplete {
     display: inline-block;
     position: absolute;
     color: @color-section-rule;
-    top: 1.2rem;
+    line-height: 2rem;
+    height: 1.6rem;
     white-space: pre;
 }

--- a/src/style/shared/select.less
+++ b/src/style/shared/select.less
@@ -42,6 +42,10 @@
     border-top: 1px solid @color-section-rule;
 }
 
+.select__header:first-child {
+    border: none;
+}
+
 .select__option__info {
     margin-left: 1rem;
     color: @warm-gray;


### PR DESCRIPTION
Issues #1816, #1807, and also:
- Fix for if you had a filter set, the autocomplete suggestion would not always be lined up depending on your screen resolution.
- Fix for if there were no filter suggestions, there was an extra line on the top of the drop down.
- When you click on the dialog and the input loses focus, don't show the autofill suggestion
- Removes code that supported displaying multiple svgs for filters since it is not necessary.