### PR TITLE
Libraries - drag and drop layer

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -520,7 +520,7 @@ define(function (require, exports) {
      * @param {Layer|Immutable.Iterable.<Layer>} layerSpec Either a single layer that
      *  the selection is based on, or an array of such layers
      * @param {string} modifier Way of modifying the selection. Possible values
-     *  are defined in `adapter/lib/layer.js` under `select.vals`
+     *  are defined in `adapter/src/lib/layer.js` under `select.vals`
      *
      * @returns {Promise}
      */

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -354,9 +354,12 @@ define(function (require, exports) {
                     return descriptor.playObject(placeObj);
                 })
                 .then(function () {
+                    // Standard PS will auto select the newly placed layer. This gives us the opportunity 
+                    // to get the new layer ID by getting the "layerID" property of the currently selected layer. 
                     return descriptor.getProperty("layer", "layerID");
                 })
                 .then(function (newLayerID) {
+                    // Update the current document with the new layer id.
                     this.flux.actions.layers.addLayers(currentDocument, newLayerID);
                 });
     };

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -312,7 +312,7 @@ define(function (require, exports, module) {
         return {
             // Don't allow dropping if the position of the draged targets is not inside the Scrim component.
             valid: droppableScrim.state.isMouseOver,
-            compatible: true
+            compatible: droppableScrim.state.isMouseOver
         };
     };
     

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
 
             return {
                 dragTargets: dragAndDropState.dragTargets,
-                dropTarget: dragAndDropState.dropTarget,
+                dropTarget: dragAndDropState.hasValidDropTarget ? dragAndDropState.dropTarget : null,
                 dragPosition: dragAndDropState.dragPosition,
                 pastDragTargets: dragAndDropState.pastDragTargets
             };

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -159,9 +159,9 @@ define(function (require, exports, module) {
             return (
                 <div>
                     {this._getColorAssets(library)}
-                    {this._getGraphicAssets(library)}
                     {this._getCharacterStyleAssets(library)}
                     {this._getLayerStyleAssets(library)}
+                    {this._getGraphicAssets(library)}
                 </div>
             );
         }

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -112,11 +112,18 @@ define(function (require, exports, module) {
          * @return {boolean}
          */
         _canAddGraphic: function () {
-            if (this.props.disabled || this.props.document.layers.selected.isEmpty()) {
+            var selectedLayers = this.props.document.layers.selected;
+            
+            if (this.props.disabled || selectedLayers.isEmpty()) {
+                return false;
+            }
+           
+            // Single linked layer is not accepted, but multiple linked (or mixed) layers are accepted. 
+            if (selectedLayers.size === 1 && selectedLayers.first().isLinked) {
                 return false;
             }
 
-            var layersAreAllEmpty = this.props.document.layers.selected.every(function (layer) {
+            var layersAreAllEmpty = selectedLayers.every(function (layer) {
                 return layer.kind === layer.layerKinds.GROUP && this.props.document.layers.isEmptyGroup(layer);
             }.bind(this));
         

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -28,10 +28,7 @@ define(function (require, exports, module) {
         React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
-
-    var Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
-
+        
     var CharacterStyle = React.createClass({
         mixins: [FluxMixin],
 
@@ -63,16 +60,10 @@ define(function (require, exports, module) {
             return (
                 <div className="sub-header"
                     key={element.id}>
-                    <img src={this.state.renditionPath} />
+                    <div className="assets__character-style__preview">
+                        <img src={this.state.renditionPath} />
+                    </div>
                     "A character style!"
-                    <Button
-                        title="Add to Photoshop"
-                        className="button-plus"
-                        onClick={this._handleAdd}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
                 </div>
             );
         }

--- a/src/js/jsx/sections/libraries/assets/Color.jsx
+++ b/src/js/jsx/sections/libraries/assets/Color.jsx
@@ -28,9 +28,6 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
-
     var Color = React.createClass({
         mixins: [FluxMixin],
 
@@ -101,14 +98,6 @@ define(function (require, exports, module) {
                         }}
                     />
                     {this.state.colorString}
-                    <Button
-                        title="Add to Photoshop"
-                        className="button-plus"
-                        onClick={this._handleAdd}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
                 </div>
             );
         }

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -30,16 +30,14 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         classnames = require("classnames");
 
-    var Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        Draggable = require("jsx!js/jsx/shared/Draggable");
+    var Draggable = require("jsx!js/jsx/shared/Draggable");
 
     var Graphic = React.createClass({
         mixins: [FluxMixin],
 
         getInitialState: function () {
             return {
-                renditionPath: "",
+                renditionPath: null,
                 dragging: false
             };
         },
@@ -51,22 +49,13 @@ define(function (require, exports, module) {
             Promise.fromNode(function (cb) {
                 element.getRenditionPath(40, cb);
             }).bind(this).then(function (path) {
-                this.setState({
-                    renditionPath: path
-                });
+                // Path is undefined if the graphic asset is empty (e.g. empty artboard).
+                if (path) {
+                    this.setState({ renditionPath: path });
+                }
             });
         },
 
-        /**
-         * Handle add layer from graphic asset
-         * @private
-         */
-        _handleAdd: function () {
-            // TODO: new graphic is add to a fixed location. Ideally it should place the new graphic layer 
-            // at the center of the view port.
-            this.getFlux().actions.libraries.createLayerFromElement(this.props.element, { x: 100, y: 100 });
-        },
-        
         /**
          * Create preview of the dragged graphic asset under the cursor.
          * @private
@@ -91,7 +80,8 @@ define(function (require, exports, module) {
 
         render: function () {
             var element = this.props.element,
-                dragPreview = this._renderDragPreview();
+                dragPreview = this._renderDragPreview(),
+                previewImage = this.state.renditionPath && (<img src={this.state.renditionPath}/>);
             
             var classNames = classnames("sub-header", {
                 "assets__graphic_dragging": this.props.isDragging
@@ -101,16 +91,10 @@ define(function (require, exports, module) {
                 <div className={classNames}
                      key={element.id}
                      onMouseDown={this.props.handleDragStart}>
-                    <img src={this.state.renditionPath}/>
+                     <div className="assets__graphic__preview">
+                         {previewImage}
+                     </div>
                     {element.displayName}
-                    <Button
-                        title="Add to Photoshop"
-                        className="button-plus"
-                        onClick={this._handleAdd}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
                     {dragPreview}
                 </div>
             );

--- a/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
@@ -29,9 +29,6 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
-
     var LayerStyle = React.createClass({
         mixins: [FluxMixin],
 
@@ -65,14 +62,6 @@ define(function (require, exports, module) {
                     key={element.id}>
                     <img src={this.state.renditionPath} />
                     {element.displayName}
-                    <Button
-                        title="Add to Photoshop"
-                        className="button-plus"
-                        onClick={this._handleAdd}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
                 </div>
             );
         }

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -218,6 +218,8 @@ define(function (require, exports, module) {
             var dropTargets = this._dropTargetsByZone.get(zone),
                 dropTargetOrderings = this._dropTargetOrderingsByZone.get(zone),
                 foundDropTargetIndex = -1;
+        
+            this._dropTarget = null;
 
             dropTargetOrderings.some(function (key, index) {
                 var dropTarget = dropTargets.get(key),
@@ -232,8 +234,6 @@ define(function (require, exports, module) {
                 foundDropTargetIndex = index;
                 if (valid) {
                     this._dropTarget = dropTarget;
-                } else {
-                    this._dropTarget = null;
                 }
 
                 return true;

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -30,8 +30,8 @@
 }
 
 .layer__dummy {
-    min-height: 1.5rem;
-    max-height: 1.5rem;
+    min-height: 2.5rem;
+    max-height: 2.5rem;
 }
 
 .layer__dummy_drop {

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -233,6 +233,7 @@ input[type="text"].face__name {
     width: @properties-width - 4rem;
     border-radius: @face-border-radius;
     z-index: 1;
+    pointer-events: none;
 }
 
 // Group collapsed state

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -21,12 +21,31 @@
  *
  */
  
- @drag-preview-size: 64px;
+ @graphic-drag-preview-size: 64px;
 
 .libraries {
+    position: relative;
     min-height: 7.5rem;
     flex-grow: 1;
     flex-shrink: 0;
+}
+
+.libraries__content {
+}
+
+.libraries__drop-overlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    background-color: rgba(0,0,0,0.2);
+    z-index: 1;
+    cursor: copy;
+}
+
+.libraries__drop-overlay_disallow {
+    cursor: not-allowed;
 }
 
 .libraries .section-container {
@@ -42,8 +61,8 @@
 // }
 
 .library-color-swatch {
-    width: 3rem;
-    height: 3rem;
+    width: 50px;
+    height: 40px;
     display: flex;
     align-items: center;
     flex-grow: 0;
@@ -86,17 +105,37 @@
 
 .assets__graphic__drag-preview {
     position: fixed;
-    width: @drag-preview-size;
-    height: @drag-preview-size;
-    line-height: @drag-preview-size;
+    width: @graphic-drag-preview-size;
+    height: @graphic-drag-preview-size;
+    line-height: @graphic-drag-preview-size;
     text-align: center;
-    margin-top: -@drag-preview-size/2;
-    margin-left: -@drag-preview-size/2;
+    margin-top: -@graphic-drag-preview-size/2;
+    margin-left: -@graphic-drag-preview-size/2;
     pointer-events: none;
     
     img {
-        max-width: @drag-preview-size;
-        max-height: @drag-preview-size;
+        max-width: @graphic-drag-preview-size;
+        max-height: @graphic-drag-preview-size;
         vertical-align: middle;
     }
+}
+
+.assets__graphic__preview, .assets__character-style__preview { 
+    position: relative;
+    width: 50px;
+    height: 40px;
+    background-color: @warm-white;
+    
+    img {
+        position: absolute;  
+        top: 0;  
+        bottom: 0;  
+        left: 0;  
+        right: 0;  
+        margin: auto;  
+    }
+}
+
+.assets__graphic__preview {
+    .background-checkerboard();
 }


### PR DESCRIPTION
Now you can drag and drop layers into the libraries panel to create graphic asset.

Here are few things worth of mention:

* Adding a single linked layer is prohibited, but multiple or mixed multiple linked layers are accepted (same as standard PS)
* Asset + buttons are removed for now. More discussion is at #1859 
* Dragging a layer down to the libraries panel might cause the libraries panel's scroll event unexpectedly. 

![lib-layer-dnd](https://cloud.githubusercontent.com/assets/118264/9019777/8e6ca086-37a6-11e5-9d33-03277bc61883.gif)