### PR TITLE
Better ordering of search results

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -255,13 +255,37 @@ define(function (require, exports, module) {
             }.bind(this));
 
             var optionList = filteredOptionGroups.reduce(function (filteredOptions, group) {
+                // Whether this group of options should be listed first
+                var topGroup = false;
+
                 // Sort by priority, then only take the object, without the priority
+                // While sorting, figure out which of the categories should be at the top of the 
+                // search bar. If a group contains the autofill suggestion, it should move to the top.
+                //
+                // The filters group should go above all of the other groups of options. Since
+                // we can guarentee the filters are the last group in this.state.groupedOptions,
+                // they will be moved to the top of the list of options last
                 var sortedOptions = group.sortBy(function (opt) {
-                        return opt[1];
+                        var priority = opt[1];
+
+                        // group contains the autofill suggestion
+                        if (priority === 0) {
+                            topGroup = true;
+                        }
+                        return priority;
                     }).map(function (opt) {
-                        return opt[0];
+                        var option = opt[0];
+                        //  group contains the filters so should be at top of list.
+                        if (option.type === "filter") {
+                            topGroup = true;
+                        }
+                        return option;
                     });
-                
+
+                if (topGroup) {
+                    return sortedOptions.concat(filteredOptions);
+                }
+
                 return filteredOptions.concat(sortedOptions);
             }, Immutable.List());
 

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -93,6 +93,13 @@ define(function (require, exports, module) {
 
         componentDidUpdate: function () {
             this._updateAutofillPosition();
+
+            // If there is no autofill suggestion and nothing else is selected,
+            // select the first element
+            if (this.props.useAutofill && !this.state.id && this.refs.select) {
+                var options = this._filterOptions(this.state.filter.toLowerCase(), false);
+                this.refs.select._selectExtreme(options, "next", 0);
+            }
         },
 
         /**
@@ -445,7 +452,7 @@ define(function (require, exports, module) {
                     }) : null;
                 }
 
-                var suggestionID = suggestion ? suggestion.id : this.state.id,
+                var suggestionID = suggestion && suggestion.id,
                     suggestionTitle = suggestion ? suggestion.title : "";
 
                 // If all the options are headers (no confirmable options, then set selected ID to null or placeholder
@@ -459,8 +466,12 @@ define(function (require, exports, module) {
                     suggestTitle: suggestionTitle
                 });
 
-                if (this.refs.select) {
-                    this.refs.select._setSelected(suggestionID);
+                if (this.refs.select && valueLowerCase !== "") {
+                    if (suggestionID) {
+                        this.refs.select._setSelected(suggestionID);
+                    } else { // If there is no suggestion, select the first selectable option
+                        this.refs.select._selectExtreme(options, "next", 0);
+                    }
                 }
             }
         },

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -227,7 +227,8 @@ define(function (require, exports, module) {
                         return items.concat(options);
                     }.bind(this), []);
 
-                search.searchItems = Immutable.List(searchItems).unshift(filterItems);
+                searchItems.push(Immutable.List(filterItems));
+                search.searchItems = Immutable.List(searchItems);
             }
             this.emit("change");
         },
@@ -303,7 +304,7 @@ define(function (require, exports, module) {
          * Make list of search category dropdown options
          * 
          * @param {Array.<string>} searchTypes Headers to make filters for
-         * @return {Immutable.List.<object>}
+         * @return {Array.<object>}
          */
         _getFilterOptions: function (searchTypes) {
             var allFilters = [];
@@ -340,14 +341,15 @@ define(function (require, exports, module) {
                 allFilters = allFilters.concat(filters);
             }, this);
 
-            var header = {
+            var filterHeader = {
                 id: "FILTER-header",
                 title: HEADERS.FILTER,
                 category: [],
                 type: "header"
             };
 
-            return Immutable.List(allFilters).unshift(header);
+            allFilters.unshift(filterHeader);
+            return allFilters;
         }
     });
         


### PR DESCRIPTION
Order search results so that the group of options that contains the suggestion is on top. Also if there is no suggestion, select the first item. With these changes, you will always be able to see what is selected (with the one exception of the first render, when you open the dialog and click on the text input).

As a side effect, also fixes a bug where the search bar would not reopen after hitting escape on a search with a filter applied. The dialog would not close properly in that case, because the filter element was still selected. Now, after applying a filter, the first element of the list will be selected and the modal will fully close when you hit escape.