### PR TITLE
Handle searching for libraries that have identical names

### DIFF
--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -91,7 +91,7 @@ define(function (require, exports) {
                         name: title,
                         pathInfo: library.name + ": " + strings.SEARCH.CATEGORIES[categoryKey],
                         iconID: _getSVGClass([categoryKey]),
-                        category: ["LIBRARY", library.name, categoryKey]
+                        category: ["LIBRARY", library.id.replace(/-/g, "."), categoryKey]
                     });
                 }
             });
@@ -171,15 +171,18 @@ define(function (require, exports) {
      * @param {Array.<AdobeLibraryComposite>} libraries
      */
     var registerLibrarySearch = function (libraries) {
-        var libraryNames = libraries.length > 0 ? collection.pluck(libraries, "name") : Immutable.List(),
+        var libraryIDs = libraries.length > 0 ? collection.pluck(libraries, "id") : Immutable.List(),
+            libraryNames = libraries.length > 0 ? collection.pluck(libraries, "name") : Immutable.List(),
             assetTypes = ["LIBRARY", "GRAPHIC", "LAYERSTYLE", "CHARACTERSTYLE"];
         
-        var filters = libraryNames.concat(assetTypes);
+        var filters = libraryIDs.concat(assetTypes),
+            displayFilters = libraryNames.concat(assetTypes);
 
         var payload = {
             "type": "LIBRARY",
             "getOptions": _getLibrarySearchOptions.bind(this),
             "filters": filters,
+            "displayFilters": displayFilters,
             "handleExecute": _confirmSearch.bind(this),
             "shortenPaths": false,
             "getSVGClass": _getSVGClass

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
                 // List of IDs corresponding with the filter options and the placeholder option
                 // Gets passed to Datalist as list of option IDs that when selected, should not close the dialog
                 filterIDs: filterIDs,
-                // Filter names that contain "-", stored under names that don't contain "-", which are in the filter ID
+                // Filter names that are user-inputted strings, stored under IDs
                 safeFilterNameMap: searchState.safeFilterNameMap
             };
         },
@@ -109,6 +109,8 @@ define(function (require, exports, module) {
         componentDidUpdate: function (prevProps, prevState) {
             if (prevState.filter !== this.state.filter && this.refs.datalist) {
                 this._updateDatalistInput(this.state.filter);
+                // Force update because Datalist's state might not change at all
+                this.refs.datalist.forceUpdate();
             }
         },
 
@@ -131,16 +133,6 @@ define(function (require, exports, module) {
         _updateFilter: function (id) {
             var idArray = id ? id.split("-") : [],
                 filterValues = _.drop(idArray);
-                
-
-            _.forEach(filterValues, function (value, index) {
-                // Check if there is a different, user-facing title we should use
-                var altTitle = this.state.safeFilterNameMap[value];
-                
-                if (altTitle) {
-                    filterValues[index] = altTitle;
-                }
-            }, this);
 
             var updatedFilter = id ? _.uniq(this.state.filter.concat(filterValues)) : [],
                 filterIcon = id && this.getFlux().store("search").getSVGClass(updatedFilter);
@@ -412,8 +404,9 @@ define(function (require, exports, module) {
             // If we have applied a filter, change the placeholder text
             if (filter.length > 0) {
                 var lastFilter = filter[filter.length - 1],
-                    category = searchStrings.CATEGORIES[lastFilter] ?
-                        searchStrings.CATEGORIES[lastFilter].toLowerCase() : lastFilter;
+                    categoryString = searchStrings.CATEGORIES[lastFilter],
+                    category = categoryString ?
+                        categoryString.toLowerCase() : this.state.safeFilterNameMap[lastFilter];
                 placeholderText = searchStrings.PLACEHOLDER_FILTER + category;
             }
 

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -103,7 +103,6 @@ define(function (require, exports, module) {
                 this.state.filter !== nextState.filter ||
                 this.state.active !== nextState.active ||
                 this.state.suggestTitle !== nextState.suggestTitle ||
-                this.props.filterIcon !== nextProps.filterIcon ||
                 this.props.value !== nextProps.value);
         },
 


### PR DESCRIPTION
Issue #2024. 
There's currently no way to tell the difference between filtering for one library versus another when they have the same name, but it will at least properly filter when you select either of the two options.

I also changed back how Datalist updates when you apply a filter to a forceUpdate instead of checking if the icon changes, because when you have the "all libraries" filter selected and then pick a specific library, the icon won't change and the Datalist has no way of updating.