### PR TITLE
[Armchair designer] UI transparency

### DIFF
--- a/src/style/shared/colors.less
+++ b/src/style/shared/colors.less
@@ -24,8 +24,8 @@
 
 /* Basic Colors */
 @bg-app: #1d1d1d;
-@bg-border: #262626;
-@bg-panel: #2d2d2d;
+@bg-border: rgba(38, 38, 38, 0.98);
+@bg-panel: rgba(45, 45, 45, 0.98);
 @bg-alt: #34332F;
 
 @item: #FFFFFF;


### PR DESCRIPTION
This reintroduces a slight (3%) transparency to the UI, including the toolbar, header, and properties panel. It looks like this:
![transparency](https://s3.amazonaws.com/f.cl.ly/items/0u0D27302o280J2q1o3Q/Image%202015-08-15%20at%206.07.49%20PM.png "click to embiggen")

It correctly maintains full opacity for all the dialogs, like the color picker and search bar.

Addresses #1978. See in particular @DivyaPrabhakar's [recent note](https://github.com/adobe-photoshop/spaces-design/issues/1978#issuecomment-129993462).

Over to @designedbyscience and @placegraphichere for discussion. 