### PR TITLE
Modify color change in text to only sometimes add history

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -202,7 +202,7 @@ define(function (require, exports) {
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var updateColor = function (document, layers, color, coalesce) {
+    var updateColor = function (document, layers, color, coalesce, fromSet) {
         var layerIDs = collection.pluck(layers, "id"),
             normalizedColor = null;
 
@@ -217,7 +217,11 @@ define(function (require, exports) {
                 calesce: coalesce
             };
 
-        return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
+        if (fromSet) {
+            return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
+        } else {
+            return this.dispatchAsync(events.document.history.amendment.TYPE_COLOR_CHANGED, payload);
+        }
     };
     updateColor.reads = [];
     updateColor.writes = [locks.PS_DOC, locks.JS_DOC];
@@ -256,7 +260,7 @@ define(function (require, exports) {
 
             playObject = [playObject].concat(setOpacityPlayObjects);
         }
-        var updatePromise = this.transfer(updateColor, document, layers, color, coalesce),
+        var updatePromise = this.transfer(updateColor, document, layers, color, coalesce, true),
             setColorPromise = locking.playWithLockOverride(document, layers, playObject, typeOptions);
 
         return Promise.join(updatePromise, setColorPromise);

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -200,9 +200,10 @@ define(function (require, exports) {
      * @param {Immutable.Iterable.<Layers>} layers
      * @param {Color} color
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
+     * @param {boolean=} optimisticHistory Whether this event will be included in our history model
      * @return {Promise}
      */
-    var updateColor = function (document, layers, color, coalesce, fromSet) {
+    var updateColor = function (document, layers, color, coalesce, optimisticHistory) {
         var layerIDs = collection.pluck(layers, "id"),
             normalizedColor = null;
 
@@ -217,7 +218,7 @@ define(function (require, exports) {
                 calesce: coalesce
             };
 
-        if (fromSet) {
+        if (optimisticHistory) {
             return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
         } else {
             return this.dispatchAsync(events.document.history.amendment.TYPE_COLOR_CHANGED, payload);

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -71,6 +71,7 @@ define(function (require, exports, module) {
                     DELETE_LAYERS: "deleteLayersNonOptimistic" // eg: ps deletes the entire layer after last path del
                 },
                 amendment: {
+                    TYPE_COLOR_CHANGED: "typeColorChanged",
                     REORDER_LAYERS: "reorderLayersAmendment"
                 }
             },

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
                     DELETE_LAYERS: "deleteLayersNonOptimistic" // eg: ps deletes the entire layer after last path del
                 },
                 amendment: {
-                    TYPE_COLOR_CHANGED: "typeColorChanged",
+                    TYPE_COLOR_CHANGED: "typeColorChangedAmendment",
                     REORDER_LAYERS: "reorderLayersAmendment"
                 }
             },

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -88,6 +88,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_FACE_CHANGED, this._handleTypeFaceChanged,
                 events.document.TYPE_SIZE_CHANGED, this._handleTypeSizeChanged,
                 events.document.history.optimistic.TYPE_COLOR_CHANGED, this._handleTypeColorChanged,
+                events.document.history.amendment.TYPE_COLOR_CHANGED, this._handleTypeColorChanged,
                 events.document.TYPE_TRACKING_CHANGED, this._handleTypeTrackingChanged,
                 events.document.TYPE_LEADING_CHANGED, this._handleTypeLeadingChanged,
                 events.document.TYPE_ALIGNMENT_CHANGED, this._handleTypeAlignmentChanged


### PR DESCRIPTION
Our history model and modal text states do not currently coexist properly.
to work around this the color set routine which was a nonoptomistic history state
if set in the modal environment should instead append to history.