### PR TITLE
Faster artboard creation

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1459,6 +1459,7 @@ define(function (require, exports) {
                     groupEndID: result.layerSectionEndID,
                     groupname: result.layerName,
                     isArtboard: true,
+                    bounds: result.artboardRect,
                     // don't redraw UI until after resetting the index
                     suppressChange: true
                 };

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1226,14 +1226,15 @@ define(function (require, exports) {
     unlockSelectedInCurrentDocument.transfers = [setLocking];
 
     /**
-     * Updates our layer information based on the current document 
+     * Reset the layer z-index. Assumes that all layers are already in the model,
+     * though possibly out of order w.r.t. Photoshop's model.
      *
      * @param {Document} document Document for which layers should be reordered
      * @param {boolean=} suppressHistory if truthy, dispatch a non-history-changing event.
      * @param {boolean=} amendHistory if truthy, update the current state (requires suppressHistory)
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
      **/
-    var getLayerOrder = function (document, suppressHistory, amendHistory) {
+    var resetIndex = function (document, suppressHistory, amendHistory) {
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
                 return _getSelectedLayerIndices(document).then(function (selectedIndices) {
@@ -1253,9 +1254,9 @@ define(function (require, exports) {
                 }
             });
     };
-    getLayerOrder.reads = [locks.PS_DOC];
-    getLayerOrder.writes = [locks.JS_DOC];
-    getLayerOrder.post = [_verifyLayerIndex, _verifyLayerSelection];
+    resetIndex.reads = [locks.PS_DOC];
+    resetIndex.writes = [locks.JS_DOC];
+    resetIndex.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**
      * Moves the given layers to their given position
@@ -1291,7 +1292,7 @@ define(function (require, exports) {
       
         return reorderPromise.bind(this)
             .then(function () {
-                return this.transfer(getLayerOrder, document, false, false);
+                return this.transfer(resetIndex, document, false, false);
             })
             .then(function () {
                 // The selected layers may have changed after the reorder.
@@ -1301,7 +1302,7 @@ define(function (require, exports) {
     };
     reorderLayers.reads = [locks.PS_DOC, locks.JS_DOC];
     reorderLayers.writes = [locks.PS_DOC, locks.JS_DOC];
-    reorderLayers.transfers = [getLayerOrder];
+    reorderLayers.transfers = [resetIndex];
     reorderLayers.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**
@@ -1411,7 +1412,7 @@ define(function (require, exports) {
      * or we add a default sized "iphone" artboard 
      * otherwise passed in bounds are used
      *
-     * @param {Bounds?} artboardBounds where to place the new artboard
+     * @param {Bounds=} artboardBounds where to place the new artboard
      * @return {Promise}
      */
     var createArtboard = function (artboardBounds) {
@@ -1451,14 +1452,24 @@ define(function (require, exports) {
         
         return descriptor.playObject(createObj)
             .bind(this)
-            .then(function () {
-                log.debug("Warning: calling updateDocument to add a single artboard is very slow!");
-                return this.transfer(documentActions.updateDocument);
+            .then(function (result) {
+                var payload = {
+                    documentID: document.id,
+                    groupID: result.layerID,
+                    groupEndID: result.layerSectionEndID,
+                    groupname: result.layerName,
+                    isArtboard: true,
+                    // don't redraw UI until after resetting the index
+                    suppressChange: true
+                };
+
+                this.dispatch(events.document.history.optimistic.GROUP_SELECTED, payload);
+                return this.transfer(resetIndex, document, true, true);
             });
     };
     createArtboard.reads = [locks.JS_APP];
     createArtboard.writes = [locks.PS_DOC, locks.JS_DOC];
-    createArtboard.transfers = ["documents.updateDocument"];
+    createArtboard.transfers = [resetIndex];
     createArtboard.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**
@@ -1831,7 +1842,7 @@ define(function (require, exports) {
     exports.duplicate = duplicate;
     exports.setGroupExpansion = setGroupExpansion;
     exports.revealLayers = revealLayers;
-    exports.getLayerOrder = getLayerOrder;
+    exports.resetIndex = resetIndex;
     exports.editVectorMask = editVectorMask;
 
     exports.beforeStartup = beforeStartup;

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -655,7 +655,7 @@ define(function (require, exports) {
                                 descriptor.once("newDuplicateSheets", _newDuplicateSheetsListener);
                             } else {
                                 _moveToArtboardListener = _.once(function () {
-                                    this.flux.actions.layers.getLayerOrder(doc, true, true);
+                                    this.flux.actions.layers.resetIndex(doc, true, true);
                                 }.bind(this));
 
                                 descriptor.addListener("moveToArtboard", _moveToArtboardListener);

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1110,7 +1110,7 @@ define(function (require, exports) {
                     this.flux.actions.layers.resetSelection(nextDoc);
                 }).then(function () {
                     nextDoc = appStore.getCurrentDocument();
-                    this.flux.actions.layers.getLayerOrder(nextDoc, true);
+                    this.flux.actions.layers.resetIndex(nextDoc, true);
                 });
         }, this);
 

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -373,10 +373,12 @@ define(function (require, exports, module) {
      * @param {string} layerName Name of the group, provided by Photoshop
      * @param {boolean} isGroupEnd If the layer is the groupEnd layer or the group start layer
      * @param {boolean=} isArtboard
+     * @param {object=} boundsDescriptor If isArtboard, boundsDescriptor is required
      *
      * @return {Layer}
      */
-    Layer.fromGroupDescriptor = function (documentID, layerID, layerName, isGroupEnd, isArtboard) {
+    Layer.fromGroupDescriptor = function (documentID, layerID, layerName, isGroupEnd,
+        isArtboard, boundsDescriptor) {
         return new Layer({
             id: layerID,
             key: documentID + "." + layerID,
@@ -395,6 +397,7 @@ define(function (require, exports, module) {
             mode: "passThrough",
             proportionalScaling: false,
             isArtboard: !!isArtboard,
+            bounds: isArtboard ? new Bounds(boundsDescriptor) : null,
             isLinked: false,
             vectorMaskEnabled: false
         });

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -371,11 +371,12 @@ define(function (require, exports, module) {
      * @param {number} documentID
      * @param {number} layerID
      * @param {string} layerName Name of the group, provided by Photoshop
-     * @param {Boolean} isGroupEnd If the layer is the groupEnd layer or the group start layer
+     * @param {boolean} isGroupEnd If the layer is the groupEnd layer or the group start layer
+     * @param {boolean=} isArtboard
      *
      * @return {Layer}
      */
-    Layer.fromGroupDescriptor = function (documentID, layerID, layerName, isGroupEnd) {
+    Layer.fromGroupDescriptor = function (documentID, layerID, layerName, isGroupEnd, isArtboard) {
         return new Layer({
             id: layerID,
             key: documentID + "." + layerID,
@@ -393,7 +394,7 @@ define(function (require, exports, module) {
             innerShadows: Immutable.List(),
             mode: "passThrough",
             proportionalScaling: false,
-            isArtboard: false,
+            isArtboard: !!isArtboard,
             isLinked: false,
             vectorMaskEnabled: false
         });

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1140,19 +1140,24 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Given IDs of group start and end, and group name, will create a new group and
-     * put all selected layers in those groups
-     * Emulates PS behavior on group - group gets created at the top most selected layer index
+     * Given IDs of group start and end, and group name, creates a new group.
+     * If the group is NOT an artboard, puts all selected layers in the new
+     * group. NOTE: If the group IS an artboard then the caller is responsible
+     * for correctly reordering the layers after this operation!
+     * 
+     * Emulates PS behavior - group gets created at the top most selected layer
+     * index.
      *
      * @param {number} documentID ID of owner document
      * @param {number} groupID ID of group head layer
      * @param {number} groupEndID ID of group end layer
      * @param {string} groupName Name of the group, assigned by Photoshop
+     * @param {boolean=} isArtboard
      *
      * @return {LayerStructure} Updated layer tree with group added
      */
-    LayerStructure.prototype.createGroup = function (documentID, groupID, groupEndID, groupName) {
-        var groupHead = Layer.fromGroupDescriptor(documentID, groupID, groupName, false),
+    LayerStructure.prototype.createGroup = function (documentID, groupID, groupEndID, groupName, isArtboard) {
+        var groupHead = Layer.fromGroupDescriptor(documentID, groupID, groupName, false, isArtboard),
             groupEnd = Layer.fromGroupDescriptor(documentID, groupEndID, "", true),
             layersToMove = this.selectedNormalized.flatMap(this.descendants, this).toOrderedSet(),
             layersToMoveIndices = layersToMove.map(this.indexOf, this),
@@ -1175,11 +1180,9 @@ define(function (require, exports, module) {
             });
 
         // Add the new layers, and the new order
-        newLayerStructure = newLayerStructure
+        return newLayerStructure
             .updateSelection(Immutable.Set.of(groupID))
             .updateOrder(newIDs);
-
-        return newLayerStructure;
     };
 
     /**

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1151,11 +1151,14 @@ define(function (require, exports, module) {
      * @param {number} groupEndID ID of group end layer
      * @param {string} groupName Name of the group, assigned by Photoshop
      * @param {boolean=} isArtboard
+     * @param {object=} boundsDescriptor If creating an artboard, a bounds descriptor is required
      *
      * @return {LayerStructure} Updated layer tree with group added
      */
-    LayerStructure.prototype.createGroup = function (documentID, groupID, groupEndID, groupName, isArtboard) {
-        var groupHead = Layer.fromGroupDescriptor(documentID, groupID, groupName, false, isArtboard),
+    LayerStructure.prototype.createGroup = function (documentID, groupID, groupEndID, groupName,
+        isArtboard, boundsDescriptor) {
+        var groupHead = Layer.fromGroupDescriptor(documentID, groupID, groupName, false,
+                isArtboard, boundsDescriptor),
             groupEnd = Layer.fromGroupDescriptor(documentID, groupEndID, "", true),
             layersToMove = this.selectedNormalized.flatMap(this.descendants, this).toOrderedSet(),
             layersToMoveIndices = layersToMove.map(this.indexOf, this),

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1142,11 +1142,9 @@ define(function (require, exports, module) {
     /**
      * Given IDs of group start and end, and group name, creates a new group.
      * If the group is NOT an artboard, puts all selected layers in the new
-     * group. NOTE: If the group IS an artboard then the caller is responsible
+     * group. Emulates PS behavior - group gets created at the top most selected layer
+     * index. NOTE: If the group IS an artboard then the caller is responsible
      * for correctly reordering the layers after this operation!
-     * 
-     * Emulates PS behavior - group gets created at the top most selected layer
-     * index.
      *
      * @param {number} documentID ID of owner document
      * @param {number} groupID ID of group head layer

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -477,10 +477,12 @@ define(function (require, exports, module) {
                 groupEndID = payload.groupEndID,
                 groupName = payload.groupname,
                 isArtboard = payload.isArtboard,
+                bounds = payload.bounds,
                 suppressChange = payload.suppressChange;
 
             var document = this._openDocuments[documentID],
-                updatedLayers = document.layers.createGroup(documentID, groupID, groupEndID, groupName, isArtboard),
+                updatedLayers = document.layers.createGroup(documentID, groupID, groupEndID, groupName,
+                    isArtboard, bounds),
                 nextDocument = document.set("layers", updatedLayers);
 
             this.setDocument(nextDocument, true, suppressChange);

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -148,8 +148,9 @@ define(function (require, exports, module) {
          *
          * @param {Document} nextDocument
          * @param {boolean=} dirty Whether to set the dirty bit, assuming the model has changed
+         * @param {boolean=} suppressChange
          */
-        setDocument: function (nextDocument, dirty) {
+        setDocument: function (nextDocument, dirty, suppressChange) {
             var oldDocument = this._openDocuments[nextDocument.id];
             if (Immutable.is(oldDocument, nextDocument)) {
                 return;
@@ -160,7 +161,10 @@ define(function (require, exports, module) {
             }
 
             this._openDocuments[nextDocument.id] = nextDocument;
-            this.emit("change");
+
+            if (!suppressChange) {
+                this.emit("change");
+            }
         },
 
         /**
@@ -471,13 +475,15 @@ define(function (require, exports, module) {
             var documentID = payload.documentID,
                 groupID = payload.groupID,
                 groupEndID = payload.groupEndID,
-                groupName = payload.groupname;
+                groupName = payload.groupname,
+                isArtboard = payload.isArtboard,
+                suppressChange = payload.suppressChange;
 
             var document = this._openDocuments[documentID],
-                updatedLayers = document.layers.createGroup(documentID, groupID, groupEndID, groupName),
+                updatedLayers = document.layers.createGroup(documentID, groupID, groupEndID, groupName, isArtboard),
                 nextDocument = document.set("layers", updatedLayers);
 
-            this.setDocument(nextDocument, true);
+            this.setDocument(nextDocument, true, suppressChange);
         },
 
         /**


### PR DESCRIPTION
Speed up artboard creation by using new output from the `make` event that includes the resulting name and layer IDs for the new artboard to update the model without resetting the entire document. This reuses the existing group creation infrastructure, but requires updating the layer index from PS afterward due to auto-nesting.

Side note: I renamed the `layers.getLayerOrder` action to `layers.resetIndex` because that's more consistent with all the other reset-model-from-PS actions.

Requires CL 1036241 (pgdev ~465 from Friday afternoon). Addresses #1414. 