### PR TITLE
allow for adding vector masks to layers

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -30,7 +30,7 @@ define(function (require, exports) {
 
     var descriptor = require("adapter/ps/descriptor"),
         adapterOS = require("adapter/os"),
-        adapterUI = require("adapter/ps/ui");
+    adapterUI = require("adapter/ps/ui");
 
     var keyUtil = require("js/util/key"),
         system = require("js/util/system"),

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -502,7 +502,7 @@ define(function (require, exports) {
         var owlPromise = adapterUI.setClassicChromeVisibility(false);
 
         // Enable target path suppression
-        var pathPromise = adapterUI.setSuppressTargetPaths(true);
+        var pathPromise = adapterUI.setSuppressTargetPaths(false);
 
         // Add additional shortcut CMD=, so that CMD+ and CMD= both work for zoom in.
         var zoomShortcutModifier = system.isMac ? { "command": true } : { "control": true },

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -60,7 +60,8 @@ define(function (require, exports, module) {
                     LAYER_EFFECT_DELETED: "layerEffectDeleted",
                     LAYER_EFFECTS_BATCH_CHANGED: "layerEffectsBatchChanged",
                     RADII_CHANGED: "radiiChanged",
-                    TYPE_COLOR_CHANGED: "typeColorChanged"
+                    TYPE_COLOR_CHANGED: "typeColorChanged",
+                    ADD_VECTOR_MASK_TO_LAYER: "AddVectorMaskToLayer"
                 },
                 nonOptimistic: {
                     STROKE_ADDED: "strokeAdded",
@@ -118,7 +119,8 @@ define(function (require, exports, module) {
         },
         tool: {
             SELECT_TOOL: "selectTool",
-            MODAL_STATE_CHANGE: "modalStateChange"
+            MODAL_STATE_CHANGE: "modalStateChange",
+            VECTOR_STATE_CHANGE: "vectorStateChange"
         },
         ui: {
             TRANSFORM_UPDATED: "transformUpdated",

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -154,8 +154,6 @@ define(function (require, exports, module) {
         // artboards are also groups. so we handle them separately 
         if (descriptor.artboardEnabled) {
             boundsObject = objUtil.getPath(descriptor, "artboard.artboardRect");
-        } else if (descriptor.hasOwnProperty("pathBounds")) {
-            boundsObject = objUtil.getPath(descriptor, "pathBounds.pathBounds");
         } else {
             switch (descriptor.layerKind) {
                 // Photoshop's group bounds are not useful, so ignore them.
@@ -165,8 +163,11 @@ define(function (require, exports, module) {
                 case layerLib.layerKinds.TEXT:
                     boundsObject = descriptor.boundingBox;
                     break;
+                case layerLib.layerKinds.VECTOR:
+                    boundsObject = objUtil.getPath(descriptor, "pathBounds.pathBounds");
+                    break;
                 default:
-                    boundsObject = descriptor.boundsNoEffects;
+                    boundsObject = descriptor.boundsNoMask;
                     break;
             }
 

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -222,15 +222,7 @@ define(function (require, exports, module) {
             "earlier-history":
                 (document !== null) && hasPreviousHistoryState,
             "later-history":
-                (document !== null) && hasNextHistoryState,
-            "one-layer-selected-has-vector-mask":
-                (document !== null) &&
-                !document.unsupported &&
-                (document.layers !== null) &&
-                (document.layers.selectedNormalized.size === 1) &&
-                (document.layers.selected.every(function (layer) {
-                    return layer.vectorMaskEnabled === true;
-                }))
+                (document !== null) && hasNextHistoryState
         };
     };
 

--- a/src/js/models/tool.js
+++ b/src/js/models/tool.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         this.id = id;
         this.icon = id;
         this.name = name;
-        this.nativeToolName = nativeToolName;
+        this.nativeToolName = function () { return nativeToolName; };
         this.selectHandler = selectHandler || null;
         this.deselectHandler = deselectHandler || null;
         this.keyboardPolicyList = keyboardPolicyList || [];
@@ -69,8 +69,8 @@ define(function (require, exports, module) {
     Tool.prototype.name = null;
 
     /**
-     * Photoshop tool name
-     * @type {!string}
+     * a function that returns the Photoshop tool name
+     * @type {!function}
      */
     Tool.prototype.nativeToolName = null;
 
@@ -152,6 +152,12 @@ define(function (require, exports, module) {
      * @type {?Object}
      */
     Tool.prototype.toolOverlay = null;
+
+    /**
+     * Optional indicate is a tool is usable in vector make mode 
+     * @type {boolean}
+     */
+    Tool.prototype.handlevectorMaskMode = null;
 
     module.exports = Tool;
 });

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -100,7 +100,8 @@ define(function (require, exports, module) {
                 events.document.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
                 events.document.history.nonOptimistic.GUIDE_SET, this._handleGuideSet,
                 events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted,
-                events.document.history.nonOptimistic.GUIDES_CLEARED, this._handleGuidesCleared
+                events.document.history.nonOptimistic.GUIDES_CLEARED, this._handleGuidesCleared,
+                events.document.history.optimistic.ADD_VECTOR_MASK_TO_LAYER, this._handleAddVectorMask
             );
 
             this._handleReset();
@@ -1108,6 +1109,23 @@ define(function (require, exports, module) {
                 document = this._openDocuments[documentID];
 
             var nextDocument = document.set("guides", Immutable.List());
+
+            this.setDocument(nextDocument, true);
+        },
+        
+        /**
+         * Update layer with the correct vector mask property
+         *
+         * @private
+         * @param {{{documentID: number, layerIDs: Array.<number>, vectorMaskEnabled: boolean}}} payload
+         */
+        _handleAddVectorMask: function (payload) {
+            var documentID = payload.documentID,
+                layerIDs = payload.layerIDs,
+                vectorMaskEnabled = payload.vectorMaskEnabled,
+                document = this._openDocuments[documentID],
+                nextLayers = document.layers.setProperties(layerIDs, { vectorMaskEnabled: vectorMaskEnabled }),
+                nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);
         }

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -91,13 +91,22 @@ define(function (require, exports, module) {
         _inModalToolState: null,
 
         /**
+         * Flag indicating whether we're in vectormask mode
+         *
+         * @private
+         * @type {boolean}
+         */
+        _inVectorMode: null,
+
+        /**
          * Initialize the ToolStore
          */
         initialize: function () {
             this.bindActions(
                 events.RESET, this._handleReset,
                 events.tool.SELECT_TOOL, this._handleSelectTool,
-                events.tool.MODAL_STATE_CHANGE, this._handleModalStateChange
+                events.tool.MODAL_STATE_CHANGE, this._handleModalStateChange,
+                events.tool.VECTOR_STATE_CHANGE, this._handleVectorStateChange
             );
 
             this._handleReset();
@@ -134,6 +143,7 @@ define(function (require, exports, module) {
 
             this._allTools = Object.defineProperties({}, toolSpec);
             this._inModalToolState = null;
+            this._inVectorMode = null;
             this._currentKeyboardPolicyID = null;
             this._currentPointerPolicyID = null;
             this._currentTool = null;
@@ -162,6 +172,16 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Gets the tool vector mode
+         * 
+         * @return {boolean} 
+         */
+        getVectorMode: function () {
+            return this._inVectorMode;
+        },
+        
+
+        /**
          * @private
          * @param {{tool: Tool, keyboardPolicyListID: number, pointerPolicyListID: number}} payload
          */
@@ -182,6 +202,16 @@ define(function (require, exports, module) {
          */
         _handleModalStateChange: function (payload) {
             this._inModalToolState = payload.modalState;
+
+            this.emit("change");
+        },
+       
+        /**
+         * @private
+         * @param  {{vectorState: boolean}} payload
+         */
+        _handleVectorStateChange: function (payload) {
+            this._inVectorMode = payload;
 
             this.emit("change");
         },

--- a/src/js/tools/pen.js
+++ b/src/js/tools/pen.js
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
         OS = require("adapter/os"),
         UI = require("adapter/ps/ui"),
         toolLib = require("adapter/lib/tool"),
-        descriptor = require("adapter/ps/descriptor");
+        descriptor = require("adapter/ps/descriptor"),
+        vectorMaskLib = require("adapter/lib/vectorMask");
 
     var Tool = require("js/models/tool"),
         shortcuts = require("js/actions/shortcuts"),
@@ -40,15 +41,29 @@ define(function (require, exports, module) {
         shortcutUtil = require("js/util/shortcuts");
 
     var _CLEAR_PATH = 106;
-
+    
     /**
-     * @implements {Tool}
-     * @constructor
+     * Sets the tool into either path or shape mode and calls the approprate PS actions based on that mode
+     *
+     * @private
      */
-    var PenTool = function () {
-        Tool.call(this, "pen", "Pen", "penTool");
+    var _selectHandler = function () {
+        var toolStore = this.flux.store("tool"),
+            vectorMode = toolStore.getVectorMode() || false,
+            toolMode = toolLib.shapeVectorTool;
+            
+        if (vectorMode) {
+            toolMode = toolLib.pathVectorTool;
+        }
 
-        var selectHandler = function () {
+        // Reset the mode of the pen tool to "shape"
+        var setPromise = descriptor.playObject(toolLib.setShapeTool(toolMode));
+           
+       
+        if (this.vectorMode) {
+            var selectVectorMask = descriptor.playObject(vectorMaskLib.activateVectorMaskEditing());
+            return Promise.join(setPromise, selectVectorMask);
+        } else {
             var deleteFn = function (event) {
                 event.stopPropagation();
 
@@ -57,28 +72,29 @@ define(function (require, exports, module) {
                         // Silence the errors here
                     });
             };
-            
-            // Reset the mode of the pen tool to "shape"
-            var resetObj = toolLib.resetShapeTool(),
-                backspacePromise = this.transfer(shortcuts.addShortcut,
+            // Disable target path suppression
+            var backspacePromise = this.transfer(shortcuts.addShortcut,
                     OS.eventKeyCode.BACKSPACE, {}, deleteFn, "penBackspace", true),
                 deletePromise = this.transfer(shortcuts.addShortcut,
                     OS.eventKeyCode.DELETE, {}, deleteFn, "penDelete", true),
-                resetPromise = descriptor.playObject(resetObj);
-
-            // Disable target path suppression
-            var disableSuppressionPromise = UI.setSuppressTargetPaths(false);
-
-            return Promise.join(resetPromise,
+                 disableSuppressionPromise = UI.setSuppressTargetPaths(false);
+            return Promise.join(setPromise,
                 disableSuppressionPromise, backspacePromise, deletePromise);
-        };
+        }
+    };
+
+    /**
+     * @implements {Tool}
+     * @constructor
+     */
+    var PenTool = function () {
+        Tool.call(this, "pen", "Pen", "penTool");
 
         var deselectHandler = function () {
-            var targetPathsPromise = UI.setSuppressTargetPaths(true),
-                backspacePromise = this.transfer(shortcuts.removeShortcut, "penBackspace"),
+            var backspacePromise = this.transfer(shortcuts.removeShortcut, "penBackspace"),
                 deletePromise = this.transfer(shortcuts.removeShortcut, "penDelete");
 
-            return Promise.join(targetPathsPromise, backspacePromise, deletePromise);
+            return Promise.join(backspacePromise, deletePromise);
         };
 
         var backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
@@ -91,9 +107,10 @@ define(function (require, exports, module) {
             deleteKeyPolicy
         ];
         
-        this.selectHandler = selectHandler;
+        this.selectHandler = _selectHandler;
         this.deselectHandler = deselectHandler;
         this.activationKey = shortcutUtil.GLOBAL.TOOLS.PEN;
+        this.handleVectorMaskMode = true;
     };
     util.inherits(PenTool, Tool);
 

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -30,51 +30,69 @@ define(function (require, exports, module) {
         descriptor = require("adapter/ps/descriptor"),
         toolLib = require("adapter/lib/tool"),
         OS = require("adapter/os"),
-        UI = require("adapter/ps/ui");
+        UI = require("adapter/ps/ui"),
+        vectorMaskLib = require("adapter/lib/vectorMask");
 
     var Tool = require("js/models/tool"),
         toolActions = require("js/actions/tools"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
-        shortcuts = require("js/util/shortcuts");
+        utilShortcuts = require("js/util/shortcuts");
+
+    /**
+     * Sets the tool into either path or shape mode and calls the approprate PS actions based on that mode
+     *
+     * @private
+     */
+    var _selectHandler = function () {
+        var toolStore = this.flux.store("tool"),
+            vectorMode = toolStore.getVectorMode() || false,
+            toolMode = toolLib.shapeVectorTool,
+            firstLaunch = true;
+
+        if (vectorMode) {
+            toolMode = toolLib.pathVectorTool;
+        }
+
+        var setObj = toolLib.setShapeTool(toolMode);
+
+        var setPromise = descriptor.batchPlayObjects([setObj]);
+
+        if (!vectorMode && firstLaunch) {
+            var fillColor = [217, 217, 217],
+                strokeColor = [157, 157, 157];
+
+            var defaultPromise = this.transfer(toolActions.installShapeDefaults,
+                "rectangleTool", strokeColor, 2, 100, fillColor);
+
+            firstLaunch = false;
+            return Promise.join(defaultPromise, setPromise);
+        } else if (!vectorMode) {
+            return Promise.join(setPromise);
+        } else {
+            return setPromise
+            .then(function () {
+                return UI.setSuppressTargetPaths(false);
+            })
+            .then(function () {
+                return descriptor.playObject(vectorMaskLib.activateVectorMaskEditing());
+            });
+        }
+    };
 
     /**
      * @implements {Tool}
      * @constructor
      */
     var RectangleTool = function () {
-        var toolOptions = {
-            "$Abbx": false // Don't show transform controls
-        };
-
-        var toolOptionsObj = toolLib.setToolOptions("moveTool", toolOptions),
-            resetObj = toolLib.resetShapeTool(),
-            firstLaunch = true;
-
-        var selectHandler = function () {
-            var resetPromise = descriptor.batchPlayObjects([resetObj, toolOptionsObj]),
-                defaultPromise;
-            if (firstLaunch) {
-                var fillColor = [217, 217, 217],
-                    strokeColor = [157, 157, 157];
-
-                defaultPromise = this.transfer(toolActions.installShapeDefaults,
-                    "rectangleTool", strokeColor, 2, 100, fillColor);
-
-                firstLaunch = false;
-                return Promise.join(defaultPromise, resetPromise);
-            } else {
-                return resetPromise;
-            }
-        };
-
         var shiftUKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, { shift: true }, shortcuts.GLOBAL.TOOLS.SHAPE);
+                OS.eventKind.KEY_DOWN, { shift: true }, utilShortcuts.GLOBAL.TOOLS.SHAPE);
 
-        Tool.call(this, "rectangle", "Rectangle", "rectangleTool", selectHandler);
+        Tool.call(this, "rectangle", "Rectangle", "rectangleTool", _selectHandler);
        
         this.keyboardPolicyList = [shiftUKeyPolicy];
-        this.activationKey = shortcuts.GLOBAL.TOOLS.RECTANGLE;
+        this.activationKey = utilShortcuts.GLOBAL.TOOLS.RECTANGLE;
+        this.handleVectorMaskMode = true;
     };
     util.inherits(RectangleTool, Tool);
 
@@ -88,10 +106,12 @@ define(function (require, exports, module) {
             toolStore = flux.store("tool"),
             detail = event.detail;
 
-        if (detail.keyChar === shortcuts.GLOBAL.TOOLS.SHAPE && detail.modifiers.shift) {
+        if (detail.keyChar === utilShortcuts.GLOBAL.TOOLS.SHAPE && detail.modifiers.shift) {
             flux.actions.tools.select(toolStore.getToolByID("ellipse"));
         }
     };
+
+    RectangleTool.prototype.toolMode = toolLib.shapeVectorTool;
 
     module.exports = RectangleTool;
 });

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -24,19 +24,18 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var _ = require("lodash"),
-        Promise = require("bluebird");
+    var _ = require("lodash");
 
     var util = require("adapter/util"),
         descriptor = require("adapter/ps/descriptor"),
         OS = require("adapter/os"),
         UI = require("adapter/ps/ui"),
-        toolLib = require("adapter/lib/tool");
+        toolLib = require("adapter/lib/tool"),
+        vectorMaskLib = require("adapter/lib/vectorMask");
 
     var Tool = require("js/models/tool"),
         VectorTool = require("./superselect/vector"),
         TypeTool = require("./superselect/type"),
-        events = require("js/events"),
         system = require("js/util/system"),
         shortcuts = require("js/util/shortcuts"),
         SuperselectOverlay = require("jsx!js/jsx/tools/SuperselectOverlay"),
@@ -50,6 +49,58 @@ define(function (require, exports, module) {
     var _spaceKeyDown;
 
     /**
+     * @private
+     */
+    var _selectHandler = function () {
+        var toolOptions = {
+                "$AtSl": false, // Don't auto select on drag
+                "$ASGr": false, // Don't auto select Groups,
+                "$Abbx": true // Show transform controls
+            };
+
+        var toolStore = this.flux.store("tool"),
+            vectorMode = toolStore.getVectorMode() || false;
+
+        if (!vectorMode) {
+            return descriptor.playObject(toolLib.setToolOptions("moveTool", toolOptions))
+                .then(function () {
+                    UI.setPointerPropagationMode({
+                        defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
+                    });
+                });
+        } else {
+            return descriptor.playObject(vectorMaskLib.activateVectorMaskEditing())
+                .then(function () {
+                    descriptor.batchPlayObjects([vectorMaskLib.enterFreeTransformPathMode()],
+                        { synchronous: false });
+                });
+        }
+    };
+
+    /**
+     * @private
+     */
+    var _deselectHandler = function () {
+        return UI.setPointerPropagationMode({
+            defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE
+        });
+    };
+
+    /**
+     * @private
+     */
+    var _nativeToolName = function () {
+        var toolStore = this.flux.store("tool"),
+            vectorMode = toolStore.getVectorMode() || false;
+
+        if (vectorMode) {
+            return "directSelectTool";
+        } else {
+            return "moveTool";
+        }
+    };
+
+    /**
      * @implements {Tool}
      * @constructor
      */
@@ -57,38 +108,14 @@ define(function (require, exports, module) {
         this.id = "newSelect";
         this.icon = "newSelect";
         this.name = "Super Select";
-        this.nativeToolName = "moveTool";
+        this.nativeToolName = _nativeToolName;
         this.dragging = false;
         this.dragEvent = null;
         this.activationKey = shortcuts.GLOBAL.TOOLS.SELECT;
-        
-        var selectHandler = function () {
-            var toolOptions = {
-                "$AtSl": false, // Don't auto select on drag
-                "$ASGr": false, // Don't auto select Groups,
-                "$Abbx": true // Show transform controls
-            };
+        this.handleVectorMaskMode = true;
 
-            return descriptor.playObject(toolLib.setToolOptions("moveTool", toolOptions))
-                .bind(this)
-                .then(function () {
-                    var propMode = UI.setPointerPropagationMode({
-                            defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
-                        }),
-                        marquee = this.dispatchAsync(events.ui.SUPERSELECT_MARQUEE, { enabled: false });
-
-                    return Promise.join(propMode, marquee);
-                });
-        };
-
-        var deselectHandler = function () {
-            return UI.setPointerPropagationMode({
-                defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE
-            });
-        };
-
-        this.selectHandler = selectHandler;
-        this.deselectHandler = deselectHandler;
+        this.selectHandler = _selectHandler;
+        this.deselectHandler = _deselectHandler;
 
         var escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE),

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         
     var Tool = require("js/models/tool"),
         shortcuts = require("js/actions/shortcuts"),
+      //  utilShortcuts = require("js/util/shortcuts"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
 
@@ -48,11 +49,10 @@ define(function (require, exports, module) {
     var _deselectHandler = function () {
         var currentDocument = this.flux.store("application").getCurrentDocument();
 
-        var targetPathsPromise = UI.setSuppressTargetPaths(true),
-            backspacePromise = this.transfer(shortcuts.removeShortcut, "vectorBackspace"),
+        var backspacePromise = this.transfer(shortcuts.removeShortcut, "vectorBackspace"),
             deletePromise = this.transfer(shortcuts.removeShortcut, "vectorDelete");
 
-        return Promise.join(targetPathsPromise, backspacePromise, deletePromise)
+        return Promise.join(backspacePromise, deletePromise)
             .bind(this)
             .then(function () {
                 if (currentDocument) {
@@ -103,6 +103,7 @@ define(function (require, exports, module) {
         Tool.call(this, "superselectVector", "Superselect - Direct Select", "directSelectTool");
         this.icon = "directSelect";
         this.isMainTool = false;
+        this.handleVectorMaskMode = true;
 
         var escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE),

--- a/src/nls/de/shortcuts-mac.json
+++ b/src/nls/de/shortcuts-mac.json
@@ -70,7 +70,8 @@
             "ELLIPSE": "e",
             "PEN": "v",
             "TYPE": "t",
-            "SAMPLER": "i"
+            "SAMPLER": "i",
+            "VECTOR_MASK": "m"
         }
     }
 }

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -106,7 +106,8 @@
             "WEB_1440_900": "Web (1440 x 900)",
             "WEB_1920_1080": "Web (1920 x 1080)"
         },
-        "EDIT_VECTOR_MASK": "Edit Vector Mask"
+        "EDIT_VECTOR_MASK": "Edit Vector Mask",
+        "CREATE_ARTBOARD": "Create New Artboard"
     },
     "TYPE": {
         "$MENU": "Type",

--- a/src/nls/root/shortcuts-mac.json
+++ b/src/nls/root/shortcuts-mac.json
@@ -71,7 +71,9 @@
             "ELLIPSE": "e",
             "PEN": "p",
             "TYPE": "t",
-            "SAMPLER": "i"
+            "SAMPLER": "i",
+            "MASK_SELECT": "m",
+            "VECTOR_SELECT": "a"
         }
     }
 }

--- a/src/nls/root/shortcuts-win.json
+++ b/src/nls/root/shortcuts-win.json
@@ -68,7 +68,9 @@
             "ELLIPSE": "e",
             "PEN": "p",
             "TYPE": "t",
-            "SAMPLER": "i"
+            "SAMPLER": "i",
+            "MASK_SELECT": "m",
+            "VECTOR_SELECT": "a"
         }
     }
 }

--- a/src/style/toolbar.less
+++ b/src/style/toolbar.less
@@ -61,6 +61,10 @@
     display: none;
 }
 
+.toolbar__pink  {
+    color: rgba(255,100,100,1)
+}
+
 .toolbar li .button-simple:first-child {
     margin: 0;
 }

--- a/test/spec/static/layers.json
+++ b/test/spec/static/layers.json
@@ -53,7 +53,7 @@
                 }
             }
         },
-        "boundsNoEffects": {
+        "boundsNoMask": {
             "_obj": "rectangle",
             "_value": {
                 "bottom": {
@@ -218,7 +218,7 @@
                 }
             }
         },
-        "boundsNoEffects": {
+        "boundsNoMask": {
             "_obj": "rectangle",
             "_value": {
                 "bottom": {


### PR DESCRIPTION
Allows users to edit existing vector masks, requires https://github.com/adobe-photoshop/spaces-adapter/pull/143 

there are a few blocking bugs, but i thought it would be helpful to get this PR back up with my more recent changes. 

the blocking bugs are :
entering the modal state in the mask tool blocks CEF from responding to commands, 
vector masks spoil our bounds in a way that makes resizing layers impossible, 
and the pen tool does not edit the vector mask, instead it edits the work path, ( which is useless to us) 
