### PR TITLE
Post-reorder bounds reset should be non-history-changing

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1137,7 +1137,7 @@ define(function (require, exports) {
             .then(function () {
                 // The selected layers may have changed after the reorder.
                 var nextDocument = this.flux.store("document").getDocument(document.id);
-                this.flux.actions.layers.resetBounds(nextDocument, nextDocument.layers.allSelected);
+                this.flux.actions.layers.resetBounds(nextDocument, nextDocument.layers.allSelected, true);
             });
     };
     reorderLayers.reads = [locks.PS_DOC, locks.JS_DOC];


### PR DESCRIPTION
This addresses #1843 
@iwehrman: you break it, you bought it: 9d285585eb80f49b49703de96013441742e359e1
cc @shaoshing just as an FYI since you recently ported this particular code from the LayersPanel to the action.

The resetBounds action is an accident waiting to happen.  I will attempt to make this less error-prone during the next round of history changes.  In the meantime, the *default* behavior is that resetBounds is a *history changing* event.  It is generally used as a generic "final step" in several other history-changing workflows.  But, in cases like this, it must explicitly be told *not* to change history.  I agree this is confusing.