### PR TITLE
Render the visible subset of layers in the panel based on scroll position

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -30,8 +30,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         classnames = require("classnames"),
-        Immutable = require("immutable"),
-        _ = require("lodash");
+        Immutable = require("immutable");
 
     var Draggable = require("jsx!js/jsx/shared/Draggable"),
         Droppable = require("jsx!js/jsx/shared/Droppable"),
@@ -57,6 +56,12 @@ define(function (require, exports, module) {
             this.props.dragPosition !== nextProps.dragPosition ||
             this.props.dragStyle !== nextProps.dragStyle ||
             this.props.isDropTarget !== nextProps.isDropTarget) {
+            return true;
+        }
+
+        // Margin change
+        if (this.props.marginTop !== nextProps.marginTop ||
+            this.props.marginBottom !== nextProps.marginBottom) {
             return true;
         }
         
@@ -327,9 +332,9 @@ define(function (require, exports, module) {
 
             // Super Hack: If two tooltip regions are flush and have the same title,
             // the plugin does not invalidate the tooltip when moving the mouse from
-            // one region to the other. This is used to make the titles to be different,
+            // one region to the other. This is used to make adjancent titles different,
             // and hence to force the tooltip to be invalidated.
-            var tooltipPadding = _.repeat("\u200b", layerIndex),
+            var tooltipPadding = (this.props.visibleLayerIndex % 2) === 1 ? "\u200b" : "",
                 tooltipTitle = layer.isArtboard ? strings.LAYER_KIND.ARTBOARD : strings.LAYER_KIND[layer.kind],
                 iconID = svgUtil.getSVGClassFromLayer(layer),
                 showHideButton = layer.isBackground ? null : (
@@ -344,8 +349,22 @@ define(function (require, exports, module) {
                     </ToggleButton>
                 );
 
+            var style;
+            if (this.props.marginTop) {
+                style = {
+                    marginTop: this.props.marginTop + "px"
+                };
+            } else if (this.props.marginBottom) {
+                style = {
+                    marginBottom: this.props.marginBottom + "px"
+                };
+            } else {
+                style = null;
+            }
+
             return (
-                <li className={classnames(layerClasses)}>
+                <li className={classnames(layerClasses)}
+                    style={style}>
                     <div
                         style={dragStyle}
                         className={classnames(faceClasses)}


### PR DESCRIPTION
This changes how the layers panel renders the list of layers so that only a window of layers outside the visible area are rendered at once. When the selection changes, or when the scroll position changes, the set of rendered layers changes accordingly. For documents with many (visible) layers, this improves startup time significantly (~30%). It also seems to improve layer selection time from the panel somewhat.

But, there are also two known performance downsides. First, direct on-canvas selection can be slower because it can cause the layers panel to jump far away from it's current scroll position, which can require all the layers in the panel to be re-rendered. Second, scroll is jittery in some instances, especially when scrolling fast, because the necessary DOM changes require a layout, which is synchronous.

The good news is that **both of these slow-downs are significantly less bad in compiled mode** than in debug mode. I don't necessarily know if that makes this PR a net improvement overall. I'm looking for some very honest feedback here. Of course, I would also be very happy to hear suggestions about how to make this faster. For the moment, I'm out of ideas about that. I'm especially looking for feedback from @designedbyscience and @shaoshing, but I would appreciate testing and feedback from everyone! I suggest testing either with the VermilionArtboards document (with all descendants expanded) or with [this helpful document that contains ~1000 layers](http://cloud.wehrman.org/3f2N0T3n1L1h).