### PR TITLE
Search bugs

### DIFF
--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -115,7 +115,7 @@ define(function (require, exports) {
         var menuStore = this.flux.store("menu"),
             menu = menuStore.getApplicationMenu(),
             menuMap = menu.rootMap,
-            roots = menu.roots;
+            roots = menu.roots.reverse();
 
         var menuCommands = [];
         roots.forEach(function (root) {
@@ -149,7 +149,7 @@ define(function (require, exports) {
             }
         });
 
-        return Immutable.List(menuCommands);
+        return Immutable.List(menuCommands.reverse());
     };
  
     /**

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -75,6 +75,7 @@ define(function (require, exports) {
             keyChar = fullShortcut.keyChar,
             keyCode = fullShortcut.keyCode,
             modifierStrings = strings.SEARCH.MODIFIERS,
+            keyCodeStrings = strings.KEYCODE,
             shortcut = "";
 
         var modifierChars = {
@@ -99,7 +100,7 @@ define(function (require, exports) {
         }
 
         if (keyCode) {
-            shortcut += keyUtil.getKeyCodeString(keyCode);
+            shortcut += keyCodeStrings[keyCode];
         }
 
         return "(" + shortcut + ") ";

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -417,7 +417,6 @@ define(function (require, exports, module) {
                         React.findDOMNode(this.refs.autocomplete).style.left = width + "px";
                     }
                 }
-
             }
         },
 
@@ -517,7 +516,7 @@ define(function (require, exports, module) {
                     filter: ""
                 });
             }
-            
+
             if (this.props.startFocused && this.refs.textInput) {
                 this.refs.textInput._beginEdit(true);
             }

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -407,13 +407,17 @@ define(function (require, exports, module) {
             if (hiddenInput) {
                 // Find width for hidden text input
                 var elRect = hiddenInput.getBoundingClientRect(),
-                    parentEl = hiddenInput.offsetParent,
-                    parentRect = parentEl.getBoundingClientRect(),
-                    width = elRect.width + (elRect.left - parentRect.left);
+                    parentEl = hiddenInput.offsetParent;
+                // parentEl may not exist, for example when hitting escape
+                if (parentEl) {
+                    var parentRect = parentEl.getBoundingClientRect(),
+                        width = elRect.width + (elRect.left - parentRect.left);
 
-                if (this.refs.autocomplete) {
-                    React.findDOMNode(this.refs.autocomplete).style.left = width + "px";
+                    if (this.refs.autocomplete) {
+                        React.findDOMNode(this.refs.autocomplete).style.left = width + "px";
+                    }
                 }
+
             }
         },
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
             return {
                 editing: false,
                 value: this.props.value,
-                selectDisabled: true
+                selectDisabled: false
             };
         },
 
@@ -120,15 +120,17 @@ define(function (require, exports, module) {
                 node.focus();
             }
 
-            if (!this.state.selectDisabled) {
-                // If the component updated and there is selection state, restore it
-                if (window.document.activeElement === node) {
+            if (window.document.activeElement === node) {
+                if (!this.state.selectDisabled) {
+                    // If the component updated and there is selection state, restore it  
                     node.setSelectionRange(0, node.value.length);
+                    
+                    this.setState({
+                        selectDisabled: true
+                    });
+                } else {
+                    node.setSelectionRange(node.selectionEnd, node.selectionEnd);
                 }
-
-                this.setState({
-                    selectDisabled: true
-                });
             }
         },
 
@@ -221,9 +223,10 @@ define(function (require, exports, module) {
          */
         _handleFocus: function (event) {
             var node = React.findDOMNode(this.refs.input);
-
-            node.selectionStart = 0;
-            node.selectionEnd = event.target.value.length;
+            if (!this.state.selectDisabled) {
+                node.selectionStart = 0;
+                node.selectionEnd = event.target.value.length;
+            }
 
             this.props.onFocus(event);
         },
@@ -234,7 +237,7 @@ define(function (require, exports, module) {
          */
         _handleBlur: function (event) {
             if (this.state.editing) {
-                this._commit(event, true);
+                this._commit(event);
             }
 
             if (this.props.onBlur) {
@@ -252,7 +255,7 @@ define(function (require, exports, module) {
          */
         _handleKeyDown: function (event) {
             var key = event.key;
-            
+
             switch (key) {
                 case "Escape":
                     this._reset(event);

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -145,7 +145,8 @@ define(function (require, exports, module) {
          * @return {Immutable.Iterable.<object>}
          */
         getSearchItems: function (id) {
-            var groupedSearchItems = this._registeredSearches[id].searchItems,
+            var groupedSearchItems = this._registeredSearches[id] ?
+                    this._registeredSearches[id].searchItems : Immutable.List(),
                 flatSearchItems = groupedSearchItems.reduce(function (flatItems, itemGroup) {
                     return flatItems.concat(itemGroup);
                 }.bind(this), Immutable.List());

--- a/src/js/util/key.js
+++ b/src/js/util/key.js
@@ -25,8 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var system = require("js/util/system"),
-        os = require("adapter/os"),
-        _ = require("lodash");
+        os = require("adapter/os");
 
     /**
      * Convert a set of semantic key modifers to a sequence of bits, suitable

--- a/src/js/util/key.js
+++ b/src/js/util/key.js
@@ -88,50 +88,6 @@ define(function (require, exports) {
         return modifiers;
     };
 
-    /**
-     * Build table of key codes mapped to readable strings
-     *
-     * @return {object}
-     */
-    var _getKeyCodeTable = function () {
-        var codes = os.eventKeyCode,
-            table = {};
-
-        _.forEach(Object.keys(codes), function (keyCode) {
-            var value = keyCode,
-                words = keyCode.split("_");
-
-            if (keyCode.indexOf("KEY") === 0) {
-                // F1 through F12
-                value = words[1];
-            } else if (keyCode.indexOf("WIN") === 0) {
-                value = "Windows";
-            } else {
-                value = _.reduce(words, function (formatted, word) {
-                    return formatted += word.charAt(0) + word.slice(1).toLowerCase() + " ";
-                }, "");
-            }
-            table[codes[keyCode]] = value.trim();
-        });
-        return table;
-    };
-
-    /*
-     * @type {object}
-    */
-    var keyCodeTable = _getKeyCodeTable();
-    
-    /**
-     * Gets readable string corresponding with keycode
-     *
-     * @param {number} keyCode A key code from os.eventKeyCode
-     * @return {string}
-     */
-    var getKeyCodeString = function (keyCode) {
-        return keyCodeTable[keyCode];
-    };
-
     exports.modifiersToBits = modifiersToBits;
     exports.bitsToModifiers = bitsToModifiers;
-    exports.getKeyCodeString = getKeyCodeString;
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -618,6 +618,37 @@ define(function (require, exports, module) {
                 CONTROL: "Ctrl"
             }
         },
+        KEYCODE: {
+            8: "Backspace",
+            9: "Tab",
+            13: "Enter",
+            27: "Escape",
+            33: "Page Up",
+            34: "Page Down",
+            35: "End",
+            36: "Home",
+            37: "Left Arrow",
+            38: "Up Arrow",
+            39: "Right Arrow",
+            40: "Down Arrow",
+            45: "Insert",
+            46: "Delete",
+            91: "Windows",
+            92: "Windows",
+            93: "Windows Menu",
+            112: "F1",
+            113: "F2",
+            114: "F3",
+            115: "F4",
+            116: "F5",
+            117: "F6",
+            118: "F7",
+            119: "F8",
+            120: "F9",
+            121: "F10",
+            122: "F11",
+            123: "F12"
+        },
         ERR: {
             UNRECOVERABLE: "Design Space has encountered an unrecoverable error."
         }


### PR DESCRIPTION
1. Issue #1912: puts menu commands in their default order
2. Issue #1825: we now have a lovely table for looking up localized keyCode names by their integer values
3. Fixes bug where input text was highlighted when you click on the search bar itself or when applying a filter where you had more text (for example if I typed "mylayer tex" and then applied the text filter, the remaining "mylayer" would be highlighted instead of leaving the cursor at the end)
4. Prevent error from not having registered search when finding search items and from closing dialog with escape
