### PR TITLE
Do not target invisible layers

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -170,6 +170,10 @@ define(function (require, exports) {
      */
     var _getContainingLayerBounds = function (layerTree, x, y) {
         return Immutable.Set(layerTree.all.reduce(function (layerSet, layer) {
+            if (layerTree.hasInvisibleAncestor(layer)) {
+                return layerSet;
+            }
+
             var bounds;
             if (layer.isArtboard) {
                 // We need the scale factor to be able to calculate the name badge correctly as it does not scale
@@ -210,7 +214,7 @@ define(function (require, exports) {
      */
     var _removeArtboardIDs = function (layerTree, ids) {
         return ids.filterNot(function (id) {
-            return layerTree.layers.get(id).isArtboard;
+            return layerTree.byID(id).isArtboard;
         });
     };
 
@@ -389,7 +393,7 @@ define(function (require, exports) {
                     
                     clickedSelectableLayerIDs = collection.intersection(coveredLayerIDs, clickableLayerIDs);
                 }
-                
+
                 if (!clickedSelectableLayerIDs.isEmpty()) {
                     // due to way hitTest works, the top z-order layer is the last one in the list
                     var topLayerID = clickedSelectableLayerIDs.last(),

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -244,7 +244,11 @@ define(function (require, exports, module) {
                 renderLayers;
 
             if (this.state.leafBounds) {
-                renderLayers = layerTree.leaves.sortBy(indexOf);
+                renderLayers = layerTree.leaves
+                    .filterNot(function (layer) {
+                        return layerTree.hasInvisibleAncestor(layer);
+                    })
+                    .sortBy(indexOf);
 
                 // We add artboards here, so they are shown selectable
                 renderLayers = renderLayers.concat(layerTree.artboards);

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -332,6 +332,7 @@ define(function (require, exports, module) {
                 }, this.topBelowArtboards, this)
                 .filter(function (layer) {
                     return layer.superSelectable &&
+                        this.hasVisibleDescendant(layer) &&
                         !this.hasInvisibleAncestor(layer) &&
                         !this.hasLockedAncestor(layer) &&
                         !visitedParents.hasOwnProperty(layer.id);
@@ -695,6 +696,22 @@ define(function (require, exports, module) {
         return this.ancestors(layer).some(function (layer) {
             return !layer.visible;
         });
+    }));
+
+    /**
+     * Determine whether any of the non group descendants of this layer (besides itself) is visible.
+     *
+     * @param {Layer} layer
+     * @return {boolean}
+     */
+    Object.defineProperty(LayerStructure.prototype, "hasVisibleDescendant", objUtil.cachedLookupSpec(function (layer) {
+        return this.descendants(layer)
+            .filterNot(function (layer) {
+                return layer.kind === layer.layerKinds.GROUP || layer.kind === layer.layerKinds.GROUPEND;
+            })
+            .some(function (layer) {
+                return layer.visible;
+            });
     }));
 
     /**

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
                 }, this.topBelowArtboards, this)
                 .filter(function (layer) {
                     return layer.superSelectable &&
-                        layer.visible &&
+                        !this.hasInvisibleAncestor(layer) &&
                         !this.hasLockedAncestor(layer) &&
                         !visitedParents.hasOwnProperty(layer.id);
                 }, this)


### PR DESCRIPTION
Currently invisible layers are targetable on-canvas with selection and deep (command/alt) selection. This makes it impossible to target visible layers in VermilionArtboards.psd because there is a hidden grid system at the top of the layer index which covers the entire page. @placegraphichere correctly pointed out that invisible layers should not be targetable on-canvas, and that this was the source of frustration targeting layers in VermilionArtboards.psd. This change corrects that. Also, @volfied pointed out that groups with only visible children should also be treated as invisible, so he fixed that too.

Partially addresses #1734, by making smart guide overlays more consistent with the HTML overlays. (We still shouldn't draw both in different colors, but this this at least makes things less scatter-brained.)