### PR TITLE
Use correct descriptor name for libraries

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -567,7 +567,7 @@ define(function (require, exports) {
         var dependencies = {
             // Photoshop on startup will grab the port of the CC Library process and expose it to us
             vulcanCall: function (requestType, requestPayload, responseType, callback) {
-                descriptor.getProperty("application", "designSpaceLibrariesIMSInfo")
+                descriptor.getProperty("application", "designSpaceLibrariesInfo")
                     .then(function (imsInfo) {
                         var port = imsInfo.port;
 


### PR DESCRIPTION
I've removed the IMS connection from Photoshop as we don't use it. And changed the descriptor names... because there is no IMS information anymore.

This will require pg-dev-mac 440 to work. So @shaoshing, please merge this once you grab the latest Jenkins build as to not disturb your library work progress.