### PR TITLE
Allow setting the font size on transformed layers

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -353,6 +353,10 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var resetLayers = function (document, layers) {
+        if (layers.isEmpty()) {
+            return Promise.resolve();
+        }
+
         var layerRefs = layers.map(function (layer) {
             return [
                 documentLib.referenceBy.id(document.id),
@@ -390,8 +394,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var resetBounds = function (document, layers, noHistory) {
-        if (!layers) {
-            throw new Error("Reset bounds passed invalid layers");
+        if (layers.isEmpty()) {
+            return Promise.resolve();
         }
 
         var propertyRefs = layers.map(function (layer) {

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -379,9 +379,7 @@ define(function (require, exports, module) {
                 return null;
             }
 
-            var locked = this.props.disabled || layers.some(function (layer) {
-                return layer.text && layer.text.hasTransform;
-            });
+            var locked = this.props.disabled;
 
             var characterStyles = layers.reduce(function (characterStyles, layer) {
                 if (layer.text && layer.text.characterStyle) {

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -133,7 +133,6 @@ define(function (require, exports, module) {
                     
                     return layer.isBackground ||
                         layer.kind === layer.layerKinds.ADJUSTMENT ||
-                        layer.kind === layer.layerKinds.TEXT ||
                         (!childBounds || childBounds.empty) ||
                         (!layer.isArtboard && document.layers.isEmptyGroup(layer));
                 }) ||

--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -137,9 +137,10 @@ define(function (require, exports, module) {
             model.colorValid = false;
         }
 
-        var rawSize = textStyle.hasOwnProperty("size") ?
-            textStyle.size :
-            baseParentStyle.size,
+        // Use impliedFontSize instead of size to account for the layer transform.
+        var rawSize = textStyle.hasOwnProperty("impliedFontSize") ?
+            textStyle.impliedFontSize :
+            baseParentStyle.impliedFontSize,
             textSize = unitUtil.toPixels(rawSize, resolution);
 
         if (previousResult.textSizeValid === null || previousResult.textSize === textSize) {

--- a/src/js/models/text.js
+++ b/src/js/models/text.js
@@ -27,8 +27,7 @@ define(function (require, exports, module) {
     var Immutable = require("immutable");
 
     var CharacterStyle = require("./characterstyle"),
-        ParagraphStyle = require("./paragraphstyle"),
-        math = require("js/util/math");
+        ParagraphStyle = require("./paragraphstyle");
 
     /**
      * Represents the style and context of a text layer
@@ -50,13 +49,7 @@ define(function (require, exports, module) {
          * Indicates whether the text flows within a bounding box.
          * @type {boolean} 
          */
-        box: null,
-
-        /**
-         * Indicates whether the text has been transformed.
-         * @type {boolean} 
-         */
-        hasTransform: false
+        box: null
     });
 
     /**
@@ -79,12 +72,6 @@ define(function (require, exports, module) {
 
         if (textShapes.length !== 1) {
             throw new Error("Too many text shapes!");
-        }
-
-        if (textKey.hasOwnProperty("transform")) {
-            var transform = textKey.transform;
-
-            model.hasTransform = !math.isRotation(transform);
         }
 
         model.characterStyle = CharacterStyle.fromTextDescriptor(documentDescriptor, layerDescriptor, textKey);


### PR DESCRIPTION
Longer term, we want to scale the font sizes in text layers that are transformed on canvas for both typographic and asset-export reasons. For the short term, this pull request changes how font sizes are interpreted in affine-transformed text layers such that a font size that is implied by that transform is now used instead of the literal font size used by the text rendering engine.

![implied font size](https://s3.amazonaws.com/f.cl.ly/items/2k2A3X050O3a3a193T47/Screen%20Recording%202015-08-12%20at%2008.15%20PM.gif)

More concretely, this pull request: 1) loads `impliedFontSize` into the `textSize` property of the `CharacterStyle` models, 2) removes the `hasTransform` property in text models, and 3) removes the checks that disable the `Size` component in the transform panel and the size input of the `Text` component. It's also now necessary to 4) update the `textSize` property whenever a layer is text layer resized, so when that happens we call `resetLayers` instead of just `resetBounds`. (I figured that since the `textStyle` property is apparently by far the most expensive property to fetch from layer descriptors, it didn't make sense to add a special `resetFontSize` action, though we certainly could for **_extreme performance_**.)

Aside: surprisingly, this does not seem to require an adapter update because setting the `size` property of the `textStyle` property apparently does the same thing as setting the `impliedFontSize` property, which sure seems like a bug to me.

This is a strategic retreat, but, fear not @timriot, we are still fighting this good fight!
