### PR TITLE
Search for layers in any open document, not just the current document

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1691,7 +1691,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var afterStartup = function () {
-        searchActions.registerLayerSearch.call(this);
+        searchActions.registerAllLayerSearch.call(this);
+        searchActions.registerCurrentLayerSearch.call(this);
         return Promise.resolve();
     };
     afterStartup.reads = [];

--- a/src/js/actions/search/layers.js
+++ b/src/js/actions/search/layers.js
@@ -28,19 +28,20 @@ define(function (require, exports) {
         _ = require("lodash");
 
     var events = require("js/events"),
+        mathUtil = require("js/util/math"),
         svgUtil = require("js/util/svg");
     
     /**
      * Get the layer type and if it is linked or an artboard, as an array of strings.
-     * This is used for comparison against the inputted search terms and any search filters.
-     * Not directly user-visible, but needs to be able to match user input.
+     * This is used for comparison against any search filters.
      *
      * @private
      * @param {Layer} layer
+     * @param {string} type
      * @return {Array.<string>}
     */
-    var _getLayerCategory = function (layer) {
-        var layerType = ["LAYER"];
+    var _getLayerCategory = function (layer, type) {
+        var layerType = [type + "_LAYER"];
 
         if (layer.kind === layer.layerKinds.GROUP && layer.isArtboard) {
             layerType.push("ARTBOARD");
@@ -78,7 +79,41 @@ define(function (require, exports) {
     };
 
     /**
-     * Make list of certain layer info so search store can create search options
+     * Get the layer options from the specified document
+     *
+     * @private
+     * @param {Document} document
+     * @param {string} type Type of layer search, for finding correct layer category
+     * @return {Immutable.List.<object>}
+    */
+    var _getLayerOptionsFromDoc = function (document, type) {
+        var appStore = this.flux.store("application"),
+            currentID = appStore.getCurrentDocumentID(),
+            layers = document.layers.allVisibleReversed;
+        
+        return layers.map(function (layer) {
+            var ancestry,
+                layerType = _getLayerCategory(layer, type),
+                iconID = svgUtil.getSVGClassFromLayer(layer);
+
+            if (document.id === currentID) {
+                ancestry = _formatLayerAncestry(layer, appStore);
+            } else {
+                ancestry = document.name;
+            }
+
+            return {
+                id: document.id.toString() + "_" + layer.id.toString(),
+                name: layer.name,
+                pathInfo: ancestry,
+                iconID: iconID,
+                category: layerType
+            };
+        });
+    };
+
+    /**
+     * Make list of certain layer info from current document only so search store can create search options
      *
      * @private
      * @return {Immutable.List.<object>}
@@ -87,55 +122,69 @@ define(function (require, exports) {
         // Get list of layers
         var appStore = this.flux.store("application"),
             document = appStore.getCurrentDocument();
-        if (!document) {
-            return {};
-        }
-        var layers = document.layers.allVisibleReversed,
-            layerMap = layers.map(function (layer) {
-                var ancestry = _formatLayerAncestry(layer, appStore),
-                    layerType = _getLayerCategory(layer),
-                    iconID = svgUtil.getSVGClassFromLayer(layer);
 
-                return {
-                    id: layer.id.toString(),
-                    name: layer.name,
-                    pathInfo: ancestry,
-                    iconID: iconID,
-                    category: layerType
-                };
-            }.bind(this));
+        return _getLayerOptionsFromDoc.call(this, document, "CURRENT");
+    };
 
-        return layerMap;
+    /**
+     * Make list of certain layer info from all documents so search store can create search options
+     *
+     * @private
+     * @return {Immutable.List.<object>}
+    */
+    var _getAllLayerSearchOptions = function () {
+        // Get list of layers
+        var appStore = this.flux.store("application"),
+            currDoc = appStore.getCurrentDocument(),
+            documents = appStore.getOpenDocuments(),
+            // add layers from current document first, then skip it in the loop
+            allLayerMaps = _getLayerOptionsFromDoc.call(this, currDoc, "ALL");
+
+        documents.forEach(function (document) {
+            if (document !== currDoc) {
+                var layerMap = _getLayerOptionsFromDoc.call(this, document, "ALL");
+                allLayerMaps = allLayerMaps.concat(layerMap);
+            }
+        }.bind(this));
+
+        return allLayerMaps;
     };
 
     /**
      * Select layer when its item is confirmed in search
      *
      * @private
-     * @param {number} idInt ID of layer to select
+     * @param {string} id ID of layer to select
     */
-    var _confirmSearch = function (idInt) {
-        var appStore = this.flux.store("application"),
-            document = appStore.getCurrentDocument(),
-            selected = document.layers.byID(idInt);
+    var _confirmSearch = function (id) {
+        var docStore = this.flux.store("document"),
+            splitID = id.split("_"),
+            docID = mathUtil.parseNumber(splitID[0]),
+            layerID = mathUtil.parseNumber(splitID[1]),
+            document = docStore.getDocument(docID),
+            selected = document.layers.byID(layerID);
 
         if (selected) {
+            this.flux.actions.documents.selectDocument(document);
             this.flux.actions.layers.select(document, selected);
         }
     };
 
     /**
-     * Register layer info for search
+     * Register layer info to search
      *
+     * @param {boolean} searchAllDocuments Whether to search all documents or not (just the current one)
      */
-    var registerLayerSearch = function () {
-        var filters = Immutable.List.of(
-            "LAYER", "PIXEL", "TEXT", "ARTBOARD", "ADJUSTMENT", "SMARTOBJECT", "GROUP", "VECTOR"
-        );
+    var _registerLayerSearch = function (searchAllDocuments) {
+        var type = searchAllDocuments ? "ALL" : "CURRENT",
+            filters = Immutable.List.of(
+                (type + "_LAYER"), "PIXEL", "TEXT", "ARTBOARD", "ADJUSTMENT", "SMARTOBJECT", "GROUP", "VECTOR"
+            ),
+            options = searchAllDocuments ? _getAllLayerSearchOptions.bind(this) : _getLayerSearchOptions.bind(this);
 
         var payload = {
-            "type": "LAYER",
-            "getOptions": _getLayerSearchOptions.bind(this),
+            "type": type + "_LAYER",
+            "getOptions": options,
             "filters": filters,
             "handleExecute": _confirmSearch.bind(this),
             "shortenPaths": true
@@ -144,5 +193,22 @@ define(function (require, exports) {
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, payload);
     };
 
-    exports.registerLayerSearch = registerLayerSearch;
+    /**
+     * Register layer info to search for layers in all current documents
+     *
+     */
+    var registerAllLayerSearch = function () {
+        _registerLayerSearch.call(this, true);
+    };
+    
+    /**
+     * Register layer info to search for layers just in current document
+     *
+     */
+    var registerCurrentLayerSearch = function () {
+        _registerLayerSearch.call(this, false);
+    };
+
+    exports.registerCurrentLayerSearch = registerCurrentLayerSearch;
+    exports.registerAllLayerSearch = registerAllLayerSearch;
 });

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
 
         componentWillMount: function () {
             var searchStore = this.getFlux().store("search");
-            searchStore.registerSearch(SEARCH_BAR_DIALOG_ID, ["LAYER", "CURRENT_DOC", "RECENT_DOC", "MENU_COMMAND"]);
+            searchStore.registerSearch(SEARCH_BAR_DIALOG_ID,
+                ["ALL_LAYER", "CURRENT_DOC", "RECENT_DOC", "MENU_COMMAND"]);
         },
 
         /**

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -309,7 +309,9 @@ define(function (require, exports, module) {
                         }
                     });
 
-                    priority += (searchTerms.length - numTermsInTitle);
+                    // Multiply by 3 so that we are always adding a positive number
+                    // since numTermsInTitle is at most 3 times the length of the input
+                    priority += (3 * searchTerms.length - numTermsInTitle);
                     
                     // If option is the autofill option, should jump to the top
                     if (option.id === autofillID) {

--- a/src/js/stores/application.js
+++ b/src/js/stores/application.js
@@ -145,6 +145,20 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Get the currently active document models
+         * 
+         * @return {?Immutable.List.<Document>}
+         */
+        getOpenDocuments: function () {
+            var documentStore = this.flux.store("document"),
+                documents = this._documentIDs.map(function (id) {
+                    return documentStore.getDocument(id);
+                });
+
+            return documents;
+        },
+
+        /**
          * The number of currently open documents;
          *
          * @return {number}

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -174,6 +174,7 @@ define(function (require, exports, module) {
          * Add search type
          *
          * @param {object} payload
+         * {string} payload.type Type of search. Corresponds with key of SEARCH.HEADERS
          * {getOptionsCB} payload.getOptions 
          * Possible categories for items in this search type. Each string is a key of SEARCH.CATEGORIES
          * {Immutable.List.<string>} payload.filters

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -81,7 +81,8 @@ define(function (require, exports) {
                 iconID += layerLib.layerKinds[kind.toUpperCase().replace(" ", "")];
             }
 
-            if (kind !== "LAYER") {
+            // If it is "ALL_LAYER" or "CURRENT_LAYER", don't need to add iconID
+            if (kind.indexOf("LAYER") === -1) {
                 iconIDs.push(iconID);
             }
         });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -591,7 +591,8 @@ define(function (require, exports, module) {
             PLACEHOLDER: "Type to search",
             NO_OPTIONS: "No options match your search",
             HEADERS: {
-                LAYER: "Layers",
+                ALL_LAYER: "Layers",
+                CURRENT_LAYER: "Layers",
                 CURRENT_DOC: "Current Documents",
                 RECENT_DOC: "Recent Documents",
                 MENU_COMMAND: "Menu Commands"
@@ -601,7 +602,8 @@ define(function (require, exports, module) {
                 RECENT_DOC: "Recent Documents",
                 DOCUMENT: "Documents",
                 MENU_COMMAND: "Menu Commands",
-                LAYER: "Layers",
+                ALL_LAYER: "Layers",
+                CURRENT_LAYER: "Layers",
                 ARTBOARD: "Artboard",
                 PIXEL: "Pixel",
                 ADJUSTMENT: "Adjustment",


### PR DESCRIPTION
Can now register a search module to either include layers in any open document or in just the current document.

If the layer is from the non-current document, the file name it comes from will appear as secondary information on the search option. Otherwise it shows the shortened layer path (just like before).

If a layer from the non-current document is confirmed, we switch to its document and select it.
