### PR TITLE
CC Libraries - improvements

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -42,9 +42,17 @@ define(function (require, exports) {
         layerActions = require("./layers"),
         searchActions = require("./search/libraries"),
         documentActions = require("./documents"),
-        pathUtil = require("js/util/path");
+        pathUtil = require("js/util/path"),
+        preferencesActions = require("./preferences");
 
-    /** 
+    /**
+     * Preference name for storing the ID of the last selected library.
+     *
+     * @private
+     */
+    var _LAST_SELECTED_LIBRARY_ID_PREF = "lastSelectedLibraryID";
+
+    /**
      * For image elements, their extensions signify their representation type
      *
      * @type {Object}
@@ -97,7 +105,7 @@ define(function (require, exports) {
                 return representations[i];
             }
         }
-            
+
         throw new Error("Can't find a usable representation for image element: " + element.name);
     };
 
@@ -142,30 +150,30 @@ define(function (require, exports) {
                 representationType = _EXTENSION_TO_REPRESENTATION_MAP[fileExtension];
             }
         }
-        
+
         var tempLayerName = (new Date().getTime()).toString();
 
         return os.getTempFilename(tempLayerName)
             .bind(this)
             .then(function (tempFilename) {
-                // Export the selected layers 
+                // Export the selected layers
                 var tempPath = path.dirname(tempFilename.path),
                     tempPreviewPath = tempPath + "/preview.png",
                     previewSize = { w: 248, h: 188 },
                     exportObj = libraryAdapter.exportLayer(tempPath, tempPreviewPath, tempLayerName, previewSize);
-                        
+
                 return descriptor.playObject(exportObj);
             })
             .then(function (saveData) {
                 // Create new graphic asset of the exported layer(s) using the CC Libraries api.
-                
+
                 currentLibrary.beginOperation();
                 newElement = currentLibrary.createElement(currentLayer.name, IMAGE_ELEMENT_TYPE);
 
                 return Promise.fromNode(function (cb) {
                     var exportedLayerPath = saveData.in._path,
                         representation = newElement.createRepresentation(representationType, "primary");
-                    
+
                     representation.updateContentFromPath(exportedLayerPath, false, cb);
                 }).finally(function () {
                     currentLibrary.endOperation();
@@ -450,13 +458,13 @@ define(function (require, exports) {
             .then(function (nextDocumentIDS) {
                 // Expanded graphic asset (by holding OPT/ALT) will result in creating multiple new layer IDs.
                 // We can get these new IDs by calculating the difference between the next and existing layer IDs.
-                // 
-                // FIXME: we should instead get IDs back from Photoshop when layers are placed so we don't have 
-                //        to get all the layer IDs. 
-                
+                //
+                // FIXME: we should instead get IDs back from Photoshop when layers are placed so we don't have
+                //        to get all the layer IDs.
+
                 var nextLayerIDs = nextDocumentIDS.layerIDs,
                     existingLayerIDs = currentDocument.layers.index.toArray();
-                    
+
                 return _.difference(nextLayerIDs, existingLayerIDs).reverse();
             })
             .then(function (newLayerIDs) {
@@ -536,7 +544,7 @@ define(function (require, exports) {
     applyCharacterStyle.reads = [locks.JS_APP, locks.CC_LIBRARIES];
     applyCharacterStyle.writes = [locks.JS_DOC, locks.PS_DOC];
     applyCharacterStyle.transfers = [layerActions.resetLayers];
-    
+
     /**
      * Marks the given library ID as the active one
      *
@@ -545,10 +553,14 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var selectLibrary = function (id) {
-        return this.dispatchAsync(events.libraries.LIBRARY_SELECTED, { id: id });
+        return this.dispatchAsync(events.libraries.LIBRARY_SELECTED, { id: id })
+            .then(function () {
+                return this.transfer(preferencesActions.setPreference, _LAST_SELECTED_LIBRARY_ID_PREF, id);
+            });
     };
     selectLibrary.reads = [];
     selectLibrary.writes = [locks.JS_LIBRARIES];
+    selectLibrary.transfers = [preferencesActions.setPreference];
 
     /**
      * Creates a new library with the given name
@@ -639,14 +651,17 @@ define(function (require, exports) {
             return this.dispatchAsync(events.libraries.CONNECTION_FAILED);
         }
 
+        var preferences = this.flux.store("preferences").getState();
+
         // FIXME: Do we eventually need to handle other collections?
         var payload = {
             libraries: libraryCollection[0].libraries,
+            lastSelectedLibraryID: preferences.get(_LAST_SELECTED_LIBRARY_ID_PREF),
             collection: libraryCollection[0]
         };
 
         searchActions.registerLibrarySearch.call(this, libraryCollection[0].libraries);
-
+        
         return this.dispatchAsync(events.libraries.LIBRARIES_UPDATED, payload);
     };
     afterStartup.reads = [locks.JS_PREF, locks.CC_LIBRARIES];

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -142,14 +142,14 @@ define(function (require, exports) {
                 representationType = _EXTENSION_TO_REPRESENTATION_MAP[fileExtension];
             }
         }
+        
+        var tempLayerName = (new Date().getTime()).toString();
 
-        return os.getTempFilename(currentLayer.name)
+        return os.getTempFilename(tempLayerName)
             .bind(this)
             .then(function (tempFilename) {
                 // Export the selected layers 
-                
                 var tempPath = path.dirname(tempFilename.path),
-                    tempLayerName = path.basename(tempFilename.path),
                     tempPreviewPath = tempPath + "/preview.png",
                     previewSize = { w: 248, h: 188 },
                     exportObj = libraryAdapter.exportLayer(tempPath, tempPreviewPath, tempLayerName, previewSize);

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -49,19 +49,14 @@ define(function (require, exports, module) {
         getStateFromFlux: function () {
             var libraryStore = this.getFlux().store("library"),
                 libraries = libraryStore.getLibraries(),
-                selectedLibraryID = this.state ? this.state.selectedLibraryID : null,
                 dndState = this.getFlux().store("draganddrop").getState(),
                 isDropTarget = dndState.dropTarget && dndState.dropTarget.key === DroppablePanel.DROPPABLE_KEY;
-                
-            if (!selectedLibraryID && !libraries.isEmpty()) {
-                selectedLibraryID = libraries.keySeq().first();
-            }
 
             return {
                 libraries: libraries,
-                selectedLibraryID: selectedLibraryID,
                 isDropTarget: isDropTarget,
-                isValidDropTarget: dndState.hasValidDropTarget
+                isValidDropTarget: dndState.hasValidDropTarget,
+                selectedLibrary: libraryStore.getCurrentLibrary()
             };
         },
 
@@ -94,10 +89,6 @@ define(function (require, exports, module) {
         },
 
         _handleLibraryChange: function (libraryID) {
-            this.setState({
-                selectedLibraryID: libraryID
-            });
-
             this.getFlux().actions.libraries.selectLibrary(libraryID);
         },
 
@@ -123,7 +114,7 @@ define(function (require, exports, module) {
             var libraryStore = this.getFlux().store("library"),
                 connected = libraryStore.getConnectionStatus(),
                 libraries = this.state.libraries,
-                currentLibrary = libraries.get(this.state.selectedLibraryID),
+                currentLibrary = this.state.selectedLibrary,
                 containerContents;
 
             if (connected) {
@@ -186,7 +177,7 @@ define(function (require, exports, module) {
                 "libraries": true,
                 "section": true,
                 "section__collapsed": !this.props.visible,
-                "libraries_no-drop": this.state.isDropTarget && !this.state.selectedLibraryID
+                "libraries_no-drop": this.state.isDropTarget && !this.state.selectedLibrary
             });
 
             var librariesContent = this._renderLibrariesContent(),

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
 
             if (library.elements.length === 0) {
                 return (
-                    <div className={"libraries__content libraries__info " + this.props.className}>
+                    <div className="libraries__content libraries__info">
                         <div className="libraries__info__title">
                             {strings.LIBRARIES.INTRO_TITLE}
                         </div>
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
                 brushAssets = this._renderAssets("brush", strings.LIBRARIES.BRUSHES);
 
             return (
-                <div className={"libraries__content " + this.props.className}>
+                <div className="libraries__content">
                     {colorAssets}
                     {colorThemeAssets}
                     {charStyleAssets}

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         classnames = require("classnames"),
-        tinycolor = require("tinycolor");
+        tinycolor = require("tinycolor"),
+        _ = require("lodash");
         
     var strings = require("i18n!nls/strings");
     
@@ -77,7 +78,14 @@ define(function (require, exports, module) {
                 charStyle = element.getPrimaryRepresentation().getValue("characterstyle", "data"),
                 font = charStyle.adbeFont,
                 fontSize = charStyle.fontSize,
+                fontSizeStr = fontSize ? fontSize.value + fontSize.type : null,
+                fontColorHex = null;
+                
+            if (charStyle.color && charStyle.color[0]) {
                 fontColorHex = tinycolor(charStyle.color[0].value).toHexString().toUpperCase();
+            }
+            
+            var fontSizeAndColorStr = _.remove([fontSizeStr, fontColorHex], null).join(", ");
             
             var classNames = classnames("libraries__asset", {
                 "assets__graphic__dragging": this.props.isDragging,
@@ -88,10 +96,13 @@ define(function (require, exports, module) {
                 <div className="libraries__asset__desc">
                     <div>{font.name} {font.style}</div>
                     <div className="libraries__asset__desc-details">
-                        {fontSize.value}{fontSize.type}, {fontColorHex}
+                        {fontSizeAndColorStr}
                     </div>
                 </div>
             );
+            
+            var fontColorPreview = fontColorHex && (<div style={{ backgroundColor: fontColorHex }}
+                    className="libraries__asset__preview-character-style__color-swatch"/>);
 
             return (
                 <div className={classNames}
@@ -100,8 +111,7 @@ define(function (require, exports, module) {
                      onClick={this._handleSelect}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style">
                         <img src={this.state.renditionPath}/>
-                        <div className="libraries__asset__preview-character-style__color-swatch"
-                             style={{ backgroundColor: fontColorHex }}/>
+                        {fontColorPreview}
                     </div>
                     {description}
                 </div>

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
          */
         _handleReset: function () {
             this._libraries = Immutable.Map();
-            this._currentLibraryID = "";
+            this._currentLibraryID = null;
             this._serviceConnected = false;
         },
 
@@ -87,7 +87,11 @@ define(function (require, exports, module) {
          * Handles a library collection load
          *
          * @private
-         * @param {{libraries: Array.<AdobeLibraryComposite>, collection: AdobeLibraryCollection}} payload
+         * @param {Object} payload - required attributes {
+         *        	libraries: Array.<AdobeLibraryComposite>, 
+         *        	collection: AdobeLibraryCollection,
+         *        	lastSelectedLibraryID: ?string
+         *        }
          */
         _handleLibraryData: function (payload) {
             var libraries = payload.libraries,
@@ -97,6 +101,14 @@ define(function (require, exports, module) {
             this._libraries = Immutable.Map(zippedList);
             this._libraryCollection = payload.collection;
             this._serviceConnected = true;
+            
+            if (!this._libraries.isEmpty()) {
+                if (this._libraries.has(payload.lastSelectedLibraryID)) {
+                    this._currentLibraryID = payload.lastSelectedLibraryID;
+                } else {
+                    this._currentLibraryID = this._libraries.keySeq().first();
+                }
+            }
             
             this.emit("change");
         },
@@ -162,7 +174,7 @@ define(function (require, exports, module) {
         /**
          * Returns the currently shown library
          *
-         * @return {AdobeLibraryComposite}
+         * @return {?AdobeLibraryComposite}
          */
         getCurrentLibrary: function () {
             return this._libraries.get(this._currentLibraryID);

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -141,10 +141,9 @@
     
     &__content {
         flex-shrink: 1;
+        flex-grow: 1;
         overflow-y: auto;
         overflow-x: hidden;
-        min-height: 0;
-        
     }
     
     &__info {


### PR DESCRIPTION
this PR includes the following improvements over the CC Libraries:

* Memorize the last selected library, and restore it for new documents or reload - 1909
* Do not center library content vertically
* Can add graphic asset with long layer name - 2001
* Correctly render text style with no color - 1994
* Allow drag-n-drop on the initial library - 2008

@volfied please review