### PR TITLE
Clip search bar suggestion if it is longer than the text box

### DIFF
--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
         _ = require("lodash"),
         collection = require("js/util/collection");
 
-    var os = require("adapter/os");
+    var os = require("adapter/os"),
+        classnames = require("classnames");
     
     var TextInput = require("jsx!js/jsx/shared/TextInput"),
         Select = require("jsx!js/jsx/shared/Select"),
@@ -399,24 +400,34 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Updates position of autofill using hidden HTML element.
+         * Updates position and width of autofill using hidden HTML element.
          *
          * @private
          */
         _updateAutofillPosition: function () {
-            // Base position off of hidden element width
-            var hiddenInput = React.findDOMNode(this.refs.hiddenTextInput);
+            // Base position and width off of hidden element width
+            var hiddenInput = React.findDOMNode(this.refs.hiddenTextInput),
+                textInput = React.findDOMNode(this.refs.textInput);
             if (hiddenInput) {
                 // Find width for hidden text input
-                var elRect = hiddenInput.getBoundingClientRect(),
+                var hiddenElRect = hiddenInput.getBoundingClientRect(),
                     parentEl = hiddenInput.offsetParent;
                 // parentEl may not exist, for example when hitting escape
                 if (parentEl) {
                     var parentRect = parentEl.getBoundingClientRect(),
-                        width = elRect.width + (elRect.left - parentRect.left);
+                        hiddenWidth = hiddenElRect.width + (hiddenElRect.left - parentRect.left);
+
+                    var suggestionWidth = textInput.getBoundingClientRect().width - hiddenElRect.width;
 
                     if (this.refs.autocomplete) {
-                        React.findDOMNode(this.refs.autocomplete).style.left = width + "px";
+                        var style = React.findDOMNode(this.refs.autocomplete).style;
+                        if (suggestionWidth > 0) {
+                            style.left = hiddenWidth + "px";
+                            style.width = suggestionWidth + "px";
+                            style.visibility = "visible";
+                        } else {
+                            style.visibility = "hidden";
+                        }
                     }
                 }
             }
@@ -633,8 +644,13 @@ define(function (require, exports, module) {
                 );
             }
 
+            var dropDownClasses = classnames({
+                "drop-down": true,
+                "hasIcon": this.props.filterIcon
+            });
+
             return (
-                <div className="drop-down">
+                <div className={dropDownClasses}>
                     {svg}
                     {hiddenTI}
                     <TextInput

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -68,12 +68,16 @@
     background: @search-bg;
 }
 
-.search-bar__dialog .drop-down input{
+.search-bar__dialog .drop-down input {
     border: none;
     font-size: 2rem;
     margin-left: 1.1rem;
-    width: 40rem;
+    width: 42rem;
     color: @search-bright-text;
+}
+
+.search-bar__dialog .drop-down.hasIcon input {
+    width: 40rem;
 }
 
 .search-bar__dialog ::-webkit-input-placeholder {
@@ -205,6 +209,8 @@
     line-height: 2.8rem;
     white-space: pre;
     font-size: 2rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .button-simple.button-clear-search {


### PR DESCRIPTION
Issue #2025. Adjust the suggestion width to be (width of the whole text input) - (width of entered text)

@iwehrman can now open up an image of his favorite tweets without screaming :scream: