### PR TITLE
Superselect Fixes

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -359,7 +359,7 @@ define(function (require, exports) {
 
                 if (deep) {
                     // Select any non-group layer, and allow for artboard badges
-                    var hitLayerMap = new Set(hitLayerIDs.toJS()),
+                    var hitLayerMap = new Set(coveredLayerIDs.toJS()),
                         clickedSelectableLayers = _getDirectAccessLayersWithID(layerTree, hitLayerMap);
                     
                     clickedSelectableLayerIDs = collection.pluck(clickedSelectableLayers, "id");

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -116,6 +116,11 @@ define(function (require, exports, module) {
             });
         };
 
+        // Updates selectable layers by moving the child to the end of it
+        var moveToEnd = function (child) {
+            selectableLayers = pull(selectableLayers, child).push(child);
+        };
+
         // Traverse up to root
         while (layerAncestor && !visitedParents.hasOwnProperty(layerAncestor.id)) {
             // Remove the current parent because we're already below it
@@ -125,8 +130,10 @@ define(function (require, exports, module) {
             visitedParents[layerAncestor.id] = layerAncestor;
 
             // Add the siblings of this layer to accepted layers
-            selectableLayers = selectableLayers.concat(this.children(layerAncestor));
-
+            // if we encounter a layer that was in "topBelowArtboards", we replace it at the end here
+            // so it doesn't break z-order
+            this.children(layerAncestor).forEach(moveToEnd);
+            
             layerAncestor = this.parent(layerAncestor);
         }
 


### PR DESCRIPTION
Addresses #1940, and likely another superselect bug we may not have noticed.

Problem with #1940 was, I was using PS hit layer IDs for deep select, without artboards taken out.

Other bug is more nuanced, we start with `topBelowArtboards` and then systematically replace selected layers with relatives. However, if a relative is in the `topBelowArtboards`, it would remain at the beginning of the list, breaking z-order.