### PR TITLE
Fix (#1863) loading a library after creating a Type layer result in errors 

### DIFF
--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
             
             var fontStore = this.getFlux().store("font"),
                 text = this.props.document.layers.selected.first().text,
-                characterStyle = text.characterStyles.first(),
+                characterStyle = text.characterStyle,
                 textHasMissingFont = !fontStore.getFontFamilyFromPostScriptName(characterStyle.postScriptName);
             
             return !textHasMissingFont;

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
             }
 
             var obj = {},
-                textStyle = layer.text.characterStyles.first(),
+                textStyle = layer.text.characterStyle,
                 psName = textStyle.postScriptName,
                 fontObj = this._postScriptMap.get(psName, null);
                 


### PR DESCRIPTION
Just a quick update to reflect to the recent changes in the master.