### PR TITLE
Make search item overflow ellipsis color match secondary info

### DIFF
--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -124,7 +124,28 @@
 .search-bar__dialog .select__option {
     padding-left: 1rem;
     padding-right: 1rem;
+    display: flex;
+    overflow: hidden;
+    text-overflow:ellipsis;
+
+    span { 
+        flex-grow: 0;
+        flex-shrink: 0;
+        max-width: 42rem;
+        overflow: hidden;
+        text-overflow:ellipsis;
+
+    }
+    svg { 
+        flex-grow: 0;
+        flex-shrink: 0;
+    }
+    .select__option__info { 
+        flex-shrink: 1;  
+        text-overflow:ellipsis;   
+    }
 }
+
 
 .search-bar__dialog .select__option__selected {
     color: @search-highlight;
@@ -188,6 +209,7 @@
 
 .search-bar__dialog .select__option__info {
     color: @search-border;
+    line-height:2.1rem;
 }
 
 .search-bar__dialog .datalist__svg {

--- a/src/style/shared/select.less
+++ b/src/style/shared/select.less
@@ -51,4 +51,6 @@
     color: @color-section-rule;
     font-size: 1.2rem;
     font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
Uses flex display to cut off additional search info. If the primary info is very long it will have a primary-info-sized ellipsis as well. Issue #2053 