### PR TITLE
Center search dialog when there is no document

### DIFF
--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -139,12 +139,14 @@ define(function (require, exports, module) {
         },
 
         render: function () {
+            var hasDocument = this.getFlux().store("application").getCurrentDocument();
+
             var className = classnames({
                 main: true,
                 "main__ready": this.state.ready,
-                "main__no-panel": this.state.numberOfPanels === 0,
-                "main__one-panel": this.state.numberOfPanels === 1,
-                "main__both-panel": this.state.numberOfPanels === 2
+                "main__no-panel": hasDocument && this.state.numberOfPanels === 0,
+                "main__one-panel": !hasDocument || this.state.numberOfPanels === 1,
+                "main__both-panel": hasDocument && this.state.numberOfPanels === 2
             });
             return (
                 <div className={className}>


### PR DESCRIPTION
Before it would center the dialog based on your preferences, even though there is always one panel when there is no document. Now, we always assume there's one panel when there is no document open. #2003 