### PR TITLE
Eliminate disabled cursor styling on buttons

### DIFF
--- a/src/style/sections/style/style-section.less
+++ b/src/style/sections/style/style-section.less
@@ -48,7 +48,6 @@
 
 .style-button__disabled {
     opacity: 0.20 !important;
-    cursor: not-allowed;
 }
 
 .style-button {

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -35,11 +35,9 @@ button {
 }
 
 .button-simple__disabled {
-    cursor: not-allowed;
 }
 
 .button-toggle__disabled {
-    cursor: not-allowed;
 }
 
 .button-toggle.column-1 {

--- a/src/style/shared/split-button.less
+++ b/src/style/shared/split-button.less
@@ -27,7 +27,6 @@
 
 .split-button__item__disabled {
     opacity: 0.20 !important;
-    cursor: not-allowed;
 }
 
 .split-button__item:hover {


### PR DESCRIPTION
What it says. The disabled cursor styling is not disabled elsewhere, e.g., in Libraries drag and drop.

Addresses: concerns that this was a bad idea.