### PR TITLE
Work around occasional duplicate PS make event

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -378,11 +378,13 @@ define(function (require, exports) {
      * Emit RESET_LAYERS with layer descriptors for all given layers.
      *
      * @param {Document} document
-     * @param {Immutable.Iterable.<Layer>} layers
+     * @param {Layer|Immutable.Iterable.<Layer>} layers
      * @return {Promise}
      */
     var resetLayers = function (document, layers) {
-        if (layers.isEmpty()) {
+        if (layers instanceof Layer) {
+            layers = Immutable.List.of(layers);
+        } else if (layers.isEmpty()) {
             return Promise.resolve();
         }
 
@@ -1602,7 +1604,7 @@ define(function (require, exports) {
                 if (typeof event.layerID === "number") {
                     var curLayer = currentDocument.layers.byID(event.layerID);
                     if (curLayer) {
-                        this.flux.actions.layers.resetLayers(currentDocument, Immutable.List.of(curLayer));
+                        this.flux.actions.layers.resetLayers(currentDocument, curLayer);
                     } else {
                         this.flux.actions.layers.addLayers(currentDocument, event.layerID);
                     }

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -30,7 +30,8 @@ define(function (require, exports, module) {
 
     var Color = require("js/models/color"),
         Tool = require("js/models/tool"),
-        shortcuts = require("js/util/shortcuts");
+        shortcuts = require("js/util/shortcuts"),
+        log = require("js/util/log");
 
     /**
      * Layers can be moved using type tool by holding down cmd
@@ -126,9 +127,16 @@ define(function (require, exports, module) {
 
             _layerCreatedHandler = function (event) {
                 var documentStore = this.flux.store("application"),
-                    currentDocument = documentStore.getCurrentDocument();
+                    currentDocument = documentStore.getCurrentDocument(),
+                    layerID = event.layerID,
+                    currentLayer = currentDocument.layers.byID(layerID);
 
-                this.flux.actions.layers.addLayers(currentDocument, event.layerID, true);
+                if (currentLayer) {
+                    log.warn("Unexpected createTextLayer event for layer " + layerID);
+                    this.flux.actions.layers.resetLayers(currentDocument, currentLayer);
+                } else {
+                    this.flux.actions.layers.addLayers(currentDocument, layerID, true);
+                }
             }.bind(this);
             
             descriptor.addListener("createTextLayer", _layerCreatedHandler);


### PR DESCRIPTION
This works around an apparent PS race condition in which we sometimes get both a "make" and a "createTextLayer" event at the beginning of the type modal tool state. If it's the latter, and it happens after the make event, then bad things happen. With this PR, if that happens we now log a warning and reset the selected layers. 

Addresses #1969 