### PR TITLE
Libraries: should add all new layer IDs for expanded graphic asset.

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1807,6 +1807,7 @@ define(function (require, exports) {
     exports._getLayersForDocumentRef = _getLayersForDocumentRef;
     exports._verifyLayerSelection = _verifyLayerSelection;
     exports._verifyLayerIndex = _verifyLayerIndex;
+    exports._getLayerIDsForDocumentID = _getLayerIDsForDocumentID;
 
     exports.afterStartup = afterStartup;
 });


### PR DESCRIPTION
This PR fixes #1944 (CC Lib: dragging asset with Opt/Alt key to place expanded layers results in error)