### PR TITLE
Search won't lose focus when you click on the dialog itself.

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -100,18 +100,21 @@ define(function (require, exports, module) {
          * Perform action based on ID
          *
          * @param {string} id
+         * @return {boolean} Return true if dropdown dialog should not close 
          */
         _handleChange: function (id) {
             if (id === null) {
                 this.props.dismissDialog();
-                return;
+                return false;
             }
 
             if (id.indexOf("FILTER") === 0) {
                 this._updateFilter(id);
-            } else {
+            } else if (id.indexOf("NO_OPTIONS") !== 0) {
                 this.props.executeOption(id);
+                return false;
             }
+            return true;
         },
 
         /**
@@ -338,6 +341,7 @@ define(function (require, exports, module) {
                         filterOptions={this._filterSearch}
                         useAutofill={true}
                         onChange={this._handleChange}
+                        onClick={this._handleDialogClick}
                         onKeyDown={this._handleKeyDown} />
                     <Button
                         title="Clear Search Input"

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -303,24 +303,25 @@ define(function (require, exports, module) {
                 return;
             }
 
-            var dialog = this.refs.dialog;
-            if (dialog && dialog.isOpen()) {
-                dialog.toggle(event);
-            }
+            var dontCloseDialog = false;
 
             // If this select component is not live, call onChange handler here
             if (!this.props.live) {
                 if (action === "apply") {
-                    this.props.onChange(this.state.id);
+                    dontCloseDialog = this.props.onChange(this.state.id);
                 } else {
-                    this.props.onChange(null);
+                    dontCloseDialog = this.props.onChange(null);
                 }
             }
 
-            this.setState({
-                active: false
-            });
-            this._releaseFocus();
+            if (!dontCloseDialog) {
+                var dialog = this.refs.dialog;
+                if (dialog && dialog.isOpen()) {
+                    dialog.toggle(event);
+                }
+
+                this._handleDialogClose();
+            }
         },
 
         /**
@@ -444,9 +445,9 @@ define(function (require, exports, module) {
                 var suggestionID = suggestion ? suggestion.id : this.state.id,
                     suggestionTitle = suggestion ? suggestion.title : "";
 
-                // If all the options are headers (no confirmable options, then set selected ID to null
+                // If all the options are headers (no confirmable options, then set selected ID to null or placeholder
                 if (!suggestion && collection.uniformValue(collection.pluck(options, "type"))) {
-                    suggestionID = null;
+                    suggestionID = this.props.placeholderOption ? this.props.placeholderOption.first().id : null;
                 }
                
                 this.setState({
@@ -470,6 +471,10 @@ define(function (require, exports, module) {
                 this.setState({
                     suggestTitle: ""
                 });
+            }
+
+            if (this.props.startFocused && this.refs.textInput) {
+                this.refs.textInput._beginEdit(true);
             }
         },
 

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -73,6 +73,7 @@
     font-size: 2rem;
     margin-left: 1rem;
     width: 40rem;
+    color: @search-bright-text;
 }
 
 .search-bar__dialog ::-webkit-input-placeholder {


### PR DESCRIPTION
When you click inside the search dialog or on the "no options match" option, the dialog will no longer lose focus or close. Instead it will remove the autosuggest text (if it exists) and then highlight all the text in the input.

issue #1869 