### PR TITLE
Drag and drop graphic asset from libraries panel to canvas

### DIFF
--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -102,6 +102,8 @@ define(function (require, exports, module) {
         
         /**
          * Return library panel content based on the connection status of CC Library.
+         * @private
+         * 
          * @return {ReactComponent}
          */
         _containerContents: function () {

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
 
     var os = require("adapter/os");
 
-    var Image = require("jsx!./assets/Image"),
+    var Graphic = require("jsx!./assets/Graphic"),
         Color = require("jsx!./assets/Color"),
         CharacterStyle = require("jsx!./assets/CharacterStyle"),
         LayerStyle = require("jsx!./assets/LayerStyle");
@@ -80,11 +80,11 @@ define(function (require, exports, module) {
             );
         },
 
-        _getImageAssets: function (library) {
+        _getGraphicAssets: function (library) {
             var assets = library.getFilteredElements(typeNames.image),
                 components = assets.map(function (asset) {
                     return (
-                        <Image
+                        <Graphic
                             key={asset.id}
                             element={asset}
                         />
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
             return (
                 <div>
                     {this._getColorAssets(library)}
-                    {this._getImageAssets(library)}
+                    {this._getGraphicAssets(library)}
                     {this._getCharacterStyleAssets(library)}
                     {this._getLayerStyleAssets(library)}
                 </div>

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
     var Graphic = require("jsx!./assets/Graphic"),
         Color = require("jsx!./assets/Color"),
         CharacterStyle = require("jsx!./assets/CharacterStyle"),
-        LayerStyle = require("jsx!./assets/LayerStyle");
+        LayerStyle = require("jsx!./assets/LayerStyle"),
+        Scrim = require("jsx!js/jsx/Scrim");
 
     var synchronization = require("js/util/synchronization");
 
@@ -86,6 +87,8 @@ define(function (require, exports, module) {
                     return (
                         <Graphic
                             key={asset.id}
+                            zone={Scrim.DROPPABLE_ZONE}
+                            keyObject={asset}
                             element={asset}
                         />
                     );

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     var Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
 
-    var Image = React.createClass({
+    var Graphic = React.createClass({
         mixins: [FluxMixin],
 
         getInitialState: function () {
@@ -79,5 +79,5 @@ define(function (require, exports, module) {
         }
     });
 
-    module.exports = Image;
+    module.exports = Graphic;
 });

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -27,17 +27,20 @@ define(function (require, exports, module) {
     var Promise = require("bluebird"),
         React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React);
+        FluxMixin = Fluxxor.FluxMixin(React),
+        classnames = require("classnames");
 
     var Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
+        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
+        Draggable = require("jsx!js/jsx/shared/Draggable");
 
     var Graphic = React.createClass({
         mixins: [FluxMixin],
 
         getInitialState: function () {
             return {
-                renditionPath: ""
+                renditionPath: "",
+                dragging: false
             };
         },
 
@@ -54,17 +57,51 @@ define(function (require, exports, module) {
             });
         },
 
+        /**
+         * Handle add layer from graphic asset
+         * @private
+         */
         _handleAdd: function () {
-            this.getFlux().actions.libraries.createLayerFromElement(this.props.element);
+            // TODO: new graphic is add to a fixed location. Ideally it should place the new graphic layer 
+            // at the center of the view port.
+            this.getFlux().actions.libraries.createLayerFromElement(this.props.element, { x: 100, y: 100 });
+        },
+        
+        /**
+         * Create preview of the dragged graphic asset under the cursor.
+         * @private
+         * @return {ReactComponent?}
+         */
+        _renderDragPreview: function () {
+            if (!this.props.dragPosition) {
+                return null;
+            }
+        
+            var styles = {
+                left: this.props.dragPosition.x,
+                top: this.props.dragPosition.y
+            };
+            
+            return (
+                <div className="assets__graphic__drag-preview" style={styles}>
+                    <img src={this.state.renditionPath} />
+                </div>
+            );
         },
 
         render: function () {
-            var element = this.props.element;
-
+            var element = this.props.element,
+                dragPreview = this._renderDragPreview();
+            
+            var classNames = classnames("sub-header", {
+                "assets__graphic_dragging": this.props.isDragging
+            });
+            
             return (
-                <div className="sub-header"
-                    key={element.id}>
-                    <img src={this.state.renditionPath} />
+                <div className={classNames}
+                     key={element.id}
+                     onMouseDown={this.props.handleDragStart}>
+                    <img src={this.state.renditionPath}/>
                     {element.displayName}
                     <Button
                         title="Add to Photoshop"
@@ -74,10 +111,13 @@ define(function (require, exports, module) {
                             viewbox="0 0 12 12"
                             CSSID="plus" />
                     </Button>
+                    {dragPreview}
                 </div>
             );
         }
     });
+    
+    var DraggableGraphic = Draggable.createWithComponent(Graphic, "both");
 
-    module.exports = Graphic;
+    module.exports = DraggableGraphic;
 });

--- a/src/js/jsx/shared/Droppable.jsx
+++ b/src/js/jsx/shared/Droppable.jsx
@@ -42,6 +42,8 @@ define(function (require, exports, module) {
      *
      * @param {ReactComponent} Component Component to wrap
      * @param {function} getProps function to return an object with the props required by Droppable
+     * @param {function?} isEqual
+     * @param {function?} shouldUpdate
      * @return {ReactComponent}
      */
     var createWithComponent = function (Component, getProps, isEqual, shouldUpdate) {
@@ -60,7 +62,8 @@ define(function (require, exports, module) {
                         key: options.key,
                         keyObject: options.keyObject,
                         isValid: options.isValid,
-                        onDrop: options.handleDrop
+                        onDrop: options.handleDrop,
+                        droppable: this
                     };
 
                 flux.store("draganddrop").registerDroppable(zone, droppable);
@@ -92,6 +95,10 @@ define(function (require, exports, module) {
                     keyObject: options.keyObject
                 };
             },
+            
+            getInitialState: function () {
+                return { isMouseOver: false };
+            },
 
             componentDidMount: function () {
                 this._register();
@@ -105,13 +112,37 @@ define(function (require, exports, module) {
             },
 
             componentDidUpdate: function (prevProps) {
-                if (!isEqual(getProps(this.props).keyObject, getProps(prevProps).keyObject)) {
+                if (isEqual && !isEqual(getProps(this.props).keyObject, getProps(prevProps).keyObject)) {
                     this._register();
                 }
             },
+            
+            /**
+             * Handle mouse enter. To use the "isMouseOver" prop, child component must call the 
+             * "onMouseEnterDroppable" prop to notify a mouse enter event.
+             * @private
+             */
+            _handleMouseEnter: function () {
+                this.setState({ isMouseOver: true });
+            },
+            
+            /**
+             * Handle mouse leave. To use the "isMouseOver" prop, child component must call the 
+             * "onMouseLeaveDroppable" prop to notify a mouse leave event.
+             * @private
+             */
+            _handleMouseLeave: function () {
+                this.setState({ isMouseOver: false });
+            },
 
             render: function () {
-                return <Component {...this.props} {...this.state} />;
+                return (
+                    <Component
+                        {...this.props}
+                        isMouseOver={this.isMouseOver}
+                        onMouseEnterDroppable={this._handleMouseEnter}
+                        onMouseLeaveDroppable={this._handleMouseLeave} />
+                );
             }
         });
 

--- a/src/style/scrim.less
+++ b/src/style/scrim.less
@@ -30,6 +30,10 @@
     bottom: 0;
 }
 
+.scrim-drop {
+    cursor: copy;
+}
+
 .scrim svg {
 	position: absolute;
 	top: 0;

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -20,6 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
+ 
+ @drag-preview-size: 64px;
 
 .libraries {
     min-height: 7.5rem;
@@ -75,5 +77,26 @@
         .split-button__item {
             width: 30px;
         }
+    }
+}
+
+.assets__graphic_dragging {
+    opacity: 0.7;
+}
+
+.assets__graphic__drag-preview {
+    position: fixed;
+    width: @drag-preview-size;
+    height: @drag-preview-size;
+    line-height: @drag-preview-size;
+    text-align: center;
+    margin-top: -@drag-preview-size/2;
+    margin-left: -@drag-preview-size/2;
+    pointer-events: none;
+    
+    img {
+        max-width: @drag-preview-size;
+        max-height: @drag-preview-size;
+        vertical-align: middle;
     }
 }


### PR DESCRIPTION
This PR implements the drag-and-drop of graphic asset from libraries panel to canvas. Works as below:

![lib-dnd](https://cloud.githubusercontent.com/assets/118264/8951265/c4e28e0a-3580-11e5-8934-189928a88420.gif)
( For now, you have to double click the dropped asset to quit the transform mode, before you can do anything else )

@volfied please review 