### PR TITLE
String localization: French, German and Japanese

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,30 @@
 module.exports = function (grunt) {
     "use strict";
 
+    var getRequireOptions = function (locale) {
+        return {
+            options: {
+                baseUrl: "src/",
+                mainConfigFile: "src/js/config.js",
+                name: "js/main",
+                out: "build/js/main-" + locale + ".js",
+                // optimize: "none",
+                paths: {
+                    "react": "../bower_components/react/react-with-addons.min",
+                    "JSXTransformer": "../bower_components/jsx-requirejs-plugin/js/JSXTransformer"
+                },
+                stubModules: ["jsx"],
+                exclude: ["JSXTransformer"],
+                useStrict: true,
+                config: {
+                    i18n: {
+                        locale: locale
+                    }
+                }
+            }
+        };
+    };
+
     grunt.initConfig({
         jshint: {
             options: {
@@ -69,23 +93,11 @@ module.exports = function (grunt) {
             html: { src: "src/index-build.html", dest: "build/index.html" },
             img: { expand: true, cwd: "src/img", src: "**", dest: "build/img/" }
         },
-        requirejs: {
-            compile: {
-                options: {
-                    baseUrl: "src/",
-                    mainConfigFile: "src/js/config.js",
-                    name: "js/main",
-                    out: "build/js/main.js",
-                    // optimize: "none",
-                    paths: {
-                        "react": "../bower_components/react/react-with-addons.min",
-                        "JSXTransformer": "../bower_components/jsx-requirejs-plugin/js/JSXTransformer"
-                    },
-                    stubModules: ["jsx"],
-                    exclude: ["JSXTransformer"],
-                    useStrict: true
-                }
-            }
+        "requirejs": {
+            de: getRequireOptions("de"),
+            en: getRequireOptions("en"),
+            fr: getRequireOptions("fr"),
+            jp: getRequireOptions("jp")
         },
         less: {
             production: {
@@ -94,7 +106,6 @@ module.exports = function (grunt) {
                 }
             }
         }
-
     });
 
     grunt.loadNpmTasks("grunt-jsxhint");
@@ -108,8 +119,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-less");
 
     grunt.registerTask("test", ["jshint", "jscs", "jsdoc", "jsonlint"]);
-    grunt.registerTask("build", [
-        "test", "clean", "copy:requirejs", "copy:html", "copy:img", "requirejs", "less"
-    ]);
+    grunt.registerTask("compile", ["clean", "copy:requirejs", "copy:html", "copy:img", "less", "requirejs"]);
+    grunt.registerTask("build", ["test", "compile"]);
     grunt.registerTask("default", ["test"]);
 };

--- a/src/index-build.html
+++ b/src/index-build.html
@@ -28,6 +28,33 @@
     <link rel="stylesheet" type="text/css" href="style/style.css" />
     <script src="js/require.js"></script>
     <script>
+        var locale = window.navigator.language,
+            parts = locale.match(/\w+/),
+            language = parts.length > 0 && parts[0];
+
+        switch (language) {
+        case "en":
+        case "de":
+        case "fr":
+        case "jp":
+            break;
+        default:
+            language = "en"
+        }
+
+        var localeModuleName = "js/main-" + language;
+
+        require.config({
+            paths: {
+                "js/main": localeModuleName
+            },
+            config: {
+                i18n: {
+                    locale: language
+                }
+            }
+        });
+
         require(["js/main"]);
     </script>
 </head>

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,15 @@
     <script src="../bower_components/less/dist/less.js" type="text/javascript"></script>
     <script src="../bower_components/requirejs/require.js"></script>
     <script src="js/config.js"></script>
-    <script>
+    <script type="text/javascript">
+        require.config({
+            config: {
+                i18n: {
+                    locale: window.navigator.language
+                }
+            }
+        });
+
         require(["js/main"]);
     </script>
 </head>

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -28,7 +28,8 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         keyUtil = require("js/util/key"),
         system = require("js/util/system"),
-        strings = require("i18n!nls/strings");
+        strings = require("i18n!nls/strings"),
+        menuLabels = require("i18n!nls/menu");
 
     var events = require("js/events");
 
@@ -43,20 +44,19 @@ define(function (require, exports) {
      */
     var _getLabelForEntry = function (id) {
         var parts = id.split("."),
-            labels = strings.MENU,
             path = "";
 
         parts.forEach(function (part) {
-            if (labels[part] === undefined) {
+            if (menuLabels[part] === undefined) {
                 path = null;
                 return false;
             }
 
-            if (labels[part].$MENU) {
-                path += labels[part].$MENU + ">";
-                labels = labels[part];
+            if (menuLabels[part].$MENU) {
+                path += menuLabels[part].$MENU + ">";
+                menuLabels = menuLabels[part];
             } else {
-                path += labels[part];
+                path += menuLabels[part];
             }
         });
 

--- a/src/nls/de/menu.js
+++ b/src/nls/de/menu.js
@@ -22,9 +22,18 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        APPLICATION: {
+            ABOUT_MAC: "About Photoshop IN GERMAN…"
+        },
+        HELP: {
+            ABOUT_WIN: "About Photoshop IN GERMAN…"
+        }
+    };
 });

--- a/src/nls/de/shortcuts-mac.js
+++ b/src/nls/de/shortcuts-mac.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/de/shortcuts-win.js
+++ b/src/nls/de/shortcuts-win.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -22,9 +22,15 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        SEARCH: {
+            PLACEHOLDER: "Search, open & select IN GERMAN"
+        }
+    };
 });

--- a/src/nls/fr/menu.js
+++ b/src/nls/fr/menu.js
@@ -22,9 +22,18 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        APPLICATION: {
+            ABOUT_MAC: "About Photoshop IN FRENCH…"
+        },
+        HELP: {
+            ABOUT_WIN: "About Photoshop IN FRENCH…"
+        }
+    };
 });

--- a/src/nls/fr/shortcuts-mac.js
+++ b/src/nls/fr/shortcuts-mac.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/fr/shortcuts-win.js
+++ b/src/nls/fr/shortcuts-win.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -22,9 +22,15 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        SEARCH: {
+            PLACEHOLDER: "Search, open & select IN FRENCH"
+        }
+    };
 });

--- a/src/nls/jp/menu.js
+++ b/src/nls/jp/menu.js
@@ -22,9 +22,18 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        APPLICATION: {
+            ABOUT_MAC: "About Photoshop IN JAPANESE…"
+        },
+        HELP: {
+            ABOUT_WIN: "About Photoshop IN JAPANESE…"
+        }
+    };
 });

--- a/src/nls/jp/shortcuts-mac.js
+++ b/src/nls/jp/shortcuts-mac.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/jp/shortcuts-win.js
+++ b/src/nls/jp/shortcuts-win.js
@@ -22,9 +22,22 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        MENU: {
+            FILE: {
+                NEW: "n"
+            }
+        },
+        GLOBAL: {
+            TOOLS: {
+                SELECT: "v"
+            }
+        }
+    };
 });

--- a/src/nls/jp/strings.js
+++ b/src/nls/jp/strings.js
@@ -22,9 +22,15 @@
  */
 
 /*global define */
+/*jscs:disable maximumLineLength*/
+/*jshint -W101*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    module.exports = {
+        SEARCH: {
+            PLACEHOLDER: "Search, open & select IN JAPANESE"
+        }
+    };
 });

--- a/src/nls/locales.js
+++ b/src/nls/locales.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,5 +26,18 @@
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = require("./locales");
+    /**
+     * The set of locales supported by the application.
+     *
+     * @const
+     * @type {object}
+     */
+    var SUPPORTED_LOCALES = {
+        root: true,
+        de: true,
+        fr: true,
+        jp: true
+    };
+
+    module.exports = SUPPORTED_LOCALES;
 });

--- a/src/nls/shortcuts-mac.js
+++ b/src/nls/shortcuts-mac.js
@@ -21,12 +21,8 @@
  *
  */
 
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = {
-        root: true
-    };
+    module.exports = require("./locales");
 });

--- a/src/nls/shortcuts-win.js
+++ b/src/nls/shortcuts-win.js
@@ -21,12 +21,8 @@
  *
  */
 
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = {
-        root: true
-    };
+    module.exports = require("./locales");
 });

--- a/src/nls/strings.js
+++ b/src/nls/strings.js
@@ -21,12 +21,8 @@
  *
  */
 
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 
-    module.exports = {
-        root: true
-    };
+    module.exports = require("./locales");
 });


### PR DESCRIPTION
This PR makes it possible to additionally load French, German and Japanese language dictionaries based on the locale in use by Photoshop in debug and compiled builds. For now, the dictionaries are copied as-is except for the `About Photoshop...` menu item, which has been edited in the other language dictionaries to show the current language. Later, the localization team will work with translators to update these dictionaries with translations as appropriate.

In debug builds, we just need to configure require to use the locale specified by `navigator.language` before loading the main module. In compiled builds, it's a little more complicated. We concatenate/compile the JavaScript once for each locale, and then at runtime we configure the locale and also alias `js/main` to `js/main-<lang>`, again using `navigator.language`, so that require can figure out that the symbolic path name `js/main` corresponds to the file `build/js/main-de.js`.

