### PR TITLE
Modal type bug fix grab bag

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -102,7 +102,8 @@ define(function (require, exports, module) {
             TYPE_SIZE_CHANGED: "typeSizeChanged",
             TYPE_TRACKING_CHANGED: "typeTrackingChanged",
             TYPE_LEADING_CHANGED: "typeLeadingChanged",
-            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged"
+            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged",
+            TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
         },
         export: {
             ASSET_CHANGED: "exportAssetChanged",

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -30,8 +30,6 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         classnames = require("classnames");
 
-    var ps = require("adapter/ps");
-
     var ToolbarIcon = require("jsx!js/jsx/ToolbarIcon"),
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
@@ -231,9 +229,7 @@ define(function (require, exports, module) {
         _handleToolbarButtonClick: function (tool) {
             if (this.state.expanded || this.state.pinned) {
                 if (tool) {
-                    ps.endModalToolState().bind(this).then(function () {
-                        this.getFlux().actions.tools.select(tool);
-                    });
+                    this.getFlux().actions.tools.select(tool);
                     
                     // HACK: These lines are to eliminate the blink that occurs when the toolbar changes state
                     var node = React.findDOMNode(this);

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -24,8 +24,6 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var UI = require("adapter/ps/ui");
-    
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
@@ -169,21 +167,7 @@ define(function (require, exports, module) {
                 }
             }
 
-            this.getFlux().actions.layers.select(this.props.document, this.props.layer, modifier)
-                .bind(this)
-                .then(function () {
-                    var flux = this.getFlux(),
-                        toolStore = flux.store("tool"),
-                        currentTool = toolStore.getCurrentTool(),
-                        layer = this.props.layer,
-                        doc = this.props.document,
-                        numSelectedLayers = doc.layers.selected.size;
-                        
-                    if ((currentTool.id === "typeCreateOrEdit" || currentTool.id === "superselectType") &&
-                        layer.kind === layer.layerKinds.TEXT && numSelectedLayers === 1) {
-                        UI.startEditWithCurrentModalTool();
-                    }
-                });
+            this.getFlux().actions.layers.select(this.props.document, this.props.layer, modifier);
         },
 
         /**

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -239,7 +239,7 @@ define(function (require, exports, module) {
                 });
 
             if (leading === strings.STYLE.TYPE.AUTO_LEADING) {
-                leading = null;
+                leading = -1;
             }
 
             flux.actions.type.setLeadingThrottled(document, layers, leading);
@@ -410,7 +410,7 @@ define(function (require, exports, module) {
                 colors = collection.pluck(characterStyles, "color"),
                 trackings = collection.pluck(characterStyles, "tracking"),
                 leadings = characterStyles.map(function (characterStyle) {
-                    if (!characterStyle || characterStyle.leading === null) {
+                    if (!characterStyle || characterStyle.leading === -1) {
                         return strings.STYLE.TYPE.AUTO_LEADING;
                     } else {
                         return characterStyle.leading;

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         Datalist = require("jsx!js/jsx/shared/Datalist"),
         strings = require("i18n!nls/strings"),
         collection = require("js/util/collection"),
+        Color = require("js/models/color"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         textLayer = require("adapter/lib/textLayer");
 
@@ -115,6 +116,18 @@ define(function (require, exports, module) {
 
         componentDidUpdate: function () {
             this._loadFontListIfNecessary();
+
+            var toolStore = this.getFlux().store("tool");
+            if (toolStore.getModalToolState()) {
+                var document = this.props.document,
+                    layers = document.layers.selected,
+                    texts = collection.pluck(layers, "text"),
+                    characterStyles = collection.pluck(texts, "characterStyle"),
+                    colors = collection.pluck(characterStyles, "color"),
+                    color = collection.uniformValue(colors) || Color.DEFAULT;
+
+                this.refs.color.updateColorPicker(color);
+            }
         },
 
         /**
@@ -418,7 +431,7 @@ define(function (require, exports, module) {
                 });
 
             var texts = collection.pluck(layers, "text"),
-                paragraphStyles = collection.pluck(texts, "paragraphStyle").flatten(true),
+                paragraphStyles = collection.pluck(texts, "paragraphStyle"),
                 alignments = collection.pluck(paragraphStyles, "alignment"),
                 alignment = collection.uniformValue(alignments),
                 boxes = collection.pluck(texts, "box"),
@@ -551,6 +564,7 @@ define(function (require, exports, module) {
                         <Gutter />
                         <ColorInput
                             id={colorPickerID}
+                            ref="color"
                             className="type"
                             context={collection.pluck(this.props.document.layers.selected, "id")}
                             title={strings.TOOLTIPS.SET_TYPE_COLOR}

--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -110,21 +110,18 @@ define(function (require, exports, module) {
 
         // Use impliedFontSize instead of size to account for the layer transform.
         var rawSize = textStyle.hasOwnProperty("impliedFontSize") ?
-            textStyle.impliedFontSize :
-            baseParentStyle.impliedFontSize,
+                textStyle.impliedFontSize : baseParentStyle.impliedFontSize,
             textSize = unitUtil.toPixels(rawSize, resolution);
 
         model.textSize = textSize;
 
         var postScriptName = textStyle.hasOwnProperty("fontPostScriptName") ?
-            textStyle.fontPostScriptName :
-            baseParentStyle.fontPostScriptName;
+                textStyle.fontPostScriptName : baseParentStyle.fontPostScriptName;
 
         model.postScriptName = postScriptName;
 
         var tracking = textStyle.hasOwnProperty("tracking") ?
-            textStyle.tracking :
-            baseParentStyle.tracking;
+            textStyle.tracking : baseParentStyle.tracking;
 
         if (typeof tracking !== "number") {
             throw new Error("Tracking is not a number:" + tracking);
@@ -133,8 +130,7 @@ define(function (require, exports, module) {
         model.tracking = tracking;
 
         var autoLeading = textStyle.hasOwnProperty("autoLeading") ?
-            textStyle.autoLeading :
-            baseParentStyle.autoLeading;
+                textStyle.autoLeading : baseParentStyle.autoLeading;
 
         if (typeof autoLeading !== "boolean") {
             throw new Error("Auto-leading is not a boolean:" + autoLeading);
@@ -144,8 +140,7 @@ define(function (require, exports, module) {
             model.leading = -1;
         } else {
             var rawLeading = textStyle.hasOwnProperty("leading") ?
-                textStyle.leading :
-                baseParentStyle.leading,
+                    textStyle.leading : baseParentStyle.leading,
                 leading = unitUtil.toPixels(rawLeading, resolution);
 
             if (typeof leading !== "number") {

--- a/src/js/models/text.js
+++ b/src/js/models/text.js
@@ -78,7 +78,6 @@ define(function (require, exports, module) {
         model.paragraphStyle = ParagraphStyle.fromTextDescriptor(documentDescriptor, layerDescriptor, textKey);
         model.box = textShapes[0].char._value === "box";
 
-
         return new Text(model);
     };
 

--- a/src/js/tools/superselect/type.js
+++ b/src/js/tools/superselect/type.js
@@ -31,8 +31,18 @@ define(function (require, exports, module) {
         
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),
-        KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
+        KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
+        TypeTool = require("../type");
 
+
+    /**
+     * Handler for updateTextProperties events, which are emitted turing modal
+     * text editing.
+     *
+     * @private
+     * @type {?function}
+     */
+    var _typeChangedHandler;
 
     var _selectHandler = function () {
         var flux = this.flux,
@@ -43,6 +53,14 @@ define(function (require, exports, module) {
                 flux.actions.tools.select(toolStore.getToolByID("newSelect"));
             }
         });
+
+        if (_typeChangedHandler) {
+            descriptor.removeListener("updateTextProperties", _typeChangedHandler);
+        }
+
+        _typeChangedHandler = TypeTool.updateTextPropertiesHandler.bind(this);
+
+        descriptor.addListener("updateTextProperties", _typeChangedHandler);
     };
 
     /**

--- a/src/js/tools/superselect/type.js
+++ b/src/js/tools/superselect/type.js
@@ -44,6 +44,12 @@ define(function (require, exports, module) {
      */
     var _typeChangedHandler;
 
+    /**
+     * Resets the tool to select after the modal tool state is committed, and listens
+     * for updated text properties while in the modal state.
+     *
+     * @private
+     */
     var _selectHandler = function () {
         var flux = this.flux,
             toolStore = flux.store("tool");
@@ -64,6 +70,15 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Removes event listeners installed on activation.
+     *
+     * @private
+     */
+    var _deselectHandler = function () {
+        descriptor.removeListener("updateTextProperties", _typeChangedHandler);
+    };
+
+    /**
      * @implements {Tool}
      * @constructor
      */
@@ -75,6 +90,7 @@ define(function (require, exports, module) {
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE);
         this.keyboardPolicyList = [escapeKeyPolicy];
         this.selectHandler = _selectHandler;
+        this.deselectHandler = _deselectHandler;
         this.isMainTool = false;
     };
     util.inherits(SuperSelectTypeTool, Tool);

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -39,15 +39,15 @@ define(function (require, exports, module) {
      */
     var _moveHandler,
         _typeChangedHandler,
-        _layerCreatedHandler;
+        _layerCreatedHandler,
+        _layerDeletedHandler;
 
     /**
      * @implements {Tool}
      * @constructor
      */
     var TypeTool = function () {
-        var resetObj = toolLib.resetTypeTool("left", "Myriad Pro", 16, [0, 0, 0]),
-            firstLaunch = true;
+        var firstLaunch = true;
             
         var selectHandler = function () {
             // If this is set, means we didn't get to deselect the tool last time
@@ -70,80 +70,57 @@ define(function (require, exports, module) {
             
             descriptor.addListener("move", _moveHandler);
 
-            _typeChangedHandler = function (event) {
-                var documentStore = this.flux.store("application"),
-                    currentDocument = documentStore.getCurrentDocument(),
-                    layers = currentDocument.layers.allSelected,
-                    layersAllHaveType = layers.every(function (layer) {
-                        return layer.text !== null;
-                    });
-
-                if (layersAllHaveType) {
-                    if (event.sizeAssigned) {
-                        this.flux.actions.type.updateSize(currentDocument, layers, event.size);
-                    } else {
-                        this.flux.actions.type.updateSize(currentDocument, layers, null);
-                    }
-
-                    if (event.fontNameAssigned) {
-                        this.flux.actions.type.updatePostScript(currentDocument, layers, event.fontName);
-                    } else {
-                        this.flux.actions.type.updatePostScript(currentDocument, layers, null);
-                    }
-
-                    if (event.colorAssigned) {
-                        var color = Color.fromPhotoshopColorObj(event.color, 100);
-                        this.flux.actions.type.updateColor(currentDocument, layers, color);
-                    } else {
-                        this.flux.actions.type.updateColor(currentDocument, layers, null);
-                    }
-
-                    if (event.trackingAssigned) {
-                        this.flux.actions.type.updateTracking(currentDocument, layers, event.tracking);
-                    } else {
-                        this.flux.actions.type.updateTracking(currentDocument, layers, null);
-                    }
-
-                    if (event.alignAssigned) {
-                        this.flux.actions.type.updateAlignment(currentDocument, layers, event.align);
-                    } else {
-                        this.flux.actions.type.updateAlignment(currentDocument, layers, null);
-                    }
-
-                    // set leading to null if autoleading is true
-                    if (event.autoLeadingAssigned && event.autoLeading) {
-                        this.flux.actions.type.updateLeading(currentDocument, layers, null);
-                    } else {
-                        if (event.leadingAssigned) {
-                            this.flux.actions.type.updateLeading(currentDocument, layers, event.leading);
-                        } else {
-                            this.flux.actions.type.updateLeading(currentDocument, layers, undefined);
-                        }
-                    }
-                }
-            }.bind(this);
+            _typeChangedHandler = TypeTool.updateTextPropertiesHandler.bind(this);
 
             descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
             _layerCreatedHandler = function (event) {
                 var documentStore = this.flux.store("application"),
-                    currentDocument = documentStore.getCurrentDocument(),
-                    layerID = event.layerID,
-                    currentLayer = currentDocument.layers.byID(layerID);
+                    document = documentStore.getCurrentDocument();
+
+                if (!document) {
+                    log.error("Unexpected createTextLayer event: no active document");
+                    return;
+                }
+
+                var layerID = event.layerID,
+                    currentLayer = document.layers.byID(layerID);
 
                 if (currentLayer) {
                     log.warn("Unexpected createTextLayer event for layer " + layerID);
-                    this.flux.actions.layers.resetLayers(currentDocument, currentLayer);
+                    this.flux.actions.layers.resetLayers(document, currentLayer);
                 } else {
-                    this.flux.actions.layers.addLayers(currentDocument, layerID, true);
+                    this.flux.actions.layers.addLayers(document, layerID, true);
                 }
             }.bind(this);
             
             descriptor.addListener("createTextLayer", _layerCreatedHandler);
 
+            _layerDeletedHandler = function (event) {
+                var documentStore = this.flux.store("application"),
+                    document = documentStore.getCurrentDocument();
+
+                if (!document) {
+                    log.error("Unexpected deleteTextLayer event: no active document");
+                    return;
+                }
+
+                var layerID = event.layerID,
+                    layer = document.layers.byID(layerID);
+
+                if (layer) {
+                    this.flux.actions.layers.removeLayers(document, layer);
+                } else {
+                    log.warn("Unexpected deleteTextLayer event for layer " + layerID);
+                }
+            }.bind(this);
+            
+            descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
+
             if (firstLaunch) {
                 firstLaunch = false;
-                return descriptor.batchPlayObjects([resetObj]);
+
+                return descriptor.playObject(toolLib.resetTypeTool("left", "Myriad Pro", 16, [0, 0, 0]));
             }
         };
 
@@ -175,6 +152,38 @@ define(function (require, exports, module) {
         this.activationKey = shortcuts.GLOBAL.TOOLS.TYPE;
     };
     util.inherits(TypeTool, Tool);
+
+    /**
+     * Handles updateTextProperties events, which are emitted during the type modal
+     * tool state to indicate the text properties of the current text selection or
+     * cursor position.
+     *
+     * @static
+     * @param {object} event
+     */
+    TypeTool.updateTextPropertiesHandler = function (event) {
+        var documentStore = this.flux.store("application"),
+            currentDocument = documentStore.getCurrentDocument(),
+            layers = currentDocument.layers.allSelected,
+            typeLayers = layers.filter(function (layer) {
+                return layer.kind === layer.layerKinds.TEXT;
+            });
+
+        if (typeLayers.isEmpty()) {
+            return;
+        }
+
+        var properties = {
+            textSize: event.hasOwnProperty("size") ? event.size : null,
+            postScriptName: event.hasOwnProperty("fontName") ? event.fontName : null,
+            color: event.hasOwnProperty("color") ? Color.fromPhotoshopColorObj(event.color, 100) : null,
+            tracking: event.hasOwnProperty("tracking") ? event.tracking : null,
+            alignment: event.hasOwnProperty("align") ? event.align : null,
+            leading: event.autoLeading ? -1 : (event.hasOwnProperty("leading") ? event.leading : null)
+        };
+
+        this.flux.actions.type.updatePropertiesThrottled(currentDocument, layers, properties);
+    };
 
     module.exports = TypeTool;
 });

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -128,6 +128,7 @@ define(function (require, exports, module) {
             descriptor.removeListener("move", _moveHandler);
             descriptor.removeListener("updateTextProperties", _typeChangedHandler);
             descriptor.removeListener("createTextLayer", _layerCreatedHandler);
+            descriptor.removeListener("deleteTextLayer", _layerDeletedHandler);
 
             var documentStore = this.flux.store("application"),
                 currentDocument = documentStore.getCurrentDocument();


### PR DESCRIPTION
This is modal-type bug-fix PR. I believe it addresses issues #2071, #2009, #1927, #1883, #1881, #1857, #1691. There are still a number of type issues it does not address, so please take a look at the [Type issue label](https://github.com/adobe-photoshop/spaces-design/labels/Type) if you see a problem during testing to see if an issue has already been filed.

Highlights:

* Removes the `*Assigned` properties in `ParagraphStyle` and `CharacterStyle` in favor of a simpler `mergeWith` operation for resolving inconsistencies.
* Simplifies and throttles the `updatedTextProperties` event handler, which PS emits whenever the style properties for the current cursor position/text selection change in the modal state.
* Applies this handler in the select type sub-tool, as well as in the full type tool.
* Makes use of a new `deleteTextLayer` event to catch the case of a new text layer being canceled without committing.
* Factors a `layers.removeLayers` action out of `deleteSelected`, which can be used to remove layers from the JS-side layers model.
* Adds a `type.updateProperties` action to set type properties en masse instead of with separate actions that redraw the UI multiple times redundantly. (TODO: eliminate the other `type.update*` actions in favor of this one.)

@mcilroyc: I'm not sure if I've used the history events correctly. Can you double-check that part of this PR for me?

Requires at least Mac Jenkins pgdev.469 from the afternoon of Monday the 17th.