### PR TITLE
In search for menu commands, replace 'Application' with 'Photoshop CC…

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
         APP_NAME: "Photoshop",
         MENU: {
             APPLICATION: {
-                $MENU: "Application",
+                $MENU: "Photoshop CC",
                 ABOUT_MAC: "About Photoshop…",
                 PREFERENCES: "Preferences…",
                 HIDE_APPLICATION: "Hide Photoshop",


### PR DESCRIPTION
…' on Mac

For issue #1868 