### PR TITLE
Restyling of search bar

### DIFF
--- a/src/js/actions/search/documents.js
+++ b/src/js/actions/search/documents.js
@@ -38,10 +38,7 @@ define(function (require, exports) {
     var _currDocSearchOptions = function () {
         var appStore = this.flux.store("application"),
             docStore = this.flux.store("document"),
-            document = appStore.getCurrentDocument(),
-            openDocs = appStore.getOpenDocumentIDs().filterNot(function (doc) {
-                            return doc === document.id;
-                        }),
+            openDocs = appStore.getOpenDocumentIDs(),
             docMap = openDocs.map(function (doc) {
                 return {
                     id: doc.toString(),

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -348,7 +348,9 @@ define(function (require, exports, module) {
                 filter: value
             });
 
-            this._updateAutofill(value);
+            if (this.state.filter !== value) {
+                this._updateAutofill(value);
+            }
         },
 
         /**
@@ -486,7 +488,7 @@ define(function (require, exports, module) {
          * @param {Array.<string>} id
          */
         resetInput: function (id) {
-            if (this.state.filter) {
+            if (this.state.filter && id) {
                 var currFilter = this.state.filter.split(" "),
                     idString = _.map(id, function (idWord) {
                         if (strings.SEARCH.CATEGORIES[idWord]) {
@@ -613,9 +615,6 @@ define(function (require, exports, module) {
                         CSSID={this.props.filterIcon}
                         viewbox="0 0 24 24"/>
                 );
-
-                // sneakily resize text box when svg is added
-                size = "column-23";
             }
 
             return (

--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -70,8 +70,8 @@ define(function (require, exports, module) {
                     "select__option__selected": this.props.selected
                 });
 
-            var svgBlock,
-                infoBlock;
+            var svgBlock = null,
+                infoBlock = null;
 
             if (rec.svgType) {
                 svgBlock = (

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -90,6 +90,7 @@ define(function (require, exports, module) {
         shouldComponentUpdate: function (nextProps, nextState) {
             return !Immutable.is(this.props.value, nextProps.value) ||
                 !Immutable.is(this.state.value, nextState.value) ||
+                !Immutable.is(this.props.placeholderText, nextProps.placeholderText) ||
                 this.state.editing !== nextState.editing;
         },
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -588,29 +588,30 @@ define(function (require, exports, module) {
             WEB_1920_1080: "Web"
         },
         SEARCH: {
-            PLACEHOLDER: "Type to search",
+            PLACEHOLDER: "Search, open & select",
+            PLACEHOLDER_FILTER: "Search ",
             NO_OPTIONS: "No options match your search",
             HEADERS: {
                 ALL_LAYER: "Layers",
                 CURRENT_LAYER: "Layers",
                 CURRENT_DOC: "Current Documents",
                 RECENT_DOC: "Recent Documents",
-                MENU_COMMAND: "Menu Commands"
+                MENU_COMMAND: "Menu Commands",
+                FILTER: "Limit search to..."
             },
             CATEGORIES: {
                 CURRENT_DOC: "Current Documents",
                 RECENT_DOC: "Recent Documents",
-                DOCUMENT: "Documents",
                 MENU_COMMAND: "Menu Commands",
                 ALL_LAYER: "Layers",
                 CURRENT_LAYER: "Layers",
-                ARTBOARD: "Artboard",
-                PIXEL: "Pixel",
-                ADJUSTMENT: "Adjustment",
-                TEXT: "Text",
-                VECTOR: "Vector",
-                SMARTOBJECT: "Smart Object",
-                GROUP: "Group"
+                ARTBOARD: "Artboards",
+                PIXEL: "Pixel Layers",
+                ADJUSTMENT: "Adjustment Layers",
+                TEXT: "Text Layers",
+                VECTOR: "Vector Layers",
+                SMARTOBJECT: "Smart Objects",
+                GROUP: "Group Layers"
             },
             MODIFIERS: {
                 COMMAND: "Cmd",

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -21,41 +21,57 @@
  *
  */
 
+@search-bar-width: 50rem;
+@drop-down-width: 46rem;
+@dialog-radius: .4rem;
 
 .search-bar__dialog {
-    background: url(../img/ico-search-white.svg) no-repeat left @warm-black;
-    background-size: 1rem;
-    background-position: 1.5rem 1.5rem;
-    margin-left: -((@properties-width+@toolbar-button-size)/2);
+    background: url(../img/ico-search-white.svg) no-repeat left @search-bg;
+    background-size: 1.2rem;
+    background-position: 1.9rem 1.8rem;
+    top: 25%;
+    left: 25%;
+    transform: none;
+    margin-left: -(@properties-width - @toolbar-width)/2;
 
-    top: 30%;
-    color:@warm-white;
+    width: @search-bar-width;
+    min-height: 5rem;
+    max-height: 60rem; /*this is important for use with dialog.showModa()*/
     line-height: normal;
-    width: 30rem;
-    max-height: 5rem; //this is important for use with dialog.showModa()
-    height:5rem;
-    border-radius: 1rem;    
+    box-shadow: none;
+    border-radius: @dialog-radius;    
+    font-size: 1.6rem;
     overflow: visible;
-
-    font-size: 1.4rem;
 }
 
 .search-bar__dialog .drop-down {
     margin-top: 1rem;
-    margin-left: 3rem;
-    display: inline-block;
+    margin-left: 3.1rem;
 
-    background: rgba(0,0,0,0);
-    color: @warm-gray;
+    border: none;
+    width: @drop-down-width;
+    background: @search-bg;
+}
+
+.search-bar__dialog .drop-down:hover {
+    background: @search-bg;
 }
 
 .search-bar__dialog .drop-down input{
     border: none;
+    font-size: 2rem;
+    margin-left: 1rem;
+    width: 40rem;
+}
+
+.search-bar__dialog ::-webkit-input-placeholder {
+    font-style: italic;
+    color: @color-section-rule;
 }
 
 .search-bar__dialog .drop-down input:focus {
     background: rgba(0,0,0,0);
-    color: @warm-white;
+    color: @search-bright-text;
     border: none;
 }
 
@@ -64,14 +80,11 @@
     border: none;
 }
 
-.search-bar__dialog .drop-down:hover {
-    background: rgba(0,0,0,0);
-}
-
 .search-bar__dialog .drop-down .hidden-input {
+    font-size: 2rem;
     display: inline-block;
     position: absolute;
-    margin-left: .1rem;
+    margin-left: 1.1rem;
     visibility: hidden;
     white-space: pre;
 }
@@ -85,38 +98,76 @@
     background-color: rgba(0,0,0,0.01);
 }
 
-.search-bar__dialog .select__option__selected {
-    color: @highlight;
-    padding-left: .5rem;
-    border-left: .3rem solid @highlight;
-}
-
 .search-bar__dialog svg {
     width: 1.5rem;
     height: 1.5rem;
-    stroke:  @warm-gray;
-    fill: @warm-gray;
+    stroke:  @search-text;
+    fill: @search-text;
     margin-right: 1rem;
 }
 
+.search-bar__dialog .select__option {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
+.search-bar__dialog .select__option__selected {
+    color: @search-highlight;
+    padding-left: .7rem;
+    border-left: .3rem solid @search-highlight;
+    background-color: @search-dropdown-bg;
+}
+
+.search-bar__dialog .select__header {
+    color: @search-border;
+    border-top: @hairline solid @search-border;
+    margin-top: 1rem;
+    margin-bottom: .25rem;
+}
+
+
+.search-bar__dialog .select__header:first-child {
+    border: none;
+    margin-top: .25rem;
+}
+
+.search-bar__dialog .select__option__info {
+    color: @search-border;
+}
+
 .search-bar__dialog .select__option__selected svg {
-    stroke:  @highlight;
-    fill: @highlight; 
+    stroke:  @search-highlight;
+    fill: @search-highlight;
 }
 
 .search-bar__dialog .datalist__svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-right: 0.5rem;
-    stroke:  @warm-gray;
-    fill:  @warm-gray;
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0rem;
+    margin-left: 1rem;
+    padding-top: .5rem;
+    stroke: white;
+    fill: white;
 }
 
 .search-bar__dialog .autocomplete {
     display: inline-block;
     position: absolute;
     color: @color-section-rule;
-    line-height: 2rem;
-    height: 1.6rem;
+    line-height: 2.8rem;
     white-space: pre;
+    font-size: 2rem;
+}
+
+.button-simple.button-clear-search {
+    position: absolute;
+    top: 1.2rem;
+    right: 1.4rem;
+    color: @search-text;
+    font-size:1.5rem;
+    font-weight: bold;
+
+    &:hover {
+        color: @search-bright-text;
+    }
 }

--- a/src/style/shared/animation.less
+++ b/src/style/shared/animation.less
@@ -46,13 +46,11 @@
   }
 }
 
-@-webkit-keyframes revealFromCenter {
+@-webkit-keyframes fadeIn {
   0% {
-    width: 0%;
     opacity: 0;
   }
   100% {
-    width: 80%;
     opacity: 1;
   }
 }

--- a/src/style/shared/colors.less
+++ b/src/style/shared/colors.less
@@ -84,6 +84,14 @@
 /* Marquee */
 @marquee-highlight: #2d8ceb;
 
+/* Search */
+@search-bg: #2d2d2d; 
+@search-dropdown-bg: #1d1d1d; 
+@search-border: #3f3f3f;
+@search-highlight: #035dc8;
+@search-text: #8e8e8e;
+@search-bright-text: #cacaca;
+
 /* General Utilities */
 
 .shadow() {

--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -115,12 +115,18 @@ dialog::backdrop {
 }
 
 .dialog-search-bar {
-    max-height: 40rem;
-    background-color: @warm-black;
-    color: @warm-white;
-    border-radius: .5rem;
+    position: relative;
+    width: 47rem;
+    max-height: 50rem;
+    background-color: @search-dropdown-bg;
+    color: @search-text;
+    border-radius: @dialog-radius;
     box-shadow: none;
-    border: @hairline solid @color-section-rule;
+    border: @hairline solid @search-border;
+    margin-left: -1.5rem;
+    margin-top: -2.8rem;
+    margin-bottom: 5.3rem;
+    -webkit-animation: fadeIn 400ms;
 }
 
 .dialog-stroke-alignment {

--- a/src/style/shared/select.less
+++ b/src/style/shared/select.less
@@ -48,6 +48,7 @@
 
 .select__option__info {
     margin-left: 1rem;
-    color: @warm-gray;
+    color: @color-section-rule;
     font-size: 1.2rem;
+    font-style: italic;
 }


### PR DESCRIPTION
Search bar styling to match the new designs. There are some missing svgs--rectangles currently replace all of the missing item type svgs, the circle on the right will be an X to clear the inputted value, and the magnifying glass will be a different version that is flipped the other direction.

Other changes:
- Show all possible filters, not just if they have corresponding options available. For example, if there are no Smart Objects in the document, still show the Smart Objects filter option.
- Fix broken datalist updating- the filter icon would not always show until the render after selecting the filter.

The designs:
![design-space-search-001](https://cloud.githubusercontent.com/assets/12618145/8995981/cf9b097c-36c9-11e5-84be-0bcd5e0e1d13.png)
![design-space-search-002](https://cloud.githubusercontent.com/assets/12618145/8995982/cf9e01ea-36c9-11e5-859f-2f1b9ba5e792.png)
![design-space-search-003](https://cloud.githubusercontent.com/assets/12618145/8995983/cf9e97a4-36c9-11e5-92c1-b893550d1c1e.png)
![application-search-002](https://cloud.githubusercontent.com/assets/12618145/8995991/d7cb1178-36c9-11e5-8303-756bc235362b.png)
![application-search-005](https://cloud.githubusercontent.com/assets/12618145/8996151/c7dad52c-36ca-11e5-887f-100cb9dc93a3.png)