### PR TITLE
Clean up of a few older components that weren't using classnames() to its full potential

### DIFF
--- a/src/js/jsx/shared/Button.jsx
+++ b/src/js/jsx/shared/Button.jsx
@@ -36,11 +36,7 @@ define(function (require, exports, module) {
                 "button-simple__disabled": this.props.disabled
             };
 
-            if (this.props.hasOwnProperty("className")) {
-                classNameSet[this.props.className] = true;
-            }
-
-            var className = classnames(classNameSet),
+            var className = classnames(classNameSet, this.props.className),
                 handleClick = !this.props.disabled && this.props.onClick,
                 handleDoubleClick = !this.props.disabled && this.props.onDoubleClick;
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -351,21 +351,8 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var classNameSet = {};
-            
-            if (_typeToClass.hasOwnProperty()) {
-                classNameSet[_typeToClass[this.props.valueType]] = true;
-            }
+            var className = classnames(_typeToClass[this.props.valueType], this.props.className, this.props.size);
 
-            if (this.props.className) {
-                classNameSet[this.props.className] = true;
-            }
-
-            if (this.props.size) {
-                classNameSet[this.props.size] = true;
-            }
-
-            var className = classnames(classNameSet);
             if (this.state.editing || this.props.live) {
                 return (
                     <input

--- a/src/js/jsx/shared/ToggleButton.jsx
+++ b/src/js/jsx/shared/ToggleButton.jsx
@@ -62,20 +62,13 @@ define(function (require, exports, module) {
 
         render: function () {
             var selected = _normalizeSelected(this.props.selected),
-                size = this.props.size || "column-1",
                 buttonType = this.props.buttonType || "default",
-                classNameProp = this.props.className,
+                size = this.props.size || "column-1",
                 classNameSet = {
                     "button-toggle": true,
                     "button-toggle__disabled": this.props.disabled
-                };
-
-            classNameSet[size] = true;
-            if (classNameProp) {
-                classNameSet[classNameProp] = true;
-            }
-
-            var className = classnames(classNameSet),
+                },
+                className = classnames(classNameSet, size, this.props.className),
                 selectedButtonType = this.props.selectedButtonType;
                 
             if (selected && selectedButtonType) {


### PR DESCRIPTION
The new version of `classnames()`, which replaced the old react add-on, is more powerful and smart and stuff.