### PR TITLE
Post-reorder bounds reset should be non-history-changing - hotfix on release branch

### DIFF
--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -434,7 +434,7 @@ define(function (require, exports, module) {
                         var documentStore = flux.store("document"),
                             nextDocument = documentStore.getDocument(doc.id);
 
-                        flux.actions.layers.resetBounds(nextDocument, nextDocument.layers.allSelected);
+                        flux.actions.layers.resetBounds(nextDocument, nextDocument.layers.allSelected, true);
                     })
                     .finally(function () {
                         this.setState({


### PR DESCRIPTION
This is analogous to PR #1856
fixing #1843 on release branch