### PR TITLE
Apply new os.getTempFilename api in graphic asset creation.

### DIFF
--- a/src/js/util/path.js
+++ b/src/js/util/path.js
@@ -48,6 +48,22 @@ define(function (require, exports) {
 
         return path.substring(index + 1);
     };
+    
+    /**
+     * Return the directory name of a path.
+     * e.g. /foo/bar/baz -> /foo/bar
+     *
+     * @param {!string} path
+     * @return {string}
+     */
+    var dirname = function (path) {
+        var index = path.lastIndexOf(sep);
+        if (index === -1) {
+            return path;
+        }
+
+        return path.substring(0, index);
+    };
 
     /**
      * Extract the extension of a path. Empty if no extension
@@ -121,6 +137,7 @@ define(function (require, exports) {
     exports.sep = sep;
     exports.basename = basename;
     exports.extension = extension;
+    exports.dirname = dirname;
 
     exports.getShortestUniquePaths = getShortestUniquePaths;
 });


### PR DESCRIPTION
Using `os.getTempFilename` makes `createElementFromSelecteLayers` safe to run on different platforms.