### PR TITLE
Close search when window loses focus

### DIFF
--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
                         dismissOnCanvasClick={true}
                         dismissOnWindowClick={true}
                         dismissOnWindowResize={false}
+                        dismissOnWindowBlur={true}
                         dismissOnKeys={[{ key: os.eventKeyCode.ESCAPE, modifiers: null }]}
                         className={"search-bar__dialog"} >
                         <SearchBar

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -311,7 +311,7 @@ define(function (require, exports, module) {
             this.refs.datalist.removeAutofillSuggestion();
             event.stopPropagation();
         },
-        
+
         /**
          * Perform action based on ID
          *

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -70,6 +70,7 @@ define(function (require, exports, module) {
             dismissOnSelectionTypeChange: React.PropTypes.bool,
             dismissOnWindowClick: React.PropTypes.bool,
             dismissOnWindowResize: React.PropTypes.bool,
+            dismissOnWindowBlur: React.PropTypes.bool,
             dismissOnCanvasClick: React.PropTypes.bool,
             dismissOnKeys: React.PropTypes.arrayOf(React.PropTypes.object)
         },
@@ -86,6 +87,7 @@ define(function (require, exports, module) {
                 dismissOnSelectionTypeChange: false,
                 dismissOnWindowClick: true,
                 dismissOnWindowResize: true,
+                dismissOnWindowBlur: false,
                 dismissOnCanvasClick: false
             };
         },
@@ -180,6 +182,18 @@ define(function (require, exports, module) {
             this.toggle(event);
         },
 
+
+        /**
+         * Handle window blur events, closing the open dialog.
+         *
+         * @param {Event} event
+         */
+        _handleWindowBlur: function (event) {
+            window.removeEventListener("blur", this._handleWindowBlur);
+
+            this.toggle(event);
+        },
+
         /**
          * Position the dialog according to the target
          *
@@ -235,6 +249,10 @@ define(function (require, exports, module) {
                 window.addEventListener("resize", this._handleWindowResize);
             }
 
+            if (this.props.dismissOnWindowBlur) {
+                window.addEventListener("blur", this._handleWindowBlur);
+            }
+
             if (this.props.dismissOnKeys && _.isArray(this.props.dismissOnKeys)) {
                 var flux = this.getFlux();
                 this.props.dismissOnKeys.forEach(function (keyObj) {
@@ -254,6 +272,10 @@ define(function (require, exports, module) {
 
             if (this.props.dismissOnWindowResize) {
                 window.removeEventListener("resize", this._handleWindowResize);
+            }
+
+            if (this.props.dismissOnWindowBlur) {
+                window.removeEventListener("blur", this._handleWindowBlur);
             }
 
             if (this.props.dismissOnKeys && _.isArray(this.props.dismissOnKeys)) {


### PR DESCRIPTION
Otherwise the search will lose focus but remain open, and bad things will happen when you come back to the window.

This is better than the potential for those bad things, but is also maybe not the most elegant solution-- the dialog does not actually close until you come back to the window, which means you see it disappear after a short delay. 