### PR TITLE
Local lock declarations

### DIFF
--- a/src/js/actions/application.js
+++ b/src/js/actions/application.js
@@ -79,8 +79,9 @@ define(function (require, exports) {
 
         return Promise.join(setRulerUnitsPromise, updateRecentFilesPromise);
     };
-    afterStartup.reads = [locks.PS_APP];
-    afterStartup.writes = [locks.JS_APP];
+    afterStartup.reads = [];
+    afterStartup.writes = [locks.PS_APP];
+    afterStartup.transfers = [updateRecentFiles];
 
     exports.hostVersion = hostVersion;
     exports.updateRecentFiles = updateRecentFiles;

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -32,6 +32,7 @@ define(function (require, exports) {
     var events = require("../events"),
         locks = require("../locks"),
         layers = require("js/actions/layers"),
+        menu = require("./menu"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
         history = require("js/actions/history");
@@ -88,13 +89,14 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var nativeCut = function () {
-        return this.flux.actions.menu.nativeModal({
+        return this.transfer(menu.nativeModal, {
             commandID: CUT_NATIVE_MENU_COMMMAND_ID
         });
     };
     nativeCut.modal = true;
     nativeCut.reads = [];
     nativeCut.writes = [];
+    nativeCut.transfers = [menu.nativeModal];
 
     /**
      * Execute a native copy command.
@@ -103,13 +105,14 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var nativeCopy = function () {
-        return this.flux.actions.menu.nativeModal({
+        return this.transfer(menu.nativeModal, {
             commandID: COPY_NATIVE_MENU_COMMMAND_ID
         });
     };
     nativeCopy.modal = true;
     nativeCopy.reads = [];
     nativeCopy.writes = [];
+    nativeCopy.transfers = [menu.nativeModal];
 
     /**
      * Execute a native paste command.
@@ -118,13 +121,14 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var nativePaste = function () {
-        return this.flux.actions.menu.nativeModal({
+        return this.transfer(menu.nativeModal, {
             commandID: PASTE_NATIVE_MENU_COMMMAND_ID
         });
     };
     nativePaste.modal = true;
     nativePaste.reads = [];
     nativePaste.writes = [];
+    nativePaste.transfers = [menu.nativeModal];
 
     /**
      * Execute a native selectAll command.
@@ -136,7 +140,7 @@ define(function (require, exports) {
     var nativeSelectAll = function (waitForCompletion) {
         waitForCompletion = waitForCompletion || false;
 
-        return this.flux.actions.menu.nativeModal({
+        return this.transfer(menu.nativeModal, {
             commandID: SELECT_ALL_NATIVE_MENU_COMMMAND_ID,
             waitForCompletion: waitForCompletion
         });
@@ -144,6 +148,7 @@ define(function (require, exports) {
     nativeSelectAll.modal = true;
     nativeSelectAll.reads = [];
     nativeSelectAll.writes = [];
+    nativeSelectAll.transfers = [menu.nativeModal];
 
     /**
      * Execute either a cut or copy operation, depending on the value of the parameter.
@@ -186,9 +191,9 @@ define(function (require, exports) {
                 // If we're on modal state (type edit), we should go with native copy/cut
                 if (this.flux.store("tool").getModalToolState()) {
                     if (cut) {
-                        this.flux.actions.edit.nativeCut();
+                        return this.transfer(nativeCut);
                     } else {
-                        this.flux.actions.edit.nativeCopy();
+                        return this.transfer(nativeCopy);
                     }
                 } else if (!cut) {
                     var applicationStore = this.flux.store("application"),
@@ -221,8 +226,9 @@ define(function (require, exports) {
         return _cutOrCopy.call(this, true);
     };
     cut.modal = true;
-    cut.reads = [];
-    cut.writes = [locks.JS_DOC, locks.PS_DOC];
+    cut.reads = [locks.JS_TOOL, locks.PS_APP];
+    cut.writes = [locks.JS_DOC, locks.PS_DOC, locks.OS_CLIPBOARD];
+    cut.transfers = [nativeCut];
 
     /**
      * Execute a copy operation on the currently active HTML element.
@@ -234,8 +240,9 @@ define(function (require, exports) {
         return _cutOrCopy.call(this, false);
     };
     copy.modal = true;
-    copy.reads = [locks.JS_DOC];
-    copy.writes = [];
+    copy.reads = [locks.JS_DOC, locks.JS_TOOL, locks.PS_APP];
+    copy.writes = [locks.OS_CLIPBOARD];
+    copy.transfers = [nativeCopy];
 
     /**
      * Execute a paste operation on the currently active HTML element.
@@ -275,8 +282,7 @@ define(function (require, exports) {
                         .then(function (result) {
                             var format = result.format;
                             if (format !== LAYER_CLIPBOARD_FORMAT) {
-                                this.flux.actions.edit.nativePaste();
-                                return Promise.resolve();
+                                return this.transfer(nativePaste);
                             }
 
                             var applicationStore = this.flux.store("application"),
@@ -312,8 +318,9 @@ define(function (require, exports) {
             });
     };
     paste.modal = true;
-    paste.reads = [locks.JS_APP, locks.JS_TOOL];
-    paste.writes = [locks.JS_DOC, locks.PS_DOC, locks.PS_APP, locks.JS_POLICY];
+    paste.reads = [locks.JS_DOC, locks.JS_APP, locks.OS_CLIPBOARD, locks.PS_APP];
+    paste.writes = [];
+    paste.transfers = [layers.duplicate, nativePaste];
 
     /**
      * Execute a select operation on the currently active HTML element.
@@ -333,16 +340,17 @@ define(function (require, exports) {
                 } else {
                     var toolStore = this.flux.store("tool");
                     if (toolStore.getModalToolState()) {
-                        this.flux.actions.edit.nativeSelectAll();
+                        return this.transfer(nativeSelectAll);
                     } else {
-                        this.flux.actions.layers.selectAll();
+                        return this.transfer(layers.selectAll);
                     }
                 }
             });
     };
     selectAll.modal = true;
-    selectAll.reads = [];
+    selectAll.reads = [locks.JS_TOOL, locks.PS_APP];
     selectAll.writes = [];
+    selectAll.transfers = [layers.selectAll];
 
     /**
      * Step Backwards by transferring to the appropriate history action
@@ -363,8 +371,9 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
-    undo.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    undo.writes = [locks.JS_DOC, locks.JS_HISTORY, locks.PS_APP, locks.JS_POLICY];
+    undo.reads = [locks.JS_APP, locks.JS_DOC];
+    undo.writes = [locks.JS_UI];
+    undo.transfers = [history.decrementHistory];
 
     /**
      * Step Forward by transferring to the appropriate history action
@@ -385,8 +394,9 @@ define(function (require, exports) {
                 }.bind(this));
         }
     };
-    redo.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    redo.writes = [locks.JS_DOC, locks.JS_HISTORY, locks.PS_APP, locks.JS_POLICY];
+    redo.reads = [locks.JS_APP, locks.JS_DOC];
+    redo.writes = [locks.JS_UI];
+    redo.transfers = [history.incrementHistory];
 
     exports.nativeCut = nativeCut;
     exports.nativeCopy = nativeCopy;

--- a/src/js/actions/example.js
+++ b/src/js/actions/example.js
@@ -44,6 +44,7 @@ define(function (require, exports) {
 
         return Promise.resolve();
     };
+    syncAction.writes = locks.ALL_LOCKS;
 
     /**
      * Example asynchronous command. Returned promise does not resolve until all

--- a/src/js/actions/help.js
+++ b/src/js/actions/help.js
@@ -38,7 +38,8 @@ define(function (require, exports) {
         return this.transfer(dialog.openDialog, "first-launch-dialog");
     };
     openFirstLaunch.reads = [];
-    openFirstLaunch.writes = [locks.JS_DIALOG];
+    openFirstLaunch.writes = [];
+    openFirstLaunch.transfers = [dialog.openDialog];
 
     /**
      * Open the keyboard shortcuts dialog.
@@ -49,7 +50,8 @@ define(function (require, exports) {
         return this.transfer(dialog.openDialog, "keyboard-shortcut-dialog");
     };
     openKeyboardShortcuts.reads = [];
-    openKeyboardShortcuts.writes = [locks.JS_DIALOG];
+    openKeyboardShortcuts.writes = [];
+    openKeyboardShortcuts.transfers = [dialog.openDialog];
 
     /**
      * After startup, display the "first launch" dialog, 
@@ -67,7 +69,8 @@ define(function (require, exports) {
         }
     };
     afterStartup.reads = [locks.JS_PREF];
-    afterStartup.writes = [locks.JS_DIALOG];
+    afterStartup.writes = [];
+    afterStartup.transfers = [openFirstLaunch];
 
     exports.openFirstLaunch = openFirstLaunch;
     exports.openKeyboardShortcuts = openKeyboardShortcuts;

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -65,7 +65,7 @@ define(function (require, exports) {
             });
     };
     queryCurrentHistory.reads = [locks.PS_DOC];
-    queryCurrentHistory.writes = [locks.JS_DOC];
+    queryCurrentHistory.writes = [locks.JS_HISTORY];
     queryCurrentHistory.modal = true;
 
     /**
@@ -92,7 +92,7 @@ define(function (require, exports) {
         };
         return this.dispatchAsync(events.history.PS_HISTORY_EVENT, payload);
     };
-    handleHistoryState.reads = [locks.JS_DOC, locks.PS_DOC];
+    handleHistoryState.reads = [locks.JS_DOC, locks.JS_APP];
     handleHistoryState.writes = [locks.JS_HISTORY];
 
     /**
@@ -186,8 +186,9 @@ define(function (require, exports) {
     var incrementHistory = function (document) {
         return _navigateHistory.call(this, document, 1);
     };
-    incrementHistory.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    incrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
+    incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];
+    incrementHistory.transfers = [toolActions.resetBorderPolicies, "documents.updateDocument"];
     incrementHistory.modal = true;
 
     /**
@@ -199,8 +200,9 @@ define(function (require, exports) {
     var decrementHistory = function (document) {
         return _navigateHistory.call(this, document, -1);
     };
-    decrementHistory.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    decrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
+    decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];
+    decrementHistory.transfers = [toolActions.resetBorderPolicies, "documents.updateDocument"];
     decrementHistory.modal = true;
 
     /**
@@ -245,8 +247,9 @@ define(function (require, exports) {
                 return this.transfer(toolActions.resetBorderPolicies);
             });
     };
-    revertCurrentDocument.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    revertCurrentDocument.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    revertCurrentDocument.reads = [locks.JS_APP];
+    revertCurrentDocument.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC, locks.JS_UI];
+    revertCurrentDocument.transfers = ["documents.updateDocument", toolActions.resetBorderPolicies];
     revertCurrentDocument.post = [layerActions._verifyLayerIndex];
     revertCurrentDocument.modal = true;
 

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -35,27 +35,6 @@ define(function (require, exports) {
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
 
     /**
-     * Helper command to construct and install a single keydown policy.
-     * 
-     * @param {boolean} propagate Whether to propagate the keydown to Photoshop
-     * @param {number|string} key Either a keyCode or a keyChar
-     * @param {{shift: boolean=, control: boolean=, alt: boolean=, command: boolean=}} modifiers
-     * @return {Promise.<number>} Resolves with the installed policy list ID
-     */
-    var addKeydownPolicy = function (propagate, key, modifiers) {
-        var policyAction = propagate ?
-                adapterUI.policyAction.ALWAYS_PROPAGATE :
-                adapterUI.policyAction.NEVER_PROPAGATE,
-            eventKind = adapterOS.eventKind.KEY_DOWN;
-
-        var policy = new KeyboardEventPolicy(policyAction, eventKind, modifiers, key);
-
-        return this.transfer(addKeyboardPolicies, [policy], true);
-    };
-    addKeydownPolicy.reads = [];
-    addKeydownPolicy.writes = [locks.PS_APP, locks.JS_POLICY];
-
-    /**
      * Install a new policy list.
      *
      * @private 
@@ -141,6 +120,28 @@ define(function (require, exports) {
     addKeyboardPolicies.reads = [];
     addKeyboardPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
     addKeyboardPolicies.modal = true;
+
+    /**
+     * Helper command to construct and install a single keydown policy.
+     * 
+     * @param {boolean} propagate Whether to propagate the keydown to Photoshop
+     * @param {number|string} key Either a keyCode or a keyChar
+     * @param {{shift: boolean=, control: boolean=, alt: boolean=, command: boolean=}} modifiers
+     * @return {Promise.<number>} Resolves with the installed policy list ID
+     */
+    var addKeydownPolicy = function (propagate, key, modifiers) {
+        var policyAction = propagate ?
+                adapterUI.policyAction.ALWAYS_PROPAGATE :
+                adapterUI.policyAction.NEVER_PROPAGATE,
+            eventKind = adapterOS.eventKind.KEY_DOWN;
+
+        var policy = new KeyboardEventPolicy(policyAction, eventKind, modifiers, key);
+
+        return this.transfer(addKeyboardPolicies, [policy], true);
+    };
+    addKeydownPolicy.reads = [];
+    addKeydownPolicy.writes = [locks.PS_APP, locks.JS_POLICY];
+    addKeydownPolicy.transfers = [addKeyboardPolicies];
 
     /**
      * Remove an already-installed keyboard policy list.

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -174,8 +174,9 @@ define(function (require, exports) {
                 }
             });
     };
-    click.reads = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP];
-    click.writes = [locks.PS_DOC, locks.JS_DOC];
+    click.reads = [locks.PS_DOC, locks.JS_UI];
+    click.writes = [];
+    click.transfers = [layerFXActions.duplicateLayerEffects, shapeActions.setFillColor, typeActions.setColor];
     
     /**
      * Saves the currently selected layer's style in the style store clipboard
@@ -203,7 +204,7 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.style.COPY_STYLE, payload);
     };
-    copyLayerStyle.reads = [locks.JS_DOC];
+    copyLayerStyle.reads = [locks.JS_DOC, locks.JS_APP];
     copyLayerStyle.writes = [locks.JS_STYLE];
 
     /**
@@ -255,8 +256,10 @@ define(function (require, exports) {
 
         return Promise.join(shapeFillPromise, shapeStrokePromise, textColorPromise, textStylePromise, effectsPromise);
     };
-    pasteLayerStyle.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_STYLE, locks.JS_APP, locks.JS_TOOL];
-    pasteLayerStyle.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    pasteLayerStyle.reads = [locks.JS_DOC, locks.JS_STYLE, locks.JS_APP];
+    pasteLayerStyle.writes = [];
+    pasteLayerStyle.transfers = [shapeActions.setFillColor, shapeActions.setStrokeColor,
+        typeActions.setColor, typeActions.applyTextStyle, layerFXActions.duplicateLayerEffects];
 
     exports.click = click;
 

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -24,8 +24,7 @@
 define(function (require, exports) {
     "use strict";
 
-    var dialog = require("./dialog"),
-        locks = require("js/locks");
+    var dialog = require("./dialog");
 
     /**
      * Open the Search dialog
@@ -36,7 +35,8 @@ define(function (require, exports) {
         return this.transfer(dialog.openDialog, "search-bar-dialog");
     };
     openSearchBar.reads = [];
-    openSearchBar.writes = [locks.JS_DIALOG];
+    openSearchBar.writes = [];
+    openSearchBar.transfers = [dialog.openDialog];
 
 
     exports.openSearchBar = openSearchBar;

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -160,7 +160,7 @@ define(function (require, exports) {
      * @param {string} id ID of menu command
     */
     var _confirmMenuCommand = function (id) {
-        menuActions.playMenuCommand.call(this, id);
+        menuActions._playMenuCommand.call(this, id);
     };
 
     /*

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -178,8 +178,8 @@ define(function (require, exports) {
         // the only problem with that is having to define a default color here if none can be derived
         return setStrokeColor.call(this, document, layers, strokeIndex, color, false, enabled);
     };
-    setStrokeEnabled.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setStrokeEnabled.reads = [];
+    setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Set the color of the stroke for the given layers of the given document
@@ -253,8 +253,9 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeColor.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    setStrokeColor.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setStrokeColor.reads = [];
+    setStrokeColor.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeColor.transfers = [layerActions.resetBounds];
 
     /**
      * Set the alignment of the stroke for all selected layers of the given document.
@@ -295,8 +296,9 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeAlignment.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    setStrokeAlignment.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setStrokeAlignment.reads = [];
+    setStrokeAlignment.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeAlignment.transfers = [layerActions.resetBounds];
 
     /**
      * Set the opacity of the stroke for all selected layers of the given document.
@@ -380,8 +382,9 @@ define(function (require, exports) {
                 });
         }
     };
-    setStrokeWidth.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    setStrokeWidth.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setStrokeWidth.reads = [];
+    setStrokeWidth.writes = [locks.PS_DOC, locks.JS_DOC];
+    setStrokeWidth.transfers = [layerActions.resetBounds];
 
     /**
      * Add a stroke from scratch
@@ -623,6 +626,7 @@ define(function (require, exports) {
     };
     combineUnion.reads = [];
     combineUnion.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineUnion.transfers = [layerActions.resetLayers, layerActions.resetLayersByIndex];
 
     /**
      * Combine paths using SUBTRACT operation
@@ -642,6 +646,7 @@ define(function (require, exports) {
     };
     combineSubtract.reads = [];
     combineSubtract.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineSubtract.transfers = [layerActions.resetLayers, layerActions.resetLayersByIndex];
 
     /**
      * Combine paths using INTERSECT operation
@@ -661,6 +666,7 @@ define(function (require, exports) {
     };
     combineIntersect.reads = [];
     combineIntersect.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineIntersect.transfers = [layerActions.resetLayers, layerActions.resetLayersByIndex];
 
     /**
      * Combine paths using DIFFERENCE operation
@@ -680,6 +686,7 @@ define(function (require, exports) {
     };
     combineDifference.reads = [];
     combineDifference.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineDifference.transfers = [layerActions.resetLayers, layerActions.resetLayersByIndex];
 
     /**
      * Called by the menu items, runs the union operation on 
@@ -697,8 +704,9 @@ define(function (require, exports) {
 
         return this.transfer(combineUnion, currentDocument, currentDocument.layers.selected);
     };
-    combineUnionSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
-    combineUnionSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineUnionSelectedInCurrentDocument.reads = [locks.JS_APP];
+    combineUnionSelectedInCurrentDocument.writes = [];
+    combineUnionSelectedInCurrentDocument.transfers = [combineUnion];
 
     /**
      * Called by the menu items, runs the subtract operation on 
@@ -716,8 +724,9 @@ define(function (require, exports) {
 
         return this.transfer(combineSubtract, currentDocument, currentDocument.layers.selected);
     };
-    combineSubtractSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
-    combineSubtractSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineSubtractSelectedInCurrentDocument.reads = [locks.JS_APP];
+    combineSubtractSelectedInCurrentDocument.writes = [];
+    combineSubtractSelectedInCurrentDocument.transfer = [combineSubtract];
 
     /**
      * Called by the menu items, runs the intersect operation on 
@@ -735,8 +744,9 @@ define(function (require, exports) {
 
         return this.transfer(combineIntersect, currentDocument, currentDocument.layers.selected);
     };
-    combineIntersectSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
-    combineIntersectSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineIntersectSelectedInCurrentDocument.reads = [locks.JS_APP];
+    combineIntersectSelectedInCurrentDocument.writes = [];
+    combineIntersectSelectedInCurrentDocument.transfers = [combineIntersect];
 
     /**
      * Called by the menu items, runs the difference operation on 
@@ -754,8 +764,9 @@ define(function (require, exports) {
 
         return this.transfer(combineDifference, currentDocument, currentDocument.layers.selected);
     };
-    combineDifferenceSelectedInCurrentDocument.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP];
-    combineDifferenceSelectedInCurrentDocument.writes = [locks.PS_DOC, locks.JS_DOC];
+    combineDifferenceSelectedInCurrentDocument.reads = [locks.JS_APP];
+    combineDifferenceSelectedInCurrentDocument.writes = [];
+    combineDifferenceSelectedInCurrentDocument.transfers = [combineDifference];
 
     exports.setStrokeEnabled = setStrokeEnabled;
     exports.setStrokeWidth = setStrokeWidth;

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -72,7 +72,8 @@ define(function (require, exports) {
             });
     };
     addShortcut.reads = [];
-    addShortcut.writes = [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY];
+    addShortcut.writes = [locks.JS_SHORTCUT];
+    addShortcut.transfers = [policy.addKeydownPolicy];
     addShortcut.modal = true;
 
     /**
@@ -99,7 +100,8 @@ define(function (require, exports) {
             });
     };
     removeShortcut.reads = [];
-    removeShortcut.writes = [locks.PS_APP, locks.JS_SHORTCUT, locks.JS_POLICY];
+    removeShortcut.writes = [locks.JS_SHORTCUT];
+    removeShortcut.transfers = [policy.removeKeyboardPolicies];
     removeShortcut.modal = true;
 
     /**

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -324,8 +324,9 @@ define(function (require, exports) {
 
         return resultPromise;
     };
-    editLayer.reads = locks.ALL_LOCKS;
-    editLayer.writes = locks.ALL_LOCKS;
+    editLayer.reads = [locks.JS_UI, locks.JS_TOOL, locks.JS_DOC];
+    editLayer.writes = [locks.PS_DOC];
+    editLayer.transfers = [toolActions.select, documentActions.updateDocument];
     
     /**
      * Process a single click from the SuperSelect tool. First determines a set of
@@ -412,8 +413,9 @@ define(function (require, exports) {
                 }
             });
     };
-    click.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    click.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    click.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI];
+    click.writes = [];
+    click.transfers = [layerActions.deselectAll, layerActions.select];
 
     /**
      * Process a double click
@@ -489,8 +491,9 @@ define(function (require, exports) {
                 }
             });
     };
-    doubleClick.reads = locks.ALL_LOCKS;
-    doubleClick.writes = locks.ALL_LOCKS;
+    doubleClick.reads = [locks.JS_UI, locks.JS_DOC, locks.PS_DOC];
+    doubleClick.writes = [];
+    doubleClick.transfers = [layerActions.select, editLayer];
 
     /**
      * Backs out of the selected layers to their parents
@@ -513,8 +516,9 @@ define(function (require, exports) {
             return Promise.resolve();
         }
     };
-    backOut.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    backOut.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    backOut.reads = [locks.JS_DOC];
+    backOut.writes = [];
+    backOut.transfers = [layerActions.select, layerActions.deselectAll];
 
     /**
      * Skips to the next unlocked sibling layer of the first selected layer
@@ -529,8 +533,9 @@ define(function (require, exports) {
         _logSuperselect("key_next_sibling");
         return this.transfer(layerActions.select, doc, nextSiblings);
     };
-    nextSibling.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    nextSibling.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    nextSibling.reads = [locks.JS_DOC];
+    nextSibling.writes = [];
+    nextSibling.transfers = [layerActions.select];
 
     /**
      * Dives in one level to the selected layer, no op if it's not a group layer
@@ -565,8 +570,9 @@ define(function (require, exports) {
             return this.transfer(layerActions.select, doc, diveableLayers.first());
         }
     };
-    diveIn.reads = locks.ALL_LOCKS;
-    diveIn.writes = locks.ALL_LOCKS;
+    diveIn.reads = [locks.JS_DOC];
+    diveIn.writes = [];
+    diveIn.transfers = [layerActions.select, editLayer];
 
     /**
      * Stores the move listener that was installed by the last drag command
@@ -667,8 +673,9 @@ define(function (require, exports) {
             }
         }
     };
-    drag.reads = [locks.PS_DOC, locks.JS_DOC, locks.JS_APP, locks.JS_TOOL];
-    drag.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    drag.reads = [locks.JS_DOC];
+    drag.writes = [locks.PS_DOC, locks.JS_UI];
+    drag.transfers = [click];
 
     /**
      * Selects the given layers by the marquee
@@ -696,8 +703,9 @@ define(function (require, exports) {
             return Promise.resolve();
         }
     };
-    marqueeSelect.reads = [locks.PS_DOC, locks.JS_APP, locks.JS_TOOL];
-    marqueeSelect.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    marqueeSelect.reads = [locks.JS_DOC];
+    marqueeSelect.writes = [locks.JS_UI];
+    marqueeSelect.transfers = [layerActions.deselectAll, layerActions.select];
 
     exports.click = click;
     exports.doubleClick = doubleClick;

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -98,8 +98,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.document.TYPE_FACE_CHANGED, payload);
     };
-    updatePostScript.reads = [locks.JS_APP, locks.JS_TOOL];
-    updatePostScript.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    updatePostScript.reads = [];
+    updatePostScript.writes = [locks.JS_DOC];
     updatePostScript.modal = true;
 
     /**
@@ -131,8 +131,9 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setPostScript.reads = [locks.JS_APP, locks.JS_TOOL];
-    setPostScript.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setPostScript.reads = [locks.JS_DOC];
+    setPostScript.writes = [locks.PS_DOC, locks.JS_UI];
+    setPostScript.transfers = [updatePostScript, layerActions.resetBounds];
     setPostScript.modal = true;
 
     /**
@@ -156,8 +157,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.document.TYPE_FACE_CHANGED, payload);
     };
-    updateFace.reads = [locks.JS_APP, locks.JS_TOOL];
-    updateFace.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    updateFace.reads = [];
+    updateFace.writes = [locks.JS_DOC];
     updateFace.modal = true;
 
     /**
@@ -188,8 +189,9 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setFace.reads = [locks.JS_APP, locks.JS_TOOL];
-    setFace.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setFace.reads = [locks.JS_DOC];
+    setFace.writes = [locks.JS_UI, locks.PS_DOC];
+    setFace.transfers = [updateFace, layerActions.resetBounds];
     setFace.modal = true;
 
     /**
@@ -225,7 +227,7 @@ define(function (require, exports) {
         }
     };
     updateColor.reads = [];
-    updateColor.writes = [locks.PS_DOC, locks.JS_DOC];
+    updateColor.writes = [locks.JS_DOC];
     updateColor.modal = true;
 
     /**
@@ -266,8 +268,9 @@ define(function (require, exports) {
 
         return Promise.join(updatePromise, setColorPromise);
     };
-    setColor.reads = [];
-    setColor.writes = [locks.PS_DOC, locks.JS_DOC];
+    setColor.reads = [locks.JS_DOC];
+    setColor.writes = [locks.PS_DOC];
+    setColor.transfers = [updateColor];
     setColor.modal = true;
 
     /**
@@ -290,7 +293,7 @@ define(function (require, exports) {
     };
 
     updateSize.reads = [];
-    updateSize.writes = [locks.PS_DOC, locks.JS_DOC];
+    updateSize.writes = [locks.JS_DOC];
     updateSize.modal = true;
     /**
      * Set the type size of the given layers in the given document. This triggers
@@ -322,8 +325,9 @@ define(function (require, exports) {
                 return this.transfer(layerActions.resetBounds, document, layers);
             }.bind(this));
     };
-    setSize.reads = [locks.JS_APP, locks.JS_TOOL];
-    setSize.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setSize.reads = [locks.JS_DOC];
+    setSize.writes = [locks.JS_UI, locks.PS_DOC];
+    setSize.transfers = [updateSize, layerActions.resetBounds];
     setSize.modal = true;
     
     /**
@@ -345,8 +349,8 @@ define(function (require, exports) {
         return this.dispatchAsync(events.document.TYPE_TRACKING_CHANGED, payload);
     };
 
-    updateTracking.reads = [locks.JS_APP, locks.JS_TOOL];
-    updateTracking.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    updateTracking.reads = [];
+    updateTracking.writes = [locks.JS_DOC];
     updateTracking.modal = true;
     /**
      * Set the tracking value (aka letter-spacing) of the given layers in the given document.
@@ -376,8 +380,9 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setTracking.reads = [locks.JS_APP, locks.JS_TOOL];
-    setTracking.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setTracking.reads = [locks.JS_DOC];
+    setTracking.writes = [locks.PS_DOC, locks.JS_UI];
+    setTracking.transfers = [updateTracking, layerActions.resetBounds];
     setTracking.modal = true;
 
     /**
@@ -398,8 +403,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.document.TYPE_LEADING_CHANGED, payload);
     };
-    updateLeading.reads = [locks.JS_APP, locks.JS_TOOL];
-    updateLeading.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    updateLeading.reads = [];
+    updateLeading.writes = [locks.JS_DOC];
     updateLeading.modal = true;
 
     /**
@@ -430,8 +435,9 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setLeading.reads = [locks.JS_APP, locks.JS_TOOL];
-    setLeading.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setLeading.reads = [locks.JS_DOC];
+    setLeading.writes = [locks.PS_DOC, locks.JS_UI];
+    setLeading.transfers = [updateLeading, layerActions.resetBounds];
     setLeading.modal = true;
 
     /**
@@ -452,8 +458,8 @@ define(function (require, exports) {
 
         return this.dispatchAsync(events.document.TYPE_ALIGNMENT_CHANGED, payload);
     };
-    updateAlignment.reads = [locks.JS_APP, locks.JS_TOOL];
-    updateAlignment.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    updateAlignment.reads = [];
+    updateAlignment.writes = [locks.JS_DOC];
     updateAlignment.modal = true;
 
     /**
@@ -483,8 +489,9 @@ define(function (require, exports) {
                     return this.transfer(layerActions.resetBounds, document, layers);
                 }.bind(this));
     };
-    setAlignment.reads = [locks.JS_APP, locks.JS_TOOL];
-    setAlignment.writes = [locks.PS_DOC, locks.JS_DOC, locks.PS_APP, locks.JS_POLICY];
+    setAlignment.reads = [locks.JS_DOC];
+    setAlignment.writes = [locks.PS_DOC, locks.JS_UI];
+    setAlignment.transfers = [updateAlignment, layerActions.resetBounds];
     setAlignment.modal = true;
 
     /**
@@ -508,8 +515,9 @@ define(function (require, exports) {
                 return this.transfer(layerActions.resetLayers, document, targetLayers);
             });
     };
-    duplicateTextStyle.reads = [locks.JS_DOC, locks.PS_DOC];
-    duplicateTextStyle.writes = [locks.JS_DOC, locks.PS_DOC];
+    duplicateTextStyle.reads = [locks.JS_TYPE, locks.JS_DOC];
+    duplicateTextStyle.writes = [locks.PS_DOC];
+    duplicateTextStyle.transfers = [layerActions.resetLayers];
   
     /**
      * Applies the given text style to target layers
@@ -530,8 +538,9 @@ define(function (require, exports) {
                 return this.transfer(layerActions.resetLayers, document, targetLayers);
             });
     };
-    applyTextStyle.reads = [locks.JS_DOC, locks.PS_DOC];
-    applyTextStyle.writes = [locks.JS_DOC, locks.PS_DOC];
+    applyTextStyle.reads = [locks.JS_DOC];
+    applyTextStyle.writes = [locks.PS_DOC];
+    applyTextStyle.transfers = [layerActions.resetLayers];
 
     /**
      * Initialize the list of installed fonts from Photoshop.

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -86,18 +86,6 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Determines whether the first array is a non-strict subset of the second.
-     *
-     * @private
-     * @param {Array.<*>} arr1
-     * @param {Array.<*>} arr2
-     * @return {boolean} True if the first array is a subset of the second.
-     */
-    var _subseteq = function (arr1, arr2) {
-        return _.difference(arr1, arr2).length === 0;
-    };
-
-    /**
      * Manages the lifecycle of a Fluxxor instance.
      *
      * @constructor
@@ -106,7 +94,10 @@ define(function (require, exports, module) {
         EventEmitter.call(this);
 
         var cores = window.navigator.hardwareConcurrency || 8;
+
         this._actionQueue = new AsyncDependencyQueue(cores);
+        this._initActionNames();
+        this._initActionLocks();
 
         var actions = this._synchronizeAllModules(actionIndex),
             stores = storeIndex.create(),
@@ -114,7 +105,7 @@ define(function (require, exports, module) {
 
         this._flux = new Fluxxor.Flux(allStores, actions);
         this._resetHelper = synchronization.throttle(this._resetWithDelay, this);
-        this._actionReceivers = new Map();
+        this._actionReceivers = this._createActionReceivers(this._flux);
     };
     util.inherits(FluxController, EventEmitter);
 
@@ -141,6 +132,38 @@ define(function (require, exports, module) {
     FluxController.prototype._actionQueue = null;
 
     /**
+     * Map from unsynchronized action functions to pathnames.
+     *
+     * @private
+     * @type {Map.<function, string>}
+     */
+    FluxController.prototype._actionNames = null;
+
+    /**
+     * Map from pathnames to unsynchronized action functions.
+     *
+     * @private
+     * @type {Map.<function, string>}
+     */
+    FluxController.prototype._actionsByName = null;
+
+    /**
+     * Map from unsynchronized action functions to their transitive read lock set.
+     *
+     * @private
+     * @type {Map.<function, Set.<string>>}
+     */
+    FluxController.prototype._transitiveReads = null;
+
+    /**
+     * Map from unsynchronized action functions to their transitive write lock set.
+     *
+     * @private
+     * @type {Map.<function, Set.<string>>}
+     */
+    FluxController.prototype._transitiveWrites = null;
+
+    /**
      * Per-action cache of action receivers
      * 
      * @private
@@ -164,6 +187,139 @@ define(function (require, exports, module) {
     });
 
     /**
+     * Initialize maps to and from unsynchronized action functions and action pathnames.
+     *
+     * @private
+     */
+    FluxController.prototype._initActionNames = function () {
+        this._actionsByName = new Map();
+        this._actionNames = new Map();
+
+        Object.keys(actionIndex).forEach(function (actionModuleName) {
+            var actionModule = actionIndex[actionModuleName];
+
+            Object.keys(actionModule)
+                .filter(function (actionName) {
+                    return actionName[0] !== "_";
+                })
+                .forEach(function (actionName) {
+                    var action = actionModule[actionName],
+                        actionPath = actionModuleName + "." + actionName;
+
+                    this._actionsByName.set(actionPath, action);
+                    this._actionNames.set(action, actionPath);
+                }, this);
+        }, this);
+    };
+
+    /**
+     * Calculate the (transitive) set of locks required to execute each action
+     * based on its immediate lock requirements and its declared action transfers.
+     *
+     * @private
+     */
+    FluxController.prototype._initActionLocks = function () {
+        var actionDependencies = new Map();
+
+        var _resolveDependencies = function (action) {
+            // Map from an action to the set of all unsynchonrized actions to
+            // which it may transfer, including via sub-action transfers.
+            var dependencies = actionDependencies.get(action);
+            
+            if (!dependencies) {
+                dependencies = new Set([action]);
+                if (action.transfers) {
+                    action.transfers.forEach(function (dependency, index) {
+                        // Translate action pathnames to unsynchronized action functions
+                        if (typeof dependency === "string") {
+                            dependency = this._actionsByName.get(dependency);
+                        }
+
+                        // Validate transfer declarations
+                        if (!dependency) {
+                            var actionName = this._actionNames.get(action);
+                            throw new Error("Transfer declaration " + index + " of " + actionName + " is invalid.");
+                        }
+                        
+                        // Resolve child dependencies before proceeding
+                        _resolveDependencies(dependency).forEach(dependencies.add, dependencies);
+                    }, this);
+                }
+
+                actionDependencies.set(action, dependencies);
+
+                var reads = action.reads || locks.ALL_LOCKS,
+                    writes = action.writes || locks.ALL_LOCKS;
+
+                // Calculate transitive lock sets based on the action's dependencies
+                dependencies.forEach(function (dependency) {
+                    reads = reads.concat(dependency.reads || locks.ALL_LOCKS);
+                    writes = writes.concat(dependency.writes || locks.ALL_LOCKS);
+                });
+
+                this._transitiveReads.set(action, _.uniq(reads));
+                this._transitiveWrites.set(action, _.uniq(writes));
+            }
+
+            return dependencies;
+        }.bind(this);
+
+        this._transitiveReads = new Map();
+        this._transitiveWrites = new Map();
+        this._actionsByName.forEach(function (action, actionName) {
+            // Validate action read locks
+            if (action.reads) {
+                action.reads.forEach(function (lock, index) {
+                    if (typeof lock !== "string") {
+                        throw new Error("Read lock declaration " + index + " of " + actionName + " is invalid.");
+                    }
+                });
+            }
+
+            // Validate action write locks
+            if (action.writes) {
+                action.writes.forEach(function (lock, index) {
+                    if (typeof lock !== "string") {
+                        throw new Error("Write lock declaration " + index + " of " + actionName + " is invalid.");
+                    }
+                });
+            }
+
+            _resolveDependencies(action);
+        });
+    };
+
+    /**
+     * Create a map from all unsynchronized action functions to their action receivers.
+     *
+     * @private
+     * @param {Fluxxor.Flux} flux
+     * @return {Map.<function, ActionReceiver>}
+     */
+    FluxController.prototype._createActionReceivers = function (flux) {
+        var dispatchBinder = flux.dispatchBinder,
+            actionReceivers = new Map();
+        
+        Object.keys(actionIndex).forEach(function (actionModuleName) {
+            var actionModule = actionIndex[actionModuleName];
+
+            Object.keys(actionModule)
+                .filter(function (actionName) {
+                    return actionName[0] !== "_";
+                })
+                .forEach(function (actionName) {
+                    var action = actionModule[actionName],
+                        name = actionModuleName + "." + actionName,
+                        receiver = this._makeActionReceiver(dispatchBinder, action, name);
+
+                    actionReceivers.set(action, receiver);
+                }, this);
+        }, this);
+
+        return actionReceivers;
+    };
+
+    /**
      * Construct a receiver for the given action that augments the standard
      * Fluxxor "dispatch binder" with additional action-specific helper methods.
      *
@@ -179,13 +335,9 @@ define(function (require, exports, module) {
                 "All locks will be required for execution.");
         }
 
-        var currentReads = action.reads || locks.ALL_LOCKS,
-            currentWrites = action.writes || locks.ALL_LOCKS,
+        var currentTransfers = new Set(action.transfers || []),
             self = this,
             resolvedPromise;
-
-        // Always interpret the set of read locks as the union of read and write locks
-        currentReads = _.union(currentReads, currentWrites);
 
         var receiver = Object.create(proto, {
             /**
@@ -194,14 +346,6 @@ define(function (require, exports, module) {
              */
             controller: {
                 value: self
-            },
-
-            /**
-             * The name of this action
-             * @type {string} 
-             */
-            actionName: {
-                value: actionName
             },
 
             /**
@@ -218,16 +362,13 @@ define(function (require, exports, module) {
                         throw new Error("Transfer passed an undefined action");
                     }
 
-                    var nextReads = _.union(nextAction.reads, nextAction.writes) || locks.ALL_LOCKS;
-                    if (!_subseteq(nextReads, currentReads)) {
-                        log.error("Missing read locks:", _.difference(nextReads, currentReads).join(", "));
-                        throw new Error("Next action requires additional read locks");
-                    }
-
-                    var nextWrites = nextAction.writes || locks.ALL_LOCKS;
-                    if (!_subseteq(nextWrites, currentWrites)) {
-                        log.error("Missing write locks:", _.difference(nextWrites, currentWrites).join(", "));
-                        throw new Error("Next action requires additional write locks");
+                    if (!currentTransfers.has(nextAction)) {
+                        var nextActionName = self._actionNames.get(nextAction),
+                            message = "Invalid transfer from " + actionName + " to " + nextActionName +
+                                ". Add " + nextActionName + " to the list of transfers declared for " +
+                                actionName + ".";
+                                
+                        throw new Error(message);
                     }
 
                     var lockUI = nextAction.lockUI;
@@ -235,8 +376,10 @@ define(function (require, exports, module) {
                         self.emit("lock");
                     }
     
-                    var params = Array.prototype.slice.call(arguments, 1);
-                    return self._applyAction(nextAction, this, params);
+                    var params = Array.prototype.slice.call(arguments, 1),
+                        nextReceiver = self._actionReceivers.get(nextAction);
+
+                    return self._applyAction(nextAction, nextReceiver, params, actionName);
                 }
             },
 
@@ -288,17 +431,18 @@ define(function (require, exports, module) {
      * @param {Array.<*>} params
      * @return {Promise}
      */
-    FluxController.prototype._applyAction = function (action, actionReceiver, params) {
+    FluxController.prototype._applyAction = function (action, actionReceiver, params, parentActionName) {
         var lockUI = action.lockUI,
             post = action.post,
-            parentActionName = actionReceiver.actionName,
-            actionName = action.id,
-            actionTitle = "action " + parentActionName,
+            actionName = this._actionNames.get(action),
             preferences = this.flux.store("preferences").getState(),
-            checkPost = preferences.get("postConditionsEnabled");
+            checkPost = preferences.get("postConditionsEnabled"),
+            actionTitle;
 
-        if (parentActionName !== actionName) {
-            actionTitle = "sub-action " + actionName + " of " + actionTitle;
+        if (parentActionName) {
+            actionTitle = "sub-action " + actionName + " of action " + parentActionName;
+        } else {
+            actionTitle = "action " + actionName;
         }
 
         var actionPromise = action.apply(actionReceiver, params);
@@ -358,11 +502,9 @@ define(function (require, exports, module) {
             actionQueue = this._actionQueue,
             action = module[name],
             actionName = namespace + "." + name,
-            reads = action.reads || locks.ALL_LOCKS,
-            writes = action.writes || locks.ALL_LOCKS,
-            modal = action.modal || false;
-
-        action.id = actionName;
+            modal = action.modal || false,
+            reads = this._transitiveReads.get(action),
+            writes = this._transitiveWrites.get(action);
 
         return function () {
             var args = Array.prototype.slice.call(arguments, 0),
@@ -370,7 +512,7 @@ define(function (require, exports, module) {
 
             // The receiver of the action, augmented to include a transfer
             // function that allows it to safely transfer control to another action
-            var actionReceiver = self._getActionReceiver(this, action, actionName);
+            var actionReceiver = self._actionReceivers.get(action);
 
             log.debug("Enqueuing action %s; %d/%d",
                 actionName, actionQueue.active(), actionQueue.pending());

--- a/src/js/locks.js
+++ b/src/js/locks.js
@@ -51,7 +51,8 @@ define(function (require, exports, module) {
         JS_HISTORY: "jsHistory",
         JS_STYLE: "jsStyle",
         JS_LIBRARIES: "jsLibraries",
-        CC_LIBRARIES: "ccLibraries"
+        CC_LIBRARIES: "ccLibraries",
+        OS_CLIPBOARD: "osClipboard"
     };
 
     /**
@@ -76,22 +77,10 @@ define(function (require, exports, module) {
         LOCKS.PS_MENU
     ];
 
-    /**
-     * An array of all JavaScript-specific locks.
-     *
-     * @const
-     * @type {Array.<string>}
-     */
-    var ALL_JS_LOCKS = [
-        LOCKS.JS_APP,
-        LOCKS.JS_DOC,
-        LOCKS.JS_TOOL,
-        LOCKS.PS_MENU,
-        LOCKS.JS_DIALOG
-    ];
+    var ALL_NATIVE_LOCKS = ALL_PS_LOCKS.concat(LOCKS.CC_LIBRARIES, LOCKS.OS_CLIPBOARD);
 
     module.exports = LOCKS;
     module.exports.ALL_LOCKS = ALL_LOCKS;
     module.exports.ALL_PS_LOCKS = ALL_PS_LOCKS;
-    module.exports.ALL_JS_LOCKS = ALL_JS_LOCKS;
+    module.exports.ALL_NATIVE_LOCKS = ALL_NATIVE_LOCKS;
 });


### PR DESCRIPTION
The controller currently assumes that actions will specify the entire set of read and write locks necessary to safely execute the given action _as well as all other sub-actions to which the action may transfer_. Suppose, for example, we have:

```javascript
var foo = function () {
  // write A
};
foo.writes = [A];

var bar = function () {
  // write B, and then
  return this.transfer(foo);
}
bar.writes = [A, B]; // A is needed because of the transfer to foo
```
Above, the `foo` action writes to state protected by the `A` lock, and so includes the appropriate write lock declaration. The `bar` action itself only writes to state protected by the `B` lock, but also transfers to `foo`, and so must also include all of the locks specified by `foo` in its lock declaration. 

Suppose now we update `foo` so that it additionally writes to state protected by the `C` lock:
```javascript
var foo = function () {
  // write A
  // and, now, also write C
};
foo.writes = [A, C];
```
Unfortunately now when `bar` is executed, there will be a runtime error because it transfers to `bar` which requires both `A` and `C` locks, but `bar` only declares that it requires locks `A` and `B`. To solve this problem, we have to also amend the lock declaration of `bar` to include `C`.
```javascript
var bar = function () {
  // write B, and then
  return this.transfer(foo);
}
bar.writes = [A, B, C]; // now A AND C are needed because of the transfer to foo
```
This is hugely problematic for maintainability because small, local changes almost always require perfunctory global changes. Furthermore, because there is so much "noise" in the lock declarations related to sub-actions, mistakes in these declarations have propagated so thoroughly that **nearly 100% of our lock declarations are currently incorrect.** 

This PR makes a major change to the controller to make it easier to correctly declare the correct lock sets. Instead of requiring that an action declare all the locks needed for its execution as well as of its transferrable sub-actions, with this change it is only necessary to specify the locks needed immediately for the given action. To avoid deadlock though, the controller still acquires all the required locks up-front. In order to do this, it needs to know additionally to which sub-actions the given action may transfer. With this information, it can then calculate the complete, transitive set of locks required for each action. 

With this PR, the original example above is now correctly rewritten as follows: 
```javascript
var foo = function () {
  // write A
};
foo.writes = [A];

var bar = function () {
  // write B, and then
  return this.transfer(foo);
}
bar.writes = [B];
bar.transfers = [foo]; // If this isn't declared, the transfer will fail at runtime
```
Note that `bar` _only_ explicitly declares the `B` lock and not the `A` lock because the latter is not immediately required by `bar`, only by the sub-action `foo` to which it transfers. Furthermore, this transfer too `foo` is declared up-front in the set of `transfers` declared for `bar`. Now, if `foo` is updated as before to additional write to stated required by a `C` lock, we update `foo` as before but _no update is required to `bar`_. 

Currently, the controller validates the correctness of the lock sets when transferring from one action to another. In this new regime, it instead validates that _transfers_ have been declared up-front when performing the transfer. Because the controller calculates the lock sets statically, there is no need to validate the lock sets at runtime. That is to say, when `bar` is executed before the change it still waits until locks `A,B` are available, and after the change it waits until locks `A,B,C` are available. This doesn't change what locks are acquired as a precondition for execution; only what locks need to be explicitly declared and where.

In summary, this PR makes two changes to the controller and to action declarations:

1. We now declare only the immediately required read and write locks instead of the locks needed by all potentially transferrable sub-actions.
2. We now also declare transferrable sub-actions, and the controller validates these transfers at runtime.

**Aside 1:** Both before and after this PR, the controller is unable to validate whether the set of locks specified for a particular actions is sufficient to maintain safety in the presence of concurrently executing actions. It was and is up to the developer to choose an appropriate set of locks. This change only affects how the overall set of locks is calculated relative to sub-action transfers.

**Aside 2:** this change relies upon an assumption that there are **no circular transfer declarations**. That is, it is not currently possible for `foo` to transfer to `bar` and for `bar` to transfer to `foo`. I don't think this is a fundamental requirement, but a) I haven't quite worked out how to solve that case; and b) it doesn't happen in our application at all. 

**Aside 3:** In this PR, it is possible to specify action transfers either by direct reference to the unsynchronized action function (e.g., `toolActions.select`) OR with a string pathname (e.g., `"tools.select"`). I had to at least allow the latter to solve the problem of circular module dependencies. For example, the `layers` and `documents` modules are circularly dependent, which means one is loaded first, which means it can't refer at module-initialization time to the other's exports. I think in a future PR I will probably make the additional change of ONLY allowing string pathnames to be used, both in the transfer declarations and also in the first parameter of the `transfer` method itself. Why? Because a) it's necessary at least sometimes; b) it probably improves readability by enforcing uniformity of the declarations; and c) it will eliminate some otherwise unnecessary module dependencies and imports.