### PR TITLE
Prevent incorrect search option from being selected occasionally on click

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -104,6 +104,12 @@ define(function (require, exports, module) {
             searchStore._updateSearchItems(this.props.searchID);
         },
 
+        componentDidUpdate: function (prevProps, prevState) {
+            if (prevState.filter !== this.state.filter && this.refs.datalist) {
+                this.refs.datalist.resetInput(this.state.filter);
+            }
+        },
+
         /**
          * Dismiss the parent dialog
          *
@@ -141,11 +147,6 @@ define(function (require, exports, module) {
                 filter: updatedFilter,
                 icon: filterIcon
             });
-
-            this.refs.datalist.resetInput(filterValues);
-
-            // Force update datalist since it doesn't necessarily change datalist's state at all
-            this.refs.datalist.forceUpdate();
         },
 
         /**

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
         getInitialState: function () {
             return {
                 active: false,
-                filter: null,
+                filter: "",
                 id: this.props.defaultSelected,
                 suggestTitle: "" // If using autofill, the title of the suggested option
             };
@@ -95,18 +95,12 @@ define(function (require, exports, module) {
                 this.state.filter !== nextState.filter ||
                 this.state.active !== nextState.active ||
                 this.state.suggestTitle !== nextState.suggestTitle ||
+                this.props.filterIcon !== nextProps.filterIcon ||
                 this.props.value !== nextProps.value);
         },
 
         componentDidUpdate: function () {
             this._updateAutofillPosition();
-
-            // If there is no autofill suggestion and nothing else is selected,
-            // select the first element
-            if (this.props.useAutofill && !this.state.id && this.refs.select) {
-                var options = this._filterOptions(this.state.filter.toLowerCase(), false);
-                this.refs.select._selectExtreme(options, "next", 0);
-            }
         },
 
         /**
@@ -133,7 +127,7 @@ define(function (require, exports, module) {
             if (!this.state.active) {
                 this.setState({
                     active: true,
-                    filter: null
+                    filter: ""
                 });
             }
 
@@ -161,7 +155,7 @@ define(function (require, exports, module) {
                 if (!this.state.active) {
                     this.setState({
                         active: true,
-                        filter: null
+                        filter: ""
                     });
                 }
             }
@@ -469,7 +463,7 @@ define(function (require, exports, module) {
                     suggestTitle: suggestionTitle
                 });
 
-                if (this.refs.select && valueLowerCase !== "") {
+                if (this.refs.select) {
                     if (suggestionID) {
                         this.refs.select._setSelected(suggestionID);
                     } else { // If there is no suggestion, select the first selectable option
@@ -510,7 +504,7 @@ define(function (require, exports, module) {
          * @param {Array.<string>} id
          */
         resetInput: function (id) {
-            if (this.state.filter && id) {
+            if (id) {
                 var currFilter = this.state.filter.split(" "),
                     idString = _.map(id, function (idWord) {
                         if (strings.SEARCH.CATEGORIES[idWord]) {
@@ -560,8 +554,8 @@ define(function (require, exports, module) {
 
             var value = currentTitle || "",
                 filter = this.state.filter,
-                title = this.state.active && filter !== null ? filter : value,
-                searchableFilter = filter ? filter.toLowerCase() : "",
+                title = this.state.active && filter !== "" ? filter : value,
+                searchableFilter = filter.toLowerCase(),
                 filteredOptions = this._filterOptions(searchableFilter, true),
                 searchableOptions = filteredOptions;
 


### PR DESCRIPTION
This would happen because the updating of the search suggestion would occur when Datalist's filter value went from `null` to `""`. This meant that if you had no text in the input and clicked on an item, the first item would always be selected.