### PR TITLE
Center document when the panel is resized

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -482,25 +482,13 @@ define(function (require, exports) {
     beforeStartup.modal = true;
 
     /**
-     * Center the document after startup.
+     * Handle afterStartup event. 
      *
      * @private
-     * @param {boolean} reset Indicates whether this is being called as part of a reset
      * @return {Promise}
      */
-    var afterStartup = function (reset) {
-        var document = this.flux.store("application").getCurrentDocument();
-
-        if (document && !reset) {
-            // Flag sets whether to zoom to fit app window or not
-            return this.transfer(updateTransform)
-                .bind(this)
-                .then(function () {
-                    return this.transfer(centerBounds, document.bounds, false);
-                });
-        } else {
-            return Promise.resolve();
-        }
+    var afterStartup = function () {
+        return Promise.resolve();
     };
     afterStartup.reads = [locks.PS_APP, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
     afterStartup.writes = [locks.JS_UI, locks.PS_APP, locks.JS_POLICY];

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -482,19 +482,6 @@ define(function (require, exports) {
     beforeStartup.modal = true;
 
     /**
-     * Handle afterStartup event. 
-     *
-     * @private
-     * @return {Promise}
-     */
-    var afterStartup = function () {
-        return Promise.resolve();
-    };
-    afterStartup.reads = [locks.PS_APP, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    afterStartup.writes = [locks.JS_UI, locks.PS_APP, locks.JS_POLICY];
-    afterStartup.modal = true;
-
-    /**
      * Remove event handlers.
      *
      * @private
@@ -525,7 +512,6 @@ define(function (require, exports) {
     exports.zoom = zoom;
 
     exports.beforeStartup = beforeStartup;
-    exports.afterStartup = afterStartup;
     exports.onReset = onReset;
 
     // This module must have a higher priority than the tool action module.


### PR DESCRIPTION
The previous implementation only center the selected document once after startup, leaves the other documents shifted when opening multiple document. This PR will make sure document is centered when the panel is resize (including initial startup), which is the same behavior in standard PS.

Fix issue: #1830 

