### PR TITLE
Singularize stroke and fill for layer models

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -53,7 +53,7 @@ define(function (require, exports) {
 
         switch (sourceLayer.kind) {
             case layerKinds.VECTOR:
-                color = sourceLayer.fills.first() ? sourceLayer.fills.first().color : null;
+                color = sourceLayer.fill ? sourceLayer.fill.color : null;
 
                 return Promise.resolve(color);
             case layerKinds.TEXT:
@@ -244,9 +244,9 @@ define(function (require, exports) {
         });
 
         var shapeFillPromise = (!style.fillColor || shapeLayers.isEmpty()) ? Promise.resolve() :
-                this.transfer(shapeActions.setFillColor, document, shapeLayers, 0, style.fillColor, false),
+                this.transfer(shapeActions.setFillColor, document, shapeLayers, style.fillColor, false),
             shapeStrokePromise = (!style.stroke || shapeLayers.isEmpty()) ? Promise.resolve() :
-                this.transfer(shapeActions.setStroke, document, shapeLayers, 0, style.stroke, false),
+                this.transfer(shapeActions.setStroke, document, shapeLayers, style.stroke, false),
             textColorPromise = (!style.fillColor || textLayers.isEmpty()) ? Promise.resolve() :
                 this.transfer(typeActions.setColor, document, textLayers, style.fillColor, false, false),
             textStylePromise = (!style.typeStyle || textLayers.isEmpty()) ? Promise.resolve() :

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -38,7 +38,6 @@ define(function (require, exports) {
         locks = require("js/locks"),
         layerActions = require("./layers"),
         collection = require("js/util/collection"),
-        objUtil = require("js/util/object"),
         layerActionsUtil = require("js/util/layeractions"),
         strings = require("i18n!nls/strings");
 
@@ -73,17 +72,15 @@ define(function (require, exports) {
      * @private
      * @param {Document} document active Document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke in each layer
      * @param {object} strokeProperties a pseudo stroke object containing only new props
      * @param {string} eventName name of the event to emit afterwards
      * @param {boolean=} coalesce optionally include this in the payload to drive history coalescing
      * @return Promise
      */
-    var _strokeChangeDispatch = function (document, layers, strokeIndex, strokeProperties, eventName, coalesce) {
+    var _strokeChangeDispatch = function (document, layers, strokeProperties, eventName, coalesce) {
         var payload = {
                 documentID: document.id,
                 layerIDs: collection.pluck(layers, "id"),
-                strokeIndex: strokeIndex,
                 strokeProperties: strokeProperties,
                 coalesce: coalesce
             };
@@ -97,18 +94,16 @@ define(function (require, exports) {
      * @private
      * @param {Document} document active Document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} fillIndex index of the fill in each layer
      * @param {object} fillProperties a pseudo fill object containing only new props
      * @param {string} eventName name of the event to emit afterwards
      * @param {boolean=} coalesce optionally include this in the payload to drive history coalescing
      * @return Promise
      */
-    var _fillChangeDispatch = function (document, layers, fillIndex, fillProperties, eventName, coalesce) {
+    var _fillChangeDispatch = function (document, layers, fillProperties, eventName, coalesce) {
         // TODO layers param needs to be made fa real
         var payload = {
                 documentID: document.id,
                 layerIDs: collection.pluck(layers, "id"),
-                fillIndex: fillIndex,
                 fillProperties: fillProperties,
                 coalesce: coalesce
             };
@@ -117,17 +112,16 @@ define(function (require, exports) {
     };
 
     /**
-     * Test the given layers for the existence of a stroke of specified index
+     * Test the given layers for the existence of a stroke
      *
      * @private
      * @param {Immutable.Iterable.<Layer>} layers set of layers to test
-     * @param {number} strokeIndex index of the stroke of which to test or existence
      *
      * @return {boolean} true if all strokes exist
      */
-    var _allStrokesExist = function (layers, strokeIndex) {
+    var _allStrokesExist = function (layers) {
         return layers.every(function (layer) {
-            return layer.strokes && layer.strokes.get(strokeIndex);
+            return layer.stroke;
         });
     };
 
@@ -138,11 +132,10 @@ define(function (require, exports) {
      * @private
      * @param {Document} document
      * @param {Immutable.Iterable.<Layer>} layers
-     * @param {number} strokeIndex the index at which the given strokes will be added to the layer model
      *
      * @return {Promise} Promise of the initial batch call to photoshop
      */
-    var _refreshStrokes = function (document, layers, strokeIndex) {
+    var _refreshStrokes = function (document, layers) {
         var layerIDs = collection.pluck(layers, "id"),
             refs = layerLib.referenceBy.id(layerIDs.toArray());
 
@@ -154,7 +147,6 @@ define(function (require, exports) {
                 }
                 var payload = {
                     documentID: document.id,
-                    strokeIndex: strokeIndex,
                     layerIDs: layerIDs,
                     strokeStyleDescriptor: Immutable.List(_.pluck(batchGetResponse, "AGMStrokeStyleInfo"))
                 };
@@ -167,12 +159,11 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer
      * @param {Stroke} stroke Stroke properties to apply
      * @param {boolean=} enabled
      * @return {Promise}
      */
-    var setStroke = function (document, layers, strokeIndex, stroke, enabled) {
+    var setStroke = function (document, layers, stroke, enabled) {
         // if enabled is not provided, assume it is true
         // derive the type of event to be dispatched based on this parameter's existence
         var eventName,
@@ -191,7 +182,7 @@ define(function (require, exports) {
             documentRef = documentLib.referenceBy.id(document.id),
             options = _options(documentRef, strings.ACTIONS.SET_STROKE);
 
-        if (_allStrokesExist(layers, strokeIndex)) {
+        if (_allStrokesExist(layers)) {
             // toJS gets rid of color so we re-insert it here
             strokeJSObj.color = stroke.color.normalizeAlpha();
             strokeJSObj.opacity = strokeJSObj.color.a;
@@ -200,7 +191,6 @@ define(function (require, exports) {
             var dispatchPromise = _strokeChangeDispatch.call(this,
                 document,
                 layers,
-                strokeIndex,
                 strokeJSObj,
                 eventName);
 
@@ -217,7 +207,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     // upon completion, fetch the stroke info for all layers
-                    return _refreshStrokes.call(this, document, layers, strokeIndex);
+                    return _refreshStrokes.call(this, document, layers);
                 });
         }
     };
@@ -230,15 +220,14 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer
      * @param {Color} color color of the strokes, since photoshop does not provide a way to simply enable a stroke
      * @param {boolean=} enabled
      * @return {Promise}
      */
-    var setStrokeEnabled = function (document, layers, strokeIndex, color, enabled) {
+    var setStrokeEnabled = function (document, layers, color, enabled) {
         // TODO is it reasonable to not require a color, but instead to derive it here based on the selected layers?
         // the only problem with that is having to define a default color here if none can be derived
-        return setStrokeColor.call(this, document, layers, strokeIndex, color, false, enabled);
+        return setStrokeColor.call(this, document, layers, color, false, enabled);
     };
     setStrokeEnabled.reads = [];
     setStrokeEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
@@ -252,7 +241,6 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer(s)
      * @param {Color} color
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @param {boolean=} enabled optional enabled flag, default=true. If supplied, causes a resetBounds afterwards
@@ -260,7 +248,7 @@ define(function (require, exports) {
      *  supplied color and only update the opaque color.
      * @return {Promise}
      */
-    var setStrokeColor = function (document, layers, strokeIndex, color, coalesce, enabled, ignoreAlpha) {
+    var setStrokeColor = function (document, layers, color, coalesce, enabled, ignoreAlpha) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
 
@@ -287,12 +275,11 @@ define(function (require, exports) {
             documentRef = documentLib.referenceBy.id(document.id),
             options = _options(documentRef, strings.ACTIONS.SET_STROKE_COLOR, coalesce);
 
-        if (_allStrokesExist(layers, strokeIndex)) {
+        if (_allStrokesExist(layers)) {
             // optimistically dispatch the change event    
             var dispatchPromise = _strokeChangeDispatch.call(this,
                 document,
                 layers,
-                strokeIndex,
                 { enabled: enabled, color: color, ignoreAlpha: ignoreAlpha },
                 eventName,
                 coalesce);
@@ -312,7 +299,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     // upon completion, fetch the stroke info for all layers
-                    _refreshStrokes.call(this, document, layers, strokeIndex);
+                    _refreshStrokes.call(this, document, layers);
                 });
         }
     };
@@ -324,22 +311,20 @@ define(function (require, exports) {
      * Set the alignment of the stroke for all selected layers of the given document.
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer(s)
      * @param {string} alignmentType type as inside,outside, or center
      * @return {Promise}
      */
-    var setStrokeAlignment = function (document, layers, strokeIndex, alignmentType) {
+    var setStrokeAlignment = function (document, layers, alignmentType) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeAlignment(layerRef, alignmentType),
             documentRef = documentLib.referenceBy.id(document.id),
             options = _options(documentRef, strings.ACTIONS.SET_STROKE_ALIGNMENT);
 
-        if (_allStrokesExist(layers, strokeIndex)) {
+        if (_allStrokesExist(layers)) {
             // optimistically dispatch the change event    
             var dispatchPromise = _strokeChangeDispatch.call(this,
                     document,
                     layers,
-                    strokeIndex,
                     { alignment: alignmentType, enabled: true },
                     events.document.STROKE_ALIGNMENT_CHANGED);
 
@@ -355,7 +340,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     // upon completion, fetch the stroke info for all layers
-                    _refreshStrokes.call(this, document, layers, strokeIndex);
+                    _refreshStrokes.call(this, document, layers);
                 });
         }
     };
@@ -367,23 +352,21 @@ define(function (require, exports) {
      * Set the opacity of the stroke for all selected layers of the given document.
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer(s)
      * @param {number} opacity opacity as a percentage [0,100]
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var setStrokeOpacity = function (document, layers, strokeIndex, opacity, coalesce) {
+    var setStrokeOpacity = function (document, layers, opacity, coalesce) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeOpacity(layerRef, opacity),
             documentRef = documentLib.referenceBy.id(document.id),
             options = _options(documentRef, strings.ACTIONS.SET_STROKE_OPACITY, coalesce);
 
-        if (_allStrokesExist(layers, strokeIndex)) {
+        if (_allStrokesExist(layers)) {
             // optimistically dispatch the change event    
             var dispatchPromise = _strokeChangeDispatch.call(this,
                 document,
                 layers,
-                strokeIndex,
                 { opacity: opacity, enabled: true },
                 events.document.history.optimistic.STROKE_OPACITY_CHANGED,
                 coalesce);
@@ -398,7 +381,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     // upon completion, fetch the stroke info for all layers
-                    _refreshStrokes.call(this, document, layers, strokeIndex);
+                    _refreshStrokes.call(this, document, layers);
                 });
         }
     };
@@ -410,22 +393,20 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} strokeIndex index of the stroke within the layer(s)
      * @param {number} width stroke width, in pixels
      * @return {Promise}
      */
-    var setStrokeWidth = function (document, layers, strokeIndex, width) {
+    var setStrokeWidth = function (document, layers, width) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setShapeStrokeWidth(layerRef, width),
             documentRef = documentLib.referenceBy.id(document.id),
             options = _options(documentRef, strings.ACTIONS.SET_STROKE_WIDTH);
 
-        if (_allStrokesExist(layers, strokeIndex)) {
+        if (_allStrokesExist(layers)) {
             // dispatch the change event    
             var dispatchPromise = _strokeChangeDispatch.call(this,
                 document,
                 layers,
-                strokeIndex,
                 { width: width, enabled: true },
                 events.document.STROKE_WIDTH_CHANGED);
 
@@ -441,7 +422,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     // upon completion, fetch the stroke info for all layers
-                    _refreshStrokes.call(this, document, layers, strokeIndex);
+                    _refreshStrokes.call(this, document, layers);
                 });
         }
     };
@@ -450,50 +431,16 @@ define(function (require, exports) {
     setStrokeWidth.transfers = [layerActions.resetBounds];
 
     /**
-     * Add a stroke from scratch
-     * 
-     * @param {Document} document
-     * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @return {Promise}
-     */
-    var addStroke = function (document, layers) {
-        // build the playObject
-        var layerRef = contentLayerLib.referenceBy.current,
-            strokeObj = contentLayerLib.setShapeStrokeWidth(layerRef, 1), // TODO hardcoded default
-            documentRef = documentLib.referenceBy.id(document.id),
-            options = _options(documentRef, strings.ACTIONS.ADD_STROKE);
-
-        // submit to adapter
-        return layerActionsUtil.playSimpleLayerActions(document, layers, strokeObj, true, options)
-            .bind(this)
-            .then(function (playResponse) {
-                // dispatch information about the newly created stroke
-                var strokeStyleDescriptor = objUtil.getPath(playResponse, "to.strokeStyle"),
-                    payload = {
-                        documentID: document.id,
-                        layerIDs: collection.pluck(layers, "id"),
-                        strokeStyleDescriptor: strokeStyleDescriptor,
-                        strokeIndex: 0
-                    };
-
-                this.dispatch(events.document.history.nonOptimistic.STROKE_ADDED, payload);
-            });
-    };
-    addStroke.reads = [locks.PS_DOC, locks.JS_DOC];
-    addStroke.writes = [locks.PS_DOC, locks.JS_DOC];
-
-    /**
      * Set the enabled flag for the given fill of all selected Layers on a given doc
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} fillIndex index of the fill within the layer
      * @param {Color} color
      * @param {boolean=} enabled
      * @return {Promise}
      */
-    var setFillEnabled = function (document, layers, fillIndex, color, enabled) {
-        return setFillColor.call(this, document, layers, fillIndex, color, false, enabled);
+    var setFillEnabled = function (document, layers, color, enabled) {
+        return setFillColor.call(this, document, layers, color, false, enabled);
     };
     setFillEnabled.reads = [locks.PS_DOC, locks.JS_DOC];
     setFillEnabled.writes = [locks.PS_DOC, locks.JS_DOC];
@@ -503,7 +450,6 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
-     * @param {number} fillIndex index of the fill within the layer(s)
      * @param {Color} color
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @param {boolean=} enabled optional enabled flag, default=true
@@ -511,7 +457,7 @@ define(function (require, exports) {
      *  supplied color and only update the opaque color.
      * @return {Promise}
      */
-    var setFillColor = function (document, layers, fillIndex, color, coalesce, enabled, ignoreAlpha) {
+    var setFillColor = function (document, layers, color, coalesce, enabled, ignoreAlpha) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
         // if enabled is not provided, assume it is true
@@ -521,7 +467,6 @@ define(function (require, exports) {
         var dispatchPromise = _fillChangeDispatch.call(this,
             document,
             layers,
-            fillIndex,
             { color: color, enabled: enabled, ignoreAlpha: ignoreAlpha },
             events.document.history.optimistic.FILL_COLOR_CHANGED,
             coalesce);
@@ -554,17 +499,15 @@ define(function (require, exports) {
      * 
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers
-     * @param {number} fillIndex index of the fill within the layer(s)
      * @param {number} opacity Opacity percentage [0,100]
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
-    var setFillOpacity = function (document, layers, fillIndex, opacity, coalesce) {
+    var setFillOpacity = function (document, layers, opacity, coalesce) {
         // dispatch the change event
         var dispatchPromise = _fillChangeDispatch.call(this,
             document,
             layers,
-            fillIndex,
             { opacity: opacity, enabled: true },
             events.document.history.optimistic.FILL_OPACITY_CHANGED,
             coalesce);
@@ -580,36 +523,6 @@ define(function (require, exports) {
     };
     setFillOpacity.reads = [locks.PS_DOC, locks.JS_DOC];
     setFillOpacity.writes = [locks.PS_DOC, locks.JS_DOC];
-
-    /**
-     * Add a new fill to the specified layers of the specified document.
-     *
-     * @param {Document} document
-     * @param {Immutable.List.<Layer>} layers
-     * @param {Color} color of the fill to be added
-     * @return {Promise}
-     */
-    var addFill = function (document, layers, color) {
-        // build the playObject
-        var contentLayerRef = contentLayerLib.referenceBy.current,
-            fillObj = contentLayerLib.setShapeFillTypeSolidColor(contentLayerRef, color),
-            documentRef = documentLib.referenceBy.id(document.id),
-            options = _options(documentRef, strings.ACTIONS.ADD_FILL);
-
-        return layerActionsUtil.playSimpleLayerActions(document, layers, fillObj, true, options)
-            .bind(this)
-            .then(function (setDescriptor) {
-                // dispatch information about the newly created stroke
-                var payload = {
-                        documentID: document.id,
-                        layerIDs: collection.pluck(layers, "id"),
-                        setDescriptor: setDescriptor
-                    };
-                this.dispatch(events.document.history.optimistic.FILL_ADDED, payload);
-            });
-    };
-    addFill.reads = [locks.PS_DOC, locks.JS_DOC];
-    addFill.writes = [locks.PS_DOC, locks.JS_DOC];
 
     /**
      * Call the adapter and then transfer to another action to reset layers as necessary
@@ -837,12 +750,10 @@ define(function (require, exports) {
     exports.setStrokeOpacity = setStrokeOpacity;
     exports.setStrokeAlignment = setStrokeAlignment;
     exports.setStroke = setStroke;
-    exports.addStroke = addStroke;
 
     exports.setFillEnabled = setFillEnabled;
     exports.setFillColor = setFillColor;
     exports.setFillOpacity = setFillOpacity;
-    exports.addFill = addFill;
 
     exports.combineUnion = combineUnion;
     exports.combineSubtract = combineSubtract;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -57,7 +57,6 @@ define(function (require, exports, module) {
                     STROKE_OPACITY_CHANGED: "strokeOpacityChanged",
                     FILL_COLOR_CHANGED: "fillColorChanged",
                     FILL_OPACITY_CHANGED: "fillOpacityChanged",
-                    FILL_ADDED: "fillAdded",
                     LAYER_EFFECT_CHANGED: "layerEffectChanged",
                     LAYER_EFFECT_DELETED: "layerEffectDeleted",
                     LAYER_EFFECTS_BATCH_CHANGED: "layerEffectsBatchChanged",

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -79,10 +79,10 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Helper function to create color button based on the layer attribute (fills or strokes)
+         * Helper function to create color button based on the layer attribute (fill or stroke)
          * @private
          *
-         * @param {string} attr name of the color attribute ("fills" or "strokes")
+         * @param {string} attr name of the color attribute ("fill" or "stroke")
          * @param {string} buttonTitle title of the button
          *
          * @return {SplitButtonItem}
@@ -90,11 +90,11 @@ define(function (require, exports, module) {
         _createColorButton: function (attr, buttonTitle) {
             var layer = this.props.document.layers.selected.first();
 
-            if (this.props.document.layers.selected.size !== 1 || layer[attr].isEmpty()) {
+            if (this.props.document.layers.selected.size !== 1 || !layer[attr]) {
                 return null;
             }
 
-            var color = layer[attr].first().color;
+            var color = layer[attr].color;
 
             return (
                 <SplitButtonItem title={buttonTitle} disabled={this.props.disabled}>
@@ -187,8 +187,8 @@ define(function (require, exports, module) {
                             onClick={this.addLayerStyle}
                             disabled={!this._canAddLayerStyle()}
                             />
-                        {this._createColorButton("fills", strings.TOOLTIPS.ADD_FILL_COLOR)}
-                        {this._createColorButton("strokes", strings.TOOLTIPS.ADD_STROKE_COLOR)}
+                        {this._createColorButton("fill", strings.TOOLTIPS.ADD_FILL_COLOR)}
+                        {this._createColorButton("stroke", strings.TOOLTIPS.ADD_STROKE_COLOR)}
                     </ul>
 
                     <ul className="button-radio libraries-bar__section__right">

--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
         getInitialState: function () {
             return {
                 layers: Immutable.List(),
-                fill: {}
+                fill: null
             };
         },
 
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
 
         render: function () {
             // If there are no vector layers, hide the component
-            if (this.state.layers.isEmpty()) {
+            if (!this.state.fill || this.state.layers.isEmpty()) {
                 return null;
             }
 

--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -22,7 +22,7 @@
  */
 
 
-define(function (require, exports) {
+define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
@@ -37,8 +37,6 @@ define(function (require, exports) {
     var Color = require("js/models/color"),
         Gutter = require("jsx!js/jsx/shared/Gutter"),
         Label = require("jsx!js/jsx/shared/Label"),
-        Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
@@ -52,10 +50,31 @@ define(function (require, exports) {
     var Fill = React.createClass({
         mixins: [FluxMixin],
 
-        shouldComponentUpdate: function (nextProps) {
-            return !Immutable.is(this.props.fills, nextProps.fills) ||
-                this.props.index !== nextProps.index ||
-                this.props.readOnly !== nextProps.readOnly;
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return !Immutable.is(this.state.fill, nextState.fill) ||
+                this.props.disabled !== nextProps.disabled;
+        },
+
+        getInitialState: function () {
+            return {
+                layers: Immutable.List(),
+                fill: {}
+            };
+        },
+
+        componentWillReceiveProps: function (nextProps) {
+            var document = nextProps.document,
+                // We only care about vector layers.  If at least one exists, then this component should render
+                layers = document.layers.selected.filter(function (layer) {
+                    return layer.kind === layer.layerKinds.VECTOR;
+                }),
+                fills = collection.pluck(layers, "fill"),
+                downsample = this._downsampleFills(fills);
+
+            this.setState({
+                layers: layers,
+                fill: downsample
+            });
         },
 
         /**
@@ -66,15 +85,10 @@ define(function (require, exports) {
          * @param {boolean} isChecked
          */
         _toggleFillEnabled: function (event, isChecked) {
-            var bestFill = this.props.fills.find(function (fill) {
-                return fill && _.isObject(fill.color);
-            });
-
             this.getFlux().actions.shapes.setFillEnabled(
                 this.props.document,
-                this.props.layers,
-                this.props.index,
-                bestFill && bestFill.color || Color.DEFAULT,
+                this.state.layers,
+                this.state.fill && this.state.fill.color || Color.DEFAULT,
                 isChecked
             );
         },
@@ -88,7 +102,7 @@ define(function (require, exports) {
          */
         _opacityChanged: function (event, opacity) {
             this.getFlux().actions.shapes
-                .setFillOpacityThrottled(this.props.document, this.props.layers, this.props.index, opacity);
+                .setFillOpacityThrottled(this.props.document, this.state.layers, opacity);
         },
 
         /**
@@ -100,7 +114,7 @@ define(function (require, exports) {
          */
         _colorChanged: function (color, coalesce) {
             this.getFlux().actions.shapes
-                .setFillColorThrottled(this.props.document, this.props.layers, this.props.index, color, coalesce);
+                .setFillColorThrottled(this.props.document, this.state.layers, color, coalesce);
         },
 
 
@@ -113,8 +127,8 @@ define(function (require, exports) {
          */
         _opaqueColorChanged: function (color, coalesce) {
             this.getFlux().actions.shapes
-                .setFillColorThrottled(this.props.document, this.props.layers,
-                    this.props.index, color, coalesce, true, true);
+                .setFillColorThrottled(this.props.document, this.state.layers,
+                    color, coalesce, true, true);
         },
 
         /**
@@ -126,8 +140,8 @@ define(function (require, exports) {
          */
         _alphaChanged: function (color, coalesce) {
             this.getFlux().actions.shapes
-                .setFillOpacityThrottled(this.props.document, this.props.layers,
-                    this.props.index, color.opacity, coalesce);
+                .setFillOpacityThrottled(this.props.document, this.state.layers,
+                    color.opacity, coalesce);
         },
 
         /**
@@ -162,11 +176,14 @@ define(function (require, exports) {
         },
 
         render: function () {
-            var downsample = this._downsampleFills(this.props.fills);
+            // If there are no vector layers, hide the component
+            if (this.state.layers.isEmpty()) {
+                return null;
+            }
 
             var fillClasses = classnames({
                 "fill-list__fill": true,
-                "fill-list__fill__disabled": this.props.readOnly
+                "fill-list__fill__disabled": this.props.disabled
             });
 
             var fillOverlay = function (colorTiny) {
@@ -183,114 +200,9 @@ define(function (require, exports) {
                 );
             };
 
-            var colorInputID = "fill-" + this.props.index + "-" + this.props.document.id;
+            var colorInputID = "fill-" + this.props.document.id,
+                fill = this.state.fill;
 
-            return (
-                <div className={fillClasses}>
-                    <div className="formline">
-                        <Gutter />
-                        <ColorInput
-                            id={colorInputID}
-                            className="fill"
-                            context={collection.pluck(this.props.layers, "id")}
-                            title={strings.TOOLTIPS.SET_FILL_COLOR}
-                            editable={!this.props.readOnly}
-                            defaultValue={downsample.colors}
-                            onChange={this._colorChanged}
-                            onColorChange={this._opaqueColorChanged}
-                            onAlphaChange={this._alphaChanged}
-                            onClick={!this.props.readOnly ? this._toggleColorPicker : _.noop}
-                            swatchOverlay={fillOverlay}>
-
-                            <div className="compact-stats__body">
-                                <div className="compact-stats__body__column">
-                                    <Label
-                                        title={strings.TOOLTIPS.SET_FILL_OPACITY}
-                                        size="column-4">
-                                        {strings.STYLE.FILL.ALPHA}
-                                    </Label>
-                                    <NumberInput
-                                        value={downsample.opacityPercentages}
-                                        onChange={this._opacityChanged}
-                                        min={0}
-                                        max={100}
-                                        step={1}
-                                        bigstep={10}
-                                        disabled={this.props.readOnly}
-                                        size="column-3" />
-                                </div>
-                            </div>
-                        </ColorInput>
-                        <Gutter />
-                        <ToggleButton
-                            title={strings.TOOLTIPS.TOGGLE_FILL}
-                            name="toggleFillEnabled"
-                            buttonType="layer-not-visible"
-                            selected={downsample.enabledFlags}
-                            onClick={!this.props.readOnly ? this._toggleFillEnabled : _.noop}
-                            size="column-2"
-                        />
-                        <Gutter />
-                    </div>
-                </div>
-            );
-        }
-    });
-
-    /**
-     * FillList Component maintains a set of fills components for the selected Layer(s)
-     */
-    var FillList = React.createClass({
-        mixins: [FluxMixin],
-
-        /**
-         * Handle a NEW fill
-         *
-         * @private
-         */
-        _addFill: function (layers) {
-            this.getFlux().actions.shapes.addFill(this.props.document, layers, Color.DEFAULT);
-        },
-
-        render: function () {
-            var document = this.props.document,
-                // We only care about vector layers.  If at least one exists, then this component should render
-                layers = document.layers.selected.filter(function (layer) {
-                    return layer.kind === layer.layerKinds.VECTOR;
-                });
-
-            // If there are no vector layers, hide the component
-            if (layers.isEmpty()) {
-                return null;
-            }
-
-            // Group into arrays of fills, by position in each layer
-            var fillGroups = collection.zip(collection.pluck(layers, "fills")),
-                fillList = fillGroups.map(function (fills, index) {
-                    return (
-                        <Fill {...this.props}
-                            key={index}
-                            index={index}
-                            readOnly={this.props.disabled}
-                            layers={layers}
-                            fills={fills} />
-                    );
-                }, this).toList();
-
-            // Add a "new fill" button if not read only
-            var newButton = null;
-            if (fillGroups.isEmpty()) {
-                newButton = (
-                    <Button
-                        className="button-plus"
-                        onClick = {this._addFill.bind(this, layers)}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
-                );
-            }
-            
             return (
                 <div className="fill-list__container">
                     <header className="fill-list__header sub-header">
@@ -299,16 +211,60 @@ define(function (require, exports) {
                         </h3>
                         <Gutter />
                         <hr className="sub-header-rule"/>
-                        {newButton}
                     </header>
                     <div className="fill-list__list-container">
-                        {fillList}
+                        <div className={fillClasses}>
+                            <div className="formline">
+                                <Gutter />
+                                <ColorInput
+                                    id={colorInputID}
+                                    className="fill"
+                                    context={collection.pluck(this.state.layers, "id")}
+                                    title={strings.TOOLTIPS.SET_FILL_COLOR}
+                                    editable={!this.props.disabled}
+                                    defaultValue={fill.colors}
+                                    onChange={this._colorChanged}
+                                    onColorChange={this._opaqueColorChanged}
+                                    onAlphaChange={this._alphaChanged}
+                                    onClick={!this.props.disabled ? this._toggleColorPicker : _.noop}
+                                    swatchOverlay={fillOverlay}>
+
+                                    <div className="compact-stats__body">
+                                        <div className="compact-stats__body__column">
+                                            <Label
+                                                title={strings.TOOLTIPS.SET_FILL_OPACITY}
+                                                size="column-4">
+                                                {strings.STYLE.FILL.ALPHA}
+                                            </Label>
+                                            <NumberInput
+                                                value={fill.opacityPercentages}
+                                                onChange={this._opacityChanged}
+                                                min={0}
+                                                max={100}
+                                                step={1}
+                                                bigstep={10}
+                                                disabled={this.props.disabled}
+                                                size="column-3" />
+                                        </div>
+                                    </div>
+                                </ColorInput>
+                                <Gutter />
+                                <ToggleButton
+                                    title={strings.TOOLTIPS.TOGGLE_FILL}
+                                    name="toggleFillEnabled"
+                                    buttonType="layer-not-visible"
+                                    selected={fill.enabledFlags}
+                                    onClick={!this.props.disabled ? this._toggleFillEnabled : _.noop}
+                                    size="column-2"
+                                />
+                                <Gutter />
+                            </div>
+                        </div>
                     </div>
                 </div>
             );
         }
     });
 
-    exports.Fill = Fill;
-    exports.FillList = FillList;
+    module.exports = Fill;
 });

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -22,7 +22,7 @@
  */
 
 
-define(function (require, exports) {
+define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
@@ -38,8 +38,6 @@ define(function (require, exports) {
         StrokeAlignment = require("jsx!./StrokeAlignment"),
         Gutter = require("jsx!js/jsx/shared/Gutter"),
         Label = require("jsx!js/jsx/shared/Label"),
-        Button = require("jsx!js/jsx/shared/Button"),
-        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
@@ -53,10 +51,31 @@ define(function (require, exports) {
     var Stroke = React.createClass({
         mixins: [FluxMixin],
 
-        shouldComponentUpdate: function (nextProps) {
-            return !Immutable.is(this.props.strokes, nextProps.strokes) ||
-                this.props.index !== nextProps.index ||
-                this.props.readOnly !== nextProps.readOnly;
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return !Immutable.is(this.state.stroke, nextState.stroke) ||
+                this.props.disabled !== nextProps.disabled;
+        },
+
+        getInitialState: function () {
+            return {
+                layers: Immutable.List(),
+                stroke: {}
+            };
+        },
+
+        componentWillReceiveProps: function (nextProps) {
+            var document = nextProps.document,
+                // We only care about vector layers. If at least one exists, then this component should render
+                layers = document.layers.selected.filter(function (layer) {
+                    return layer.kind === layer.layerKinds.VECTOR;
+                }),
+                strokes = collection.pluck(layers, "stroke"),
+                downsample = this._downsampleStrokes(strokes);
+
+            this.setState({
+                layers: layers,
+                stroke: downsample
+            });
         },
 
         /**
@@ -67,15 +86,10 @@ define(function (require, exports) {
          * @param {boolean} isChecked
          */
         _toggleStrokeEnabled: function (event, isChecked) {
-            var bestStroke = this.props.strokes.find(function (stroke) {
-                return stroke && _.isObject(stroke.color);
-            });
-
             this.getFlux().actions.shapes.setStrokeEnabled(
                 this.props.document,
-                this.props.layers,
-                this.props.index,
-                bestStroke && bestStroke.color || Color.DEFAULT,
+                this.state.layers,
+                this.state.stroke && this.state.stroke.colors.first() || Color.DEFAULT,
                 isChecked
             );
         },
@@ -89,7 +103,7 @@ define(function (require, exports) {
          */
         _widthChanged: function (event, width) {
             this.getFlux().actions.shapes
-                .setStrokeWidthThrottled(this.props.document, this.props.layers, this.props.index, width);
+                .setStrokeWidthThrottled(this.props.document, this.state.layers, width);
         },
 
         /**
@@ -101,7 +115,7 @@ define(function (require, exports) {
          */
         _opacityChanged: function (event, opacity) {
             this.getFlux().actions.shapes
-                .setStrokeOpacityThrottled(this.props.document, this.props.layers, this.props.index, opacity);
+                .setStrokeOpacityThrottled(this.props.document, this.state.layers, opacity);
         },
 
         /**
@@ -113,8 +127,8 @@ define(function (require, exports) {
          */
         _alphaChanged: function (color, coalesce) {
             this.getFlux().actions.shapes
-                .setStrokeOpacityThrottled(this.props.document, this.props.layers,
-                    this.props.index, color.opacity, coalesce);
+                .setStrokeOpacityThrottled(this.props.document, this.state.layers,
+                    color.opacity, coalesce);
         },
 
         /**
@@ -138,11 +152,12 @@ define(function (require, exports) {
         _colorChanged: function (color, coalesce, ignoreAlpha) {
             // If the enabled flags are mixed, or uniformly false, we want to clobber it with true
             // Otherwise left undefined, it will not cause a bounds change
-            var isEnabledChanging = !collection.uniformValue(collection.pluck(this.props.strokes, "enabled")),
+            var strokes = collection.pluck(this.state.layers, "stroke"),
+                isEnabledChanging = !collection.uniformValue(collection.pluck(strokes, "enabled")),
                 enabled = isEnabledChanging || undefined;
 
             this.getFlux().actions.shapes
-                .setStrokeColorThrottled(this.props.document, this.props.layers, this.props.index, color, coalesce,
+                .setStrokeColorThrottled(this.props.document, this.state.layers, color, coalesce,
                     enabled, ignoreAlpha);
         },
 
@@ -172,28 +187,35 @@ define(function (require, exports) {
                     .map(function (color) {
                         return color && color.opacity;
                     }),
-                enabledFlags = collection.pluck(strokes, "enabled", false);
+                enabledFlags = collection.pluck(strokes, "enabled", false),
+                alignments = collection.pluck(strokes, "alignment");
 
             return {
                 colors: colors,
                 widths: widths,
                 opacityPercentages: opacityPercentages,
-                enabledFlags: enabledFlags
+                enabledFlags: enabledFlags,
+                alignments: alignments
             };
         },
 
         render: function () {
-            var downsample = this._downsampleStrokes(this.props.strokes);
+            // If there are no vector layers, hide the component
+            if (this.state.layers.isEmpty()) {
+                return null;
+            }
+
+            var stroke = this.state.stroke;
 
             var strokeClasses = classnames({
                 "stroke-list__stroke": true,
-                "stroke-list__stroke__disabled": this.props.readOnly
+                "stroke-list__stroke__disabled": this.props.disabled
             });
 
             var strokeOverlay = function (colorTiny) {
                 var strokeStyle = {
                     width: "100%",
-                    height: (collection.uniformValue(downsample.widths) || 0) + "%",
+                    height: (collection.uniformValue(stroke.widths) || 0) + "%",
                     backgroundColor: colorTiny ? colorTiny.toRgbString() : "transparent"
                 };
 
@@ -204,142 +226,8 @@ define(function (require, exports) {
                 );
             };
 
-            var colorInputID = "stroke-" + this.props.index + "-" + this.props.document.id;
+            var colorInputID = "stroke-" + this.props.document.id;
 
-            return (
-                <div className={strokeClasses}>
-                    <div className="formline">
-                        <Gutter />
-                        <ColorInput
-                            id={colorInputID}
-                            className="stroke"
-                            context={collection.pluck(this.props.layers, "id")}
-                            title={strings.TOOLTIPS.SET_STROKE_COLOR}
-                            editable={!this.props.readOnly}
-                            defaultValue={downsample.colors}
-                            onChange={this._colorChanged}
-                            onFocus={this.props.onFocus}
-                            onColorChange={this._opaqueColorChanged}
-                            onAlphaChange={this._alphaChanged}
-                            onClick={!this.props.readOnly ? this._toggleColorPicker : _.noop}
-                            swatchOverlay={strokeOverlay}>
-
-                            <div className="compact-stats__body">
-                                <div className="compact-stats__body__column">
-                                    <Label
-                                        title={strings.TOOLTIPS.SET_STROKE_OPACITY}
-                                        size="column-4">
-                                        {strings.STYLE.STROKE.ALPHA}
-                                    </Label>
-                                    <NumberInput
-                                        value={downsample.opacityPercentages}
-                                        onChange={this._opacityChanged}
-                                        onFocus={this.props.onFocus}
-                                        min={0}
-                                        max={100}
-                                        step={1}
-                                        bigstep={10}
-                                        disabled={this.props.readOnly}
-                                        size="column-3" />
-                                </div>
-                                <Gutter />
-                                <div className="compact-stats__body__column">
-                                    <Label
-                                        title={strings.TOOLTIPS.SET_STROKE_SIZE}
-                                        size="column-4">
-                                        {strings.STYLE.STROKE.SIZE}
-                                    </Label>
-                                    <NumberInput
-                                        value={downsample.widths}
-                                        onChange={this._widthChanged}
-                                        onFocus={this.props.onFocus}
-                                        min={0}
-                                        step={1}
-                                        bigstep={5}
-                                        disabled={this.props.readOnly}
-                                        size="column-3" />
-                                </div>
-                                <Gutter />
-                                <div className="compact-stats__body__column">
-                                    <Label
-                                        title={strings.TOOLTIPS.SET_STROKE_ALIGNMENT}
-                                        size="column-4">
-                                        {strings.STYLE.STROKE.ALIGNMENT}
-                                    </Label>
-                                    <StrokeAlignment
-                                        {...this.props} />
-                                </div>
-                            </div>
-                        </ColorInput>
-                        <Gutter />
-                        <ToggleButton
-                            title={strings.TOOLTIPS.TOGGLE_STROKE}
-                            name="toggleStrokeEnabled"
-                            buttonType="layer-not-visible"
-                            selected={downsample.enabledFlags}
-                            onClick={!this.props.readOnly ? this._toggleStrokeEnabled : _.noop}
-                            size="column-2"
-                        />
-                        <Gutter />
-                    </div>
-                </div>
-            );
-        }
-    });
-
-    /**
-     * StrokeList Component maintains a set of strokes components for the selected Layer(s)
-     */
-    var StrokeList = React.createClass({
-        mixins: [FluxMixin],
-
-        /**
-         * Handle a NEW stroke
-         *
-         * @private
-         */
-        _addStroke: function (layers) {
-            this.getFlux().actions.shapes.addStroke(this.props.document, layers);
-        },
-
-        render: function () {
-            var document = this.props.document,
-                // We only care about vector layers.  If at least one exists, then this component should render
-                layers = document.layers.selected.filter(function (layer) {
-                    return layer.kind === layer.layerKinds.VECTOR;
-                });
-
-            if (layers.isEmpty()) {
-                return null;
-            }
-
-            // Group into arrays of strokes, by position in each layer
-            var strokeGroups = collection.zip(collection.pluck(layers, "strokes")),
-                strokeList = strokeGroups.map(function (strokes, index) {
-                    return (
-                        <Stroke {...this.props}
-                            key={index}
-                            index={index}
-                            readOnly={false}
-                            layers={layers}
-                            strokes={strokes} />
-                    );
-                }, this).toList();
-
-            // Add a "new stroke" button if not read only
-            var newButton = null;
-            if (strokeGroups.isEmpty()) {
-                newButton = (
-                    <Button
-                        className="button-plus"
-                        onClick = {this._addStroke.bind(this, layers)}>
-                        <SVGIcon
-                            viewbox="0 0 12 12"
-                            CSSID="plus" />
-                    </Button>
-                );
-            }
-            
             return (
                 <div className="stroke-list__container">
                     <header className="stroke-list__header sub-header">
@@ -348,16 +236,91 @@ define(function (require, exports) {
                         </h3>
                         <Gutter />
                         <hr className="sub-header-rule"/>
-                        {newButton}
                     </header>
                     <div className="stroke-list__list-container">
-                        {strokeList}
+                        <div className={strokeClasses}>
+                            <div className="formline">
+                                <Gutter />
+                                <ColorInput
+                                    id={colorInputID}
+                                    className="stroke"
+                                    context={collection.pluck(this.state.layers, "id")}
+                                    title={strings.TOOLTIPS.SET_STROKE_COLOR}
+                                    editable={!this.props.disabled}
+                                    defaultValue={stroke.colors}
+                                    onChange={this._colorChanged}
+                                    onFocus={this.props.onFocus}
+                                    onColorChange={this._opaqueColorChanged}
+                                    onAlphaChange={this._alphaChanged}
+                                    onClick={!this.props.disabled ? this._toggleColorPicker : _.noop}
+                                    swatchOverlay={strokeOverlay}>
+
+                                    <div className="compact-stats__body">
+                                        <div className="compact-stats__body__column">
+                                            <Label
+                                                title={strings.TOOLTIPS.SET_STROKE_OPACITY}
+                                                size="column-4">
+                                                {strings.STYLE.STROKE.ALPHA}
+                                            </Label>
+                                            <NumberInput
+                                                value={stroke.opacityPercentages}
+                                                onChange={this._opacityChanged}
+                                                onFocus={this.props.onFocus}
+                                                min={0}
+                                                max={100}
+                                                step={1}
+                                                bigstep={10}
+                                                disabled={this.props.disabled}
+                                                size="column-3" />
+                                        </div>
+                                        <Gutter />
+                                        <div className="compact-stats__body__column">
+                                            <Label
+                                                title={strings.TOOLTIPS.SET_STROKE_SIZE}
+                                                size="column-4">
+                                                {strings.STYLE.STROKE.SIZE}
+                                            </Label>
+                                            <NumberInput
+                                                value={stroke.widths}
+                                                onChange={this._widthChanged}
+                                                onFocus={this.props.onFocus}
+                                                min={0}
+                                                step={1}
+                                                bigstep={5}
+                                                disabled={this.props.disabled}
+                                                size="column-3" />
+                                        </div>
+                                        <Gutter />
+                                        <div className="compact-stats__body__column">
+                                            <Label
+                                                title={strings.TOOLTIPS.SET_STROKE_ALIGNMENT}
+                                                size="column-4">
+                                                {strings.STYLE.STROKE.ALIGNMENT}
+                                            </Label>
+                                            <StrokeAlignment
+                                                {...this.props}
+                                                layers={this.state.layers}
+                                                alignments={stroke.alignments}/>
+                                        </div>
+                                    </div>
+                                </ColorInput>
+                                <Gutter />
+                                <ToggleButton
+                                    title={strings.TOOLTIPS.TOGGLE_STROKE}
+                                    name="toggleStrokeEnabled"
+                                    buttonType="layer-not-visible"
+                                    selected={stroke.enabledFlags}
+                                    onClick={!this.props.disabled ? this._toggleStrokeEnabled : _.noop}
+                                    size="column-2"
+                                />
+                                <Gutter />
+                            </div>
+                        </div>
                     </div>
                 </div>
             );
         }
     });
 
-    exports.Stroke = Stroke;
-    exports.StrokeList = StrokeList;
+    module.exports = Stroke;
 });

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
         getInitialState: function () {
             return {
                 layers: Immutable.List(),
-                stroke: {}
+                stroke: null
             };
         },
 
@@ -201,7 +201,7 @@ define(function (require, exports, module) {
 
         render: function () {
             // If there are no vector layers, hide the component
-            if (this.state.layers.isEmpty()) {
+            if (!this.state.stroke || this.state.layers.isEmpty()) {
                 return null;
             }
 

--- a/src/js/jsx/sections/style/StrokeAlignment.jsx
+++ b/src/js/jsx/sections/style/StrokeAlignment.jsx
@@ -64,9 +64,8 @@ define(function (require, exports, module) {
                 .equals(collection.pluck(nextProps.layers, "id"));
 
             return !sameLayerIDs ||
-                !Immutable.is(this.props.strokes, nextProps.strokes) ||
-                this.props.index !== nextProps.index ||
-                this.props.readOnly !== nextProps.readOnly;
+                !Immutable.is(this.props.alignments, nextProps.alignments) ||
+                this.props.disabled !== nextProps.disabled;
         },
 
         getDefaultProps: function () {
@@ -84,12 +83,12 @@ define(function (require, exports, module) {
          */
         _handleChange: function (alignment) {
             this.getFlux().actions.shapes
-                .setStrokeAlignmentThrottled(this.props.document, this.props.layers, this.props.index, alignment);
+                .setStrokeAlignmentThrottled(this.props.document, this.props.layers, alignment);
         },
 
 
         render: function () {
-            var alignments = collection.pluck(this.props.strokes, "alignment"),
+            var alignments = this.props.alignments,
                 alignment = collection.uniformValue(alignments),
                 alignmentTitle = _alignmentModes.has(alignment) ? _alignmentModes.get(alignment).title :
                     (alignments.size > 1 ? strings.TRANSFORM.MIXED : alignment);
@@ -105,7 +104,7 @@ define(function (require, exports, module) {
             return (
                 <Datalist
                     list={listID}
-                    disabled={this.props.readOnly}
+                    disabled={this.props.disabled}
                     className="dialog-stroke-alignment"
                     options={_alignmentModesList}
                     value={alignmentTitle}

--- a/src/js/jsx/sections/style/StylePanel.jsx
+++ b/src/js/jsx/sections/style/StylePanel.jsx
@@ -41,8 +41,8 @@ define(function (require, exports, module) {
         Type = require("jsx!./Type"),
         DropShadowList = require("jsx!./Shadow").DropShadowList,
         InnerShadowList = require("jsx!./Shadow").InnerShadowList,
-        FillList = require("jsx!./Fill").FillList,
-        StrokeList = require("jsx!./Stroke").StrokeList,
+        Fill = require("jsx!./Fill"),
+        Stroke = require("jsx!./Stroke"),
         strings = require("i18n!nls/strings"),
         synchronization = require("js/util/synchronization");
 
@@ -181,9 +181,9 @@ define(function (require, exports, module) {
                         onFocus={this._handleFocus}/>
                     <Type {...this.props}
                         onFocus={this._handleFocus} />
-                    <FillList {...this.props}
+                    <Fill {...this.props}
                         onFocus={this._handleFocus} />
-                    <StrokeList {...this.props}
+                    <Stroke {...this.props}
                         onFocus={this._handleFocus} />
                     <DropShadowList {...this.props}
                         onFocus={this._handleFocus}

--- a/src/js/models/fill.js
+++ b/src/js/models/fill.js
@@ -105,8 +105,7 @@ define(function (require, exports, module) {
                     }
                 }
 
-                var fill = new Fill(model);
-                return Immutable.List.of(fill);
+                return new Fill(model);
             } catch (err) {
                 var message = err instanceof Error ? (err.stack || err.message) : err;
 
@@ -114,7 +113,7 @@ define(function (require, exports, module) {
             }
         }
 
-        return Immutable.List();
+        return null;
     };
 
     /**
@@ -134,7 +133,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Update certain DropShadow properties.
+     * Update certain Fill properties.
      * 
      * @param {object} fillProperties
      * @return {Fill}

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -122,9 +122,9 @@ define(function (require, exports, module) {
 
         /**
          * stroke information
-         * @type {Immutable.List.<Stroke>}
+         * @type {Stroke}
          */
-        strokes: null,
+        stroke: null,
 
         /**
          * Border radii
@@ -133,9 +133,9 @@ define(function (require, exports, module) {
         radii: null,
 
         /**
-         * @type {Immutable.List.<Fill>}
+         * @type {Fill}
          */
-        fills: null,
+        fill: null,
 
         /**
          * @type {Immutable.List.<Shadow>}
@@ -387,8 +387,8 @@ define(function (require, exports, module) {
             isBackground: false,
             opacity: 100,
             selected: true, // We'll set selected after moving layers
-            fills: Immutable.List(),
-            strokes: Immutable.List(),
+            fill: null,
+            stroke: null,
             dropShadows: Immutable.List(),
             innerShadows: Immutable.List(),
             mode: "passThrough",
@@ -435,8 +435,8 @@ define(function (require, exports, module) {
             selected: selected,
             bounds: Bounds.fromLayerDescriptor(layerDescriptor),
             radii: Radii.fromLayerDescriptor(layerDescriptor),
-            strokes: Stroke.fromLayerDescriptor(layerDescriptor),
-            fills: Fill.fromLayerDescriptor(layerDescriptor),
+            stroke: Stroke.fromLayerDescriptor(layerDescriptor),
+            fill: Fill.fromLayerDescriptor(layerDescriptor),
             dropShadows: Shadow.fromLayerDescriptor(layerDescriptor, "dropShadow"),
             innerShadows: Shadow.fromLayerDescriptor(layerDescriptor, "innerShadow"),
             text: Text.fromLayerDescriptor(resolution, layerDescriptor),
@@ -473,8 +473,8 @@ define(function (require, exports, module) {
                 opacity: _extractOpacity(layerDescriptor),
                 bounds: Bounds.fromLayerDescriptor(layerDescriptor),
                 radii: Radii.fromLayerDescriptor(layerDescriptor),
-                strokes: Stroke.fromLayerDescriptor(layerDescriptor),
-                fills: Fill.fromLayerDescriptor(layerDescriptor),
+                stroke: Stroke.fromLayerDescriptor(layerDescriptor),
+                fill: Fill.fromLayerDescriptor(layerDescriptor),
                 dropShadows: Shadow.fromLayerDescriptor(layerDescriptor, "dropShadow"),
                 innerShadows: Shadow.fromLayerDescriptor(layerDescriptor, "innerShadow"),
                 text: Text.fromLayerDescriptor(resolution, layerDescriptor),

--- a/src/js/models/stroke.js
+++ b/src/js/models/stroke.js
@@ -164,7 +164,7 @@ define(function (require, exports, module) {
                 var strokeStyleDescriptor = layerDescriptor.AGMStrokeStyleInfo,
                     stroke = Stroke.fromStrokeStyleDescriptor(strokeStyleDescriptor);
 
-                return Immutable.List.of(stroke);
+                return stroke;
             } catch (err) {
                 var message = err instanceof Error ? (err.stack || err.message) : err;
 
@@ -172,7 +172,7 @@ define(function (require, exports, module) {
             }
         }
 
-        return Immutable.List();
+        return null;
     };
 
     /**

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -76,14 +76,13 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.RADII_CHANGED, this._handleRadiiChanged,
                 events.document.history.optimistic.FILL_COLOR_CHANGED, this._handleFillPropertiesChanged,
                 events.document.history.optimistic.FILL_OPACITY_CHANGED, this._handleFillPropertiesChanged,
-                events.document.history.optimistic.FILL_ADDED, this._handleFillAdded,
                 events.document.STROKE_ALIGNMENT_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.STROKE_ENABLED_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.STROKE_WIDTH_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.STROKE_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.STROKE_COLOR_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.STROKE_OPACITY_CHANGED, this._handleStrokePropertiesChanged,
-                events.document.history.nonOptimistic.STROKE_ADDED, this._handleStrokeAdded,
+                events.document.history.nonOptimistic.STROKE_ADDED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.LAYER_EFFECT_CHANGED, this._handleLayerEffectPropertiesChanged,
                 events.document.history.optimistic.LAYER_EFFECT_DELETED, this._handleDeletedLayerEffect,
                 events.document.history.optimistic.LAYER_EFFECTS_BATCH_CHANGED, this._handleLayerEffectsBatchChanged,
@@ -685,7 +684,6 @@ define(function (require, exports, module) {
          *     {
          *         documentID: number,
          *         layerIDs: Array.<number>,
-         *         fillIndex: number,
          *         fillProperties: object
          *     }
          *
@@ -695,27 +693,9 @@ define(function (require, exports, module) {
         _handleFillPropertiesChanged: function (payload) {
             var documentID = payload.documentID,
                 layerIDs = payload.layerIDs,
-                fillIndex = payload.fillIndex,
                 fillProperties = payload.fillProperties,
                 document = this._openDocuments[documentID],
-                nextLayers = document.layers.setFillProperties(layerIDs, fillIndex, fillProperties),
-                nextDocument = document.set("layers", nextLayers);
-
-            this.setDocument(nextDocument, true);
-        },
-
-        /**
-         * Adds a fill to the specified document and layers
-         *
-         * @private
-         * @param {{!color: object, !type: string, enabled: boolean}} payload
-         */
-        _handleFillAdded: function (payload) {
-            var documentID = payload.documentID,
-                layerIDs = payload.layerIDs,
-                setDescriptor = payload.setDescriptor,
-                document = this._openDocuments[documentID],
-                nextLayers = document.layers.addFill(layerIDs, setDescriptor),
+                nextLayers = document.layers.setFillProperties(layerIDs, fillProperties),
                 nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);
@@ -723,13 +703,12 @@ define(function (require, exports, module) {
 
         /**
          * Update the provided properties of all strokes of given index of the given layers of the given document
-         * example payload {documentID:1, layerIDs:[1,2], strokeIndex: 0, strokeProperties:{width:12}}
+         * example payload {documentID:1, layerIDs:[1,2], strokeProperties:{width:12}}
          *
          * expects payload like
          *     {
          *         documentID: number,
          *         layerIDs: Array.<number>,
-         *         strokeIndex: number,
          *         strokeProperties: object
          *     }
          *
@@ -739,29 +718,9 @@ define(function (require, exports, module) {
         _handleStrokePropertiesChanged: function (payload) {
             var documentID = payload.documentID,
                 layerIDs = payload.layerIDs,
-                strokeIndex = payload.strokeIndex,
                 strokeProperties = payload.strokeProperties,
                 document = this._openDocuments[documentID],
-                nextLayers = document.layers.setStrokeProperties(layerIDs, strokeIndex, strokeProperties),
-                nextDocument = document.set("layers", nextLayers);
-
-            this.setDocument(nextDocument, true);
-        },
-
-        /**
-         * Adds a stroke to the specified document and layers
-         * This also handles updating strokes where we're refetching from Ps
-         *
-         * @private
-         * @param {{documentID: !number, layerStrokes: {layerID: number, strokeStyleDescriptor: object}} payload
-         */
-        _handleStrokeAdded: function (payload) {
-            var documentID = payload.documentID,
-                layerIDs = payload.layerIDs,
-                strokeIndex = payload.strokeIndex,
-                strokeStyleDescriptor = payload.strokeStyleDescriptor,
-                document = this._openDocuments[documentID],
-                nextLayers = document.layers.addStroke(layerIDs, strokeIndex, strokeStyleDescriptor),
+                nextLayers = document.layers.setStrokeProperties(layerIDs, strokeProperties),
                 nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -87,7 +87,6 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.RADII_CHANGED, this._updateMenuItems,
                 events.document.history.optimistic.FILL_COLOR_CHANGED, this._updateMenuItems,
                 events.document.history.optimistic.FILL_OPACITY_CHANGED, this._updateMenuItems,
-                events.document.history.optimistic.FILL_ADDED, this._updateMenuItems,
                 events.document.STROKE_ALIGNMENT_CHANGED, this._updateMenuItems,
                 events.document.STROKE_ENABLED_CHANGED, this._updateMenuItems,
                 events.document.STROKE_WIDTH_CHANGED, this._updateMenuItems,

--- a/src/js/stores/style.js
+++ b/src/js/stores/style.js
@@ -86,8 +86,8 @@ define(function (require, exports, module) {
 
             switch (layer.kind) {
             case layer.layerKinds.VECTOR:
-                fillColor = layer.fills.first() ? layer.fills.first().color : null;
-                stroke = layer.strokes.first();
+                fillColor = layer.fill ? layer.fill.color : null;
+                stroke = layer.stroke;
 
                 break;
             case layer.layerKinds.TEXT:


### PR DESCRIPTION
This one is a hairy PR, so @chadrolfs and @ktaki, please slam on the fill/stroke related workflows a little on this PR before it's merged.

Clears out the layer model to have a singular stroke and fill information, since we essentially kept a list of them when there could only be one. :sword: Gets rid of all the pesky fill/strokeIndex variables being thrown around, and makes sure style sampling/pasting and library style application work right.

@iwehrman can you review this bad boy?