### PR TITLE
Correctly represent different graphic assets

### DIFF
--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -173,6 +173,13 @@ define(function (require, exports, module) {
         isLinked: false,
 
         /**
+         * If layer is a smart object, contains the smart object information
+         *
+         * @type {object}
+         */
+        smartObject: null,
+
+        /**
          * Indicates whether the layer used to have layer effect or not. If yes, the layer will have
          * a hidden layer effect that makes the extended property descriptor works, even if the layer
          * may not have any existing layer effect.
@@ -435,6 +442,7 @@ define(function (require, exports, module) {
         object.assignIf(model, "blendMode", _extractBlendMode(layerDescriptor));
         object.assignIf(model, "isLinked", _extractIsLinked(layerDescriptor));
         object.assignIf(model, "usedToHaveLayerEffect", _extractHasLayerEffect(layerDescriptor));
+        object.assignIf(model, "smartObject", layerDescriptor.smartObject);
 
         return new Layer(model);
     };
@@ -471,6 +479,8 @@ define(function (require, exports, module) {
         object.assignIf(model, "blendMode", _extractBlendMode(layerDescriptor));
         object.assignIf(model, "isLinked", _extractIsLinked(layerDescriptor));
         object.assignIf(model, "usedToHaveLayerEffect", _extractHasLayerEffect(layerDescriptor));
+        object.assignIf(model, "smartObject", layerDescriptor.smartObject);
+
 
         return this.merge(model);
     };
@@ -489,6 +499,14 @@ define(function (require, exports, module) {
      */
     Layer.prototype.isTextLayer = function () {
         return this.kind === this.layerKinds.TEXT;
+    };
+
+    /**
+     * True if the layer is a smart object
+     * @return {boolean}
+     */
+    Layer.prototype.isSmartObject = function () {
+        return this.kind === this.layerKinds.SMARTOBJECT;
     };
 
     module.exports = Layer;

--- a/src/js/util/path.js
+++ b/src/js/util/path.js
@@ -50,6 +50,23 @@ define(function (require, exports) {
     };
 
     /**
+     * Extract the extension of a path. Empty if no extension
+     *
+     * @param {!string} path
+     * @return {string}
+     */
+    var extension = function (path) {
+        var filename = basename(path),
+            index = filename.lastIndexOf(".");
+
+        if (index === -1) {
+            return "";
+        }
+
+        return filename.substring(index + 1);
+    };
+
+    /**
      * Given a list of paths, reduces them to shortest unique paths
      * Example:
      * Input:
@@ -103,6 +120,7 @@ define(function (require, exports) {
 
     exports.sep = sep;
     exports.basename = basename;
+    exports.extension = extension;
 
     exports.getShortestUniquePaths = getShortestUniquePaths;
 });


### PR DESCRIPTION
Addresses #1860. Problem was, we were forcing all graphic assets to be Photoshop assets, which was confusing both Photoshop and library panel. This should provide more parity with the Classic panel.

@shaoshing Please review.