### PR TITLE
More search bugs

### DIFF
--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -27,17 +27,30 @@ define(function (require, exports) {
     var dialog = require("./dialog");
 
     /**
+     * The search bar dialog ID
+     * 
+     * @const
+     * @type {string} 
+     */
+    var ID = "search-bar-dialog";
+
+    /**
      * Open the Search dialog
      *
      * @return {Promise}
      */
-    var openSearchBar = function () {
-        return this.transfer(dialog.openDialog, "search-bar-dialog");
+    var toggleSearchBar = function () {
+        var dialogState = this.flux.stores.dialog.getState(),
+            open = dialogState.openDialogs.contains(ID);
+
+        if (open) {
+            return this.transfer(dialog.closeDialog, ID);
+        }
+        return this.transfer(dialog.openDialog, ID);
     };
     openSearchBar.reads = [];
     openSearchBar.writes = [];
     openSearchBar.transfers = [dialog.openDialog];
 
-
-    exports.openSearchBar = openSearchBar;
+    exports.toggleSearchBar = toggleSearchBar;
 });

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -48,9 +48,9 @@ define(function (require, exports) {
         }
         return this.transfer(dialog.openDialog, ID);
     };
-    openSearchBar.reads = [];
-    openSearchBar.writes = [];
-    openSearchBar.transfers = [dialog.openDialog];
+    toggleSearchBar.reads = [];
+    toggleSearchBar.writes = [];
+    toggleSearchBar.transfers = [dialog.openDialog, dialog.closeDialog];
 
     exports.toggleSearchBar = toggleSearchBar;
 });

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -44,19 +44,20 @@ define(function (require, exports) {
      */
     var _getLabelForEntry = function (id) {
         var parts = id.split("."),
-            path = "";
+            path = "",
+            currMenuLabels = menuLabels;
 
         parts.forEach(function (part) {
-            if (menuLabels[part] === undefined) {
+            if (currMenuLabels[part] === undefined) {
                 path = null;
                 return false;
             }
 
-            if (menuLabels[part].$MENU) {
-                path += menuLabels[part].$MENU + ">";
-                menuLabels = menuLabels[part];
+            if (currMenuLabels[part].$MENU) {
+                path += currMenuLabels[part].$MENU + ">";
+                currMenuLabels = currMenuLabels[part];
             } else {
-                path += menuLabels[part];
+                path += currMenuLabels[part];
             }
         });
 

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -137,7 +137,7 @@ define(function (require, exports) {
                         shortcut = _getShortcut(currItem.shortcut);
                     }
 
-                    if (currItem.label !== "Search" && ancestry) {
+                    if (ancestry) {
                         menuCommands.push({
                             id: currItem.id,
                             name: currItem.label,

--- a/src/js/jsx/help/KeyboardShortcuts.jsx
+++ b/src/js/jsx/help/KeyboardShortcuts.jsx
@@ -60,7 +60,10 @@ define(function (require, exports, module) {
                     shortcuts.SELECT_TOOL.HOLD_SEL_WIN,
                 targetLayerInstruction = system.isMac ?
                     shortcuts.SELECT_TOOL.TARGET_LAYER_MAC :
-                    shortcuts.SELECT_TOOL.TARGET_LAYER_WIN;
+                    shortcuts.SELECT_TOOL.TARGET_LAYER_WIN,
+                searchInstruction = system.isMac ?
+                    shortcuts.TOOLS.SEARCH_INSTRUCTION_MAC :
+                    shortcuts.TOOLS.SEARCH_INSTRUCTION_WIN;
             
             return (
                 <div className="keyboard-shortcut__content" onClick={this._dismissDialog}>
@@ -90,6 +93,12 @@ define(function (require, exports, module) {
                             <li>
                                 <span className="keyboard-shortcut__name">{shortcuts.TOOLS.SAMPLER}</span>
                                 <span className="keyboard-shortcut__instr">I</span>
+                            </li>
+                            <li>
+                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.SEARCH}</span>
+                                <span className="keyboard-shortcut__instr">
+                                    {searchInstruction}
+                                </span>
                             </li>
                         </ul>
                     </div>

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -284,8 +284,12 @@ define(function (require, exports, module) {
                 case "Tab": {
                     var id = this.refs.datalist.getSelected();
                     
-                    if (id && id.indexOf("FILTER") === 0) {
-                        this._updateFilter(id);
+                    if (id) {
+                        if (id.indexOf("FILTER") === 0) {
+                            this._updateFilter(id);
+                        } else if (id.indexOf("NO_OPTIONS") === 0) {
+                            this._handleDialogClick(event);
+                        }
                     }
                     
                     break;

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -341,7 +341,8 @@ define(function (require, exports, module) {
                         useAutofill={true}
                         onChange={this._handleChange}
                         onClick={this._handleDialogClick}
-                        onKeyDown={this._handleKeyDown} />
+                        onKeyDown={this._handleKeyDown}
+                        neverSelectAllInput={true} />
                     <Button
                         title="Clear Search Input"
                         className="button-clear-search"

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -50,7 +50,8 @@ define(function (require, exports, module) {
             placeholderText: React.PropTypes.string,
             // option to render when there are no other valid options to display
             placeholderOption: React.PropTypes.instanceOf(Immutable.Iterable),
-            useAutofill: React.PropTypes.bool // displays a suggested option next to the inputted text
+            useAutofill: React.PropTypes.bool, // displays a suggested option next to the inputted text
+            neverSelectAllInput: React.PropTypes.bool // if true, will not highlight input text on commit
         },
 
         getDefaultProps: function () {
@@ -60,7 +61,8 @@ define(function (require, exports, module) {
                 live: true,
                 startFocused: false,
                 placeholderText: "",
-                useAutofill: false
+                useAutofill: false,
+                neverSelectAllInput: false
             };
         },
 
@@ -235,7 +237,8 @@ define(function (require, exports, module) {
                 break;
             case "Tab":
                 if (!this.props.live && this.props.onKeyDown &&
-                        this.state.id && this.state.id.indexOf("FILTER") === 0) {
+                        this.state.id && (this.state.id.indexOf("FILTER") === 0 ||
+                        this.state.id.indexOf("NO_OPTIONS") === 0)) {
                     this.props.onKeyDown(event);
                     event.preventDefault();
                     return;
@@ -433,7 +436,7 @@ define(function (require, exports, module) {
                 var valueLowerCase = value ? value.toLowerCase() : "",
                     lastWord = valueLowerCase.split(" ").pop(),
                     options = this._filterOptions(valueLowerCase, false),
-                    
+
                     // First check if there's anything based on the whole search value
                     suggestion = (options && valueLowerCase !== "") ? options.find(function (opt) {
                             return ((opt.type === "item" || opt.type === "filter") &&
@@ -641,6 +644,7 @@ define(function (require, exports, module) {
                         continuous={true}
                         value={title}
                         placeholderText={this.props.placeholderText}
+                        neverSelectAll={this.props.neverSelectAllInput}
                         onFocus={this._handleInputFocus}
                         onKeyDown={this._handleInputKeyDown}
                         onChange={this._handleInputChange}

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -249,7 +249,8 @@ define(function (require, exports, module) {
             case "Enter":
             case "Return":
                 if (!this.props.live && this.props.onKeyDown &&
-                        this.state.id && this.state.id.indexOf("FILTER") === 0) {
+                        this.state.id && (this.state.id.indexOf("FILTER") === 0 ||
+                        this.state.id.indexOf("NO_OPTIONS") === 0)) {
                     this.props.onKeyDown(event);
                     return;
                 } else {
@@ -429,19 +430,21 @@ define(function (require, exports, module) {
         _updateAutofill: function (value) {
             if (this.props.useAutofill) {
                 // Find new autofill suggestion
-                // First check if there's anything based on the whole search value
-                // Otherwise suggest based on last word typed
                 var valueLowerCase = value ? value.toLowerCase() : "",
                     lastWord = valueLowerCase.split(" ").pop(),
                     options = this._filterOptions(valueLowerCase, false),
-
+                    
+                    // First check if there's anything based on the whole search value
                     suggestion = (options && valueLowerCase !== "") ? options.find(function (opt) {
-                            return (opt.type === "item" && opt.title.toLowerCase().indexOf(valueLowerCase) === 0);
+                            return ((opt.type === "item" || opt.type === "filter") &&
+                                opt.title.toLowerCase().indexOf(valueLowerCase) === 0);
                         }) : null;
 
+                // Otherwise suggest based on last word typed
                 if (!suggestion) {
                     suggestion = (options && lastWord !== "") ? options.find(function (opt) {
-                        return (opt.type === "item" && opt.title.toLowerCase().indexOf(lastWord) === 0);
+                        return ((opt.type === "item" || opt.type === "filter") &&
+                            opt.title.toLowerCase().indexOf(lastWord) === 0);
                     }) : null;
                 }
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -63,7 +63,8 @@ define(function (require, exports, module) {
             onDOMChange: React.PropTypes.func,
             onFocus: React.PropTypes.func,
             editable: React.PropTypes.bool,
-            placeholderText: React.PropTypes.string
+            placeholderText: React.PropTypes.string,
+            neverSelectAll: React.PropTypes.bool // never highlight text, regardless of this.state.selectDisabled
         },
 
         getDefaultProps: function () {
@@ -75,7 +76,8 @@ define(function (require, exports, module) {
                 editable: false,
                 live: false,
                 continuous: false,
-                placeholderText: ""
+                placeholderText: "",
+                neverSelectAll: false
             };
         },
 
@@ -83,7 +85,7 @@ define(function (require, exports, module) {
             return {
                 editing: false,
                 value: this.props.value,
-                selectDisabled: false
+                selectDisabled: true
             };
         },
 
@@ -120,17 +122,14 @@ define(function (require, exports, module) {
                 node.focus();
             }
 
-            if (window.document.activeElement === node) {
-                if (!this.state.selectDisabled) {
+            if (!this.state.selectDisabled && !this.props.neverSelectAll) {
+                if (window.document.activeElement === node) {
                     // If the component updated and there is selection state, restore it  
                     node.setSelectionRange(0, node.value.length);
-                    
-                    this.setState({
-                        selectDisabled: true
-                    });
-                } else {
-                    node.setSelectionRange(node.selectionEnd, node.selectionEnd);
                 }
+                this.setState({
+                    selectDisabled: true
+                });
             }
         },
 
@@ -223,7 +222,7 @@ define(function (require, exports, module) {
          */
         _handleFocus: function (event) {
             var node = React.findDOMNode(this.refs.input);
-            if (!this.state.selectDisabled) {
+            if (!this.props.neverSelectAll) {
                 node.selectionStart = 0;
                 node.selectionEnd = event.target.value.length;
             }

--- a/src/nls/root/menu.js
+++ b/src/nls/root/menu.js
@@ -94,7 +94,8 @@ define(function (require, exports, module) {
             DESELECT: "Deselect",
             INVERT_SELECTION: "Invert Selection",
             COPY_LAYER_STYLE: "Copy Layer Style",
-            PASTE_LAYER_STYLE: "Paste Layer Style"
+            PASTE_LAYER_STYLE: "Paste Layer Style",
+            SEARCH: "Search"
         },
         LAYER: {
             $MENU: "Layer",
@@ -102,7 +103,6 @@ define(function (require, exports, module) {
             FIND_LAYER: "Find Layer…",
             RENAME_LAYER: "Rename Layer…",
             MERGE_LAYERS: "Merge Layers",
-            SEARCH: "Search",
             COMBINE: {
                 $MENU: "Combine",
                 COMBINE_UNION: "Union",

--- a/src/nls/root/shortcuts-mac.js
+++ b/src/nls/root/shortcuts-mac.js
@@ -56,10 +56,10 @@ define(function (require, exports, module) {
                 SELECT_ALL: "a",
                 DESELECT: "a",
                 COPY_LAYER_STYLE: "c",
-                PASTE_LAYER_STYLE: "v"
+                PASTE_LAYER_STYLE: "v",
+                SEARCH: "f"
             },
             LAYER: {
-                SEARCH: "f",
                 EDIT_VECTOR_MASK: "k"
             },
             ARRANGE: {

--- a/src/nls/root/shortcuts-win.js
+++ b/src/nls/root/shortcuts-win.js
@@ -52,10 +52,10 @@ define(function (require, exports, module) {
                 SELECT_ALL: "a",
                 DESELECT: "a",
                 COPY_LAYER_STYLE: "c",
-                PASTE_LAYER_STYLE: "v"
+                PASTE_LAYER_STYLE: "v",
+                SEARCH: "f"
             },
             LAYER: {
-                SEARCH: "f",
                 EDIT_VECTOR_MASK: "k"
             },
             ARRANGE: {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -125,7 +125,10 @@ define(function (require, exports, module) {
                 ELLIPSE: "Ellipse",
                 PEN: "Pen",
                 TYPE: "Type",
-                SAMPLER: "Sampler"
+                SAMPLER: "Sampler",
+                SEARCH: "Search",
+                SEARCH_INSTRUCTION_MAC: "Cmd + F",
+                SEARCH_INSTRUCTION_WIN: "Ctrl + F"
             },
             SELECT_TOOL: {
                 TARGET: "Target Nested Group / Layers",
@@ -382,7 +385,7 @@ define(function (require, exports, module) {
         SEARCH: {
             PLACEHOLDER: "Search, open & select",
             PLACEHOLDER_FILTER: "Search ",
-            NO_OPTIONS: "No options match your search",
+            NO_OPTIONS: "No results match your search",
             HEADERS: {
                 ALL_LAYER: "Layers",
                 CURRENT_LAYER: "Layers",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -174,8 +174,11 @@
         "PASTE_LAYER_STYLE": {
             "$action": "sampler.pasteLayerStyle",
             "$enable-rule": "layers-selected-1"
+        },
+        "SEARCH": {
+            "$action": "search.toggleSearchBar",
+            "$enable-rule": "always-except-modal"
         }
-
     },
     "LAYER": {
         "$enable-rule": "always",
@@ -202,10 +205,6 @@
                 },
                 "$enable-rule": "layer-selected"
             }
-        },
-        "SEARCH": {
-            "$action": "search.openSearchBar",
-            "$enable-rule": "always-except-modal"
         },
         "COMBINE": {
             "$enable-rule": "layers-selected-all-shapes",

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -271,21 +271,24 @@
                             "option": true
                         }
                     }
-                }   
+                },
+                {
+                    "separator": true
+                },
+                {
+                    "id": "SEARCH",
+                    "shortcut": {
+                        "keyChar": "f",
+                        "modifiers": {
+                            "command": true
+                        }
+                    }
+                }  
             ]
         },
         {
             "id": "LAYER",
             "submenu": [
-                {
-                    "id": "SEARCH",
-                    "shortcut": {
-                        "keyChar": true,
-                        "modifiers": {
-                            "command": true
-                        }
-                    }
-                },
                 {
                     "id": "COMBINE",
                     "submenu": [

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -235,21 +235,24 @@
                             "alt": true
                         }
                     }
+                },
+                {
+                    "separator": true
+                },
+                {
+                    "id": "SEARCH",
+                    "shortcut": {
+                        "keyChar": "f",
+                        "modifiers": {
+                            "control": true
+                        }
+                    }
                 }
             ]
         },
         {
             "id": "LAYER",
             "submenu": [
-                {
-                    "id": "SEARCH",
-                    "shortcut": {
-                        "keyChar": true,
-                        "modifiers": {
-                            "control": true
-                        }
-                    }
-                },
                 {
                     "id": "COMBINE",
                     "submenu": [


### PR DESCRIPTION
:bug: :bee: :beetle: :snail: :ant: 

-#1929 Put search shortcut in the Keyboard Shortcuts dialog and moved the command to `Window` from `Layer`, but if the executive decision is to put it in `Edit` (or somewhere else), I can move it again.

-I was also dissatisfied with how things looked after 507b561bf74b2acfe2b800472121b2013010b704, since the text would sometimes highlight momentarily before going to the end of the word, so I undid most of those changes and added a prop to TextInput for when we will never be selecting all text. I think it now looks cleaner and means there are fewer changes in `TextInput.jsx`

-Also #1930, #1931, #1932