### PR TITLE
HOTFIX #1846: Ignore null layers during removeArtboardIDs

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -210,7 +210,9 @@ define(function (require, exports) {
      */
     var _removeArtboardIDs = function (layerTree, ids) {
         return ids.filterNot(function (id) {
-            return layerTree.layers.get(id).isArtboard;
+            var layer = layerTree.layers.get(id);
+            
+            return layer ? layer.isArtboard : true;
         });
     };
 


### PR DESCRIPTION
Fixes #1846 , for prerelease.