### PR TITLE
Don't encode search item type in IDs

### DIFF
--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
     /**
      * Unique identifier for the Search Dialog
      *
-     * @const {String}
+     * @const {string}
      */
     var SEARCH_BAR_DIALOG_ID = "search-bar-dialog";
 

--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -294,14 +294,18 @@ define(function (require, exports, module) {
          *
          */
         _selectExtreme: function (options, property, extreme) {
-            var selectedKey = options.get(extreme).id;
+            var selectedOption = options.get(extreme),
+                validOption = selectedOption.type ? selectedOption.type !== "header" : true,
+                selectedKey = selectedOption.id;
             
-            while (extreme < options.size - 1 && selectedKey.indexOf("header") > -1) {
+            while (extreme < options.size - 1 && !validOption) {
                 extreme++;
-                selectedKey = options.get(extreme).id;
+                selectedOption = options.get(extreme);
+                validOption = selectedOption.type ? selectedOption.type !== "header" : true;
+                selectedKey = selectedOption.id;
             }
             
-            if (selectedKey && selectedKey.indexOf("header") === -1) {
+            if (selectedKey && validOption) {
                 this._setSelected(selectedKey);
                 this._scrollTo(selectedKey);
                 return;


### PR DESCRIPTION
Instead, keeps a list of IDs that correspond to items with type "filter" to check if an item is a filter, or look directly at the item's type if that is easily available.

Issue #1966