### PR TITLE
Search for recent docs and menu commands when there are no documents

### DIFF
--- a/src/js/actions/search/documents.js
+++ b/src/js/actions/search/documents.js
@@ -107,7 +107,8 @@ define(function (require, exports) {
             "getOptions": _currDocSearchOptions.bind(this),
             "filters": Immutable.List.of("CURRENT_DOC"),
             "handleExecute": _confirmCurrDocSearch.bind(this),
-            "shortenPaths": false
+            "shortenPaths": false,
+            "haveDocument": true
         };
 
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, currentDocPayload);

--- a/src/js/actions/search/layers.js
+++ b/src/js/actions/search/layers.js
@@ -89,9 +89,10 @@ define(function (require, exports) {
     var _getLayerOptionsFromDoc = function (document, type) {
         var appStore = this.flux.store("application"),
             currentID = appStore.getCurrentDocumentID(),
-            layers = document.layers.allVisibleReversed;
+            layers = document.layers.allVisibleReversed,
+            layerItems = [];
         
-        return layers.map(function (layer) {
+        layers.forEach(function (layer) {
             var ancestry,
                 layerType = _getLayerCategory(layer, type),
                 iconID = svgUtil.getSVGClassFromLayer(layer);
@@ -102,14 +103,15 @@ define(function (require, exports) {
                 ancestry = document.name;
             }
 
-            return {
+            layerItems.push({
                 id: document.id.toString() + "_" + layer.id.toString(),
                 name: layer.name,
                 pathInfo: ancestry,
                 iconID: iconID,
                 category: layerType
-            };
+            });
         });
+        return layerItems;
     };
 
     /**
@@ -136,12 +138,12 @@ define(function (require, exports) {
         // Get list of layers
         var appStore = this.flux.store("application"),
             currDoc = appStore.getCurrentDocument(),
-            allLayerMaps = Immutable.List();
+            allLayerMaps = [];
 
         if (currDoc) {
             var documents = appStore.getOpenDocuments();
             // add layers from current document first, then skip it in the loop
-            allLayerMaps = _getLayerOptionsFromDoc.call(this, currDoc, "ALL");
+            allLayerMaps = allLayerMaps.concat(_getLayerOptionsFromDoc.call(this, currDoc, "ALL"));
 
             documents.forEach(function (document) {
                 if (document !== currDoc) {
@@ -150,7 +152,7 @@ define(function (require, exports) {
                 }
             }.bind(this));
         }
-        return allLayerMaps;
+        return Immutable.List(allLayerMaps);
     };
 
     /**

--- a/src/js/actions/search/layers.js
+++ b/src/js/actions/search/layers.js
@@ -136,17 +136,20 @@ define(function (require, exports) {
         // Get list of layers
         var appStore = this.flux.store("application"),
             currDoc = appStore.getCurrentDocument(),
-            documents = appStore.getOpenDocuments(),
+            allLayerMaps = Immutable.List();
+
+        if (currDoc) {
+            var documents = appStore.getOpenDocuments();
             // add layers from current document first, then skip it in the loop
             allLayerMaps = _getLayerOptionsFromDoc.call(this, currDoc, "ALL");
 
-        documents.forEach(function (document) {
-            if (document !== currDoc) {
-                var layerMap = _getLayerOptionsFromDoc.call(this, document, "ALL");
-                allLayerMaps = allLayerMaps.concat(layerMap);
-            }
-        }.bind(this));
-
+            documents.forEach(function (document) {
+                if (document !== currDoc) {
+                    var layerMap = _getLayerOptionsFromDoc.call(this, document, "ALL");
+                    allLayerMaps = allLayerMaps.concat(layerMap);
+                }
+            }.bind(this));
+        }
         return allLayerMaps;
     };
 
@@ -187,7 +190,8 @@ define(function (require, exports) {
             "getOptions": options,
             "filters": filters,
             "handleExecute": _confirmSearch.bind(this),
-            "shortenPaths": true
+            "shortenPaths": true,
+            "haveDocument": true
         };
         
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, payload);

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
             }
 
             var filteredOptionGroups = optionGroups.map(function (options) {
-                var priorities = Immutable.List();
+                var priorities = [];
                 
                 // Build list of option, priority pairs
                 options.forEach(function (option) {
@@ -174,14 +174,14 @@ define(function (require, exports, module) {
                     // Always add headers to list of searchable options
                     // The check to not render if there are no options below it is in Select.jsx
                     if (option.type === "header") {
-                        priorities = priorities.push([option, -1]);
+                        priorities.push([option, -1]);
                         return;
                     }
 
                     var title = option.title.toLowerCase(),
                         category = option.category || [];
  
-                    if (option.id.indexOf("FILTER") === 0) {
+                    if (option.type === "filter") {
                         // If it is the filter option for something that we already have filtered, don't
                         // show that filter option
                         if (_.isEqual(this.state.filter, category)) {
@@ -209,7 +209,7 @@ define(function (require, exports, module) {
 
                     // If haven't typed anything, want to use everything that fits into the category
                     if (searchTerm === "") {
-                        priorities = priorities.push([option, priority]);
+                        priorities.push([option, priority]);
                         return;
                     }
 
@@ -256,11 +256,11 @@ define(function (require, exports, module) {
                     }
 
                     if (useTerm) {
-                        priorities = priorities.push([option, priority]);
+                        priorities.push([option, priority]);
                     }
                 }.bind(this));
 
-                return priorities;
+                return Immutable.List(priorities);
             }.bind(this));
 
             var optionList = filteredOptionGroups.reduce(function (filteredOptions, group) {

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -180,11 +180,18 @@ define(function (require, exports, module) {
 
                     var title = option.title.toLowerCase(),
                         category = option.category || [];
+ 
+                    if (option.id.indexOf("FILTER") === 0) {
+                        // If it is the filter option for something that we already have filtered, don't
+                        // show that filter option
+                        if (_.isEqual(this.state.filter, category)) {
+                            return;
+                        }
 
-                    // If it is the filter option for something that we already have filtered, don't
-                    // show that filter option
-                    if (option.id.indexOf("FILTER") === 0 && _.isEqual(this.state.filter, category)) {
-                        return;
+                        // No document, so don't render document-only filters
+                        if (!this.getFlux().stores.application.getCurrentDocument() && option.haveDocument) {
+                            return;
+                        }
                     }
 
                     // All terms in this.state.filter must be in the option's category

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -189,14 +189,15 @@ define(function (require, exports, module) {
          * {Immutable.List.<string>} payload.filters
          * {handleExecuteCB} payload.handleExecute
          * {boolean} payload.shortenPaths Whether path info should be shortened or not
-         *
+         * {boolean} payload.haveDocument If we need a document to have any options for the type, defaults to false
          */
         _registerSearchType: function (payload) {
             this._registeredSearchTypes[payload.type] = {
                 "getOptions": payload.getOptions,
                 "filters": payload.filters,
                 "handleExecute": payload.handleExecute,
-                "shortenPaths": payload.shortenPaths
+                "shortenPaths": payload.shortenPaths,
+                "haveDocument": payload.haveDocument
             };
         },
 
@@ -307,6 +308,7 @@ define(function (require, exports, module) {
                             svgType: icon,
                             category: categories,
                             style: { "font-style": "italic" },
+                            haveDocument: searchInfo.haveDocument,
                             type: "item"
                         };
                     }) : Immutable.List();

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -284,11 +284,13 @@ define(function (require, exports, module) {
          * @return {Immutable.List.<object>}
          */
         _getFilterOptions: function (searchTypes) {
-            var allFilters = Immutable.List();
+            var allFilters = [];
             searchTypes.forEach(function (types, header) {
                 var searchInfo = this._registeredSearchTypes[header],
                     categories = searchInfo ? searchInfo.filters : null,
-                    filters = categories ? categories.map(function (kind) {
+                    filters = [];
+                if (categories) {
+                    categories.forEach(function (kind) {
                         var idType = kind,
                             title = CATEGORIES[kind];
 
@@ -302,17 +304,17 @@ define(function (require, exports, module) {
                         
                         var icon = svgUtil.getSVGClassesFromFilter(categories);
                         
-                        return {
+                        filters.push({
                             id: id,
                             title: title,
                             svgType: icon,
                             category: categories,
-                            style: { "font-style": "italic" },
+                            style: { "fontStyle": "italic" },
                             haveDocument: searchInfo.haveDocument,
-                            type: "item"
-                        };
-                    }) : Immutable.List();
-
+                            type: "filter"
+                        });
+                    });
+                }
                 allFilters = allFilters.concat(filters);
             }.bind(this, allFilters));
 
@@ -323,7 +325,7 @@ define(function (require, exports, module) {
                 type: "header"
             };
 
-            return allFilters.unshift(header);
+            return Immutable.List(allFilters).unshift(header);
         }
     });
         

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -196,7 +196,7 @@
         },
         "SEARCH": {
             "$action": "search.openSearchBar",
-            "$enable-rule": "have-document"
+            "$enable-rule": "always-except-modal"
         },
         "COMBINE": {
             "$enable-rule": "layers-selected-all-shapes",


### PR DESCRIPTION
You can now open the search bar when there is no document and search recent documents and menu commands to your heart's content. (issue #1888)

I added an optional property to the registered searches in the search store specifying if a category will have any options when there is no document. Then we can ignore those filters when rendering the drop down, so we don't have a bunch of filter options for layers and current documents when there is no open document.