### PR TITLE
Export enhancements: quick selection, and improved style in export all panel

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -67,7 +67,8 @@ define(function (require, exports) {
      */
     var _syncLayerExportMetadata = function (documentID, layerID) {
         var documentExports = this.flux.stores.export.getDocumentExports(documentID),
-            layerExportsArray = documentExports && documentExports.layerExportsArray(layerID),
+            layerExports = documentExports && documentExports.getLayerExports(layerID),
+            layerExportsArray = layerExports && layerExports.toJS(),
             document = this.flux.stores.document.getDocument(documentID),
             layer = document && document.layers.byID(layerID),
             exportEnabled = document && layer && layer.exportEnabled;
@@ -301,7 +302,7 @@ define(function (require, exports) {
      * @param {Document} document Owner document
      * @param {Layer|Immutable.List.<Layer>} layers Either a Layer reference or array of Layers
      * @param {boolean=} exportEnabled
-     * @returns {Promise}
+     * @return {Promise}
      */
     var setLayerExportEnabled = function (document, layers, exportEnabled) {
         var layerIDs = Immutable.List.isList(layers) ?
@@ -330,7 +331,7 @@ define(function (require, exports) {
      * @private
      * @param {Document} document Owner document
      * @param {boolean=} exportEnabled
-     * @returns {Promise}
+     * @return {Promise}
      */
     var setAllArtboardsExportEnabled = function (document, exportEnabled) {
         var documentExports = this.flux.stores.export.getDocumentExports(document.id);
@@ -352,7 +353,7 @@ define(function (require, exports) {
      * @private
      * @param {Document} document Owner document
      * @param {boolean=} exportEnabled
-     * @returns {Promise}
+     * @return {Promise}
      */
     var setAllNonABLayersExportEnabled = function (document, exportEnabled) {
         var documentExports = this.flux.stores.export.getDocumentExports(document.id);

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -169,7 +169,7 @@ define(function (require, exports) {
             });
     };
     updateLayerExportAsset.reads = [locks.JS_DOC];
-    updateLayerExportAsset.writes = [locks.JS_DOC, locks.PS_DOC];
+    updateLayerExportAsset.writes = [locks.JS_EXPORT, locks.PS_DOC];
 
     /**
      * Set the numerical scale of the asset specified by the given index
@@ -255,6 +255,7 @@ define(function (require, exports) {
 
     /**
      * Update the status of all assets that are being requested
+     * This update does not get synced to PS metadata
      *
      * @param {Document} document
      */
@@ -268,7 +269,7 @@ define(function (require, exports) {
         return this.dispatchAsync(events.export.SET_AS_REQUESTED, { documentID: document.id, layerIDs: layerIDs });
     };
     setAllAssetsRequested.reads = [];
-    setAllAssetsRequested.writes = [locks.JS_DOC];
+    setAllAssetsRequested.writes = [locks.JS_EXPORT];
 
     /**
      * Delete the Export Asset configuration specified by the given index
@@ -294,7 +295,7 @@ define(function (require, exports) {
             });
     };
     deleteLayerExportAsset.reads = [locks.JS_DOC];
-    deleteLayerExportAsset.writes = [locks.JS_DOC, locks.PS_DOC];
+    deleteLayerExportAsset.writes = [locks.JS_EXPORT, locks.PS_DOC];
 
     /**
      * Sets the exportEnabled flag for a given layer or layers
@@ -323,7 +324,7 @@ define(function (require, exports) {
                 }, this));
             });
     };
-    setLayerExportEnabled.reads = [locks.JS_DOC];
+    setLayerExportEnabled.reads = [];
     setLayerExportEnabled.writes = [locks.JS_DOC, locks.PS_DOC];
 
     /**
@@ -344,7 +345,7 @@ define(function (require, exports) {
 
         return this.transfer(setLayerExportEnabled, document, layersWithExports, exportEnabled);
     };
-    setAllArtboardsExportEnabled.reads = [locks.JS_DOC];
+    setAllArtboardsExportEnabled.reads = [locks.JS_EXPORT];
     setAllArtboardsExportEnabled.writes = [];
     setAllArtboardsExportEnabled.transfers = [setLayerExportEnabled];
 
@@ -366,7 +367,7 @@ define(function (require, exports) {
 
         return this.transfer(setLayerExportEnabled, document, layersWithExports, exportEnabled);
     };
-    setAllNonABLayersExportEnabled.reads = [locks.JS_DOC];
+    setAllNonABLayersExportEnabled.reads = [locks.JS_EXPORT];
     setAllNonABLayersExportEnabled.writes = [];
     setAllNonABLayersExportEnabled.transfers = [setLayerExportEnabled];
 
@@ -407,7 +408,7 @@ define(function (require, exports) {
 
         return Promise.all(exportArray);
     };
-    exportAllAssets.reads = [locks.JS_DOC];
+    exportAllAssets.reads = [locks.JS_DOC, locks.JS_EXPORT];
     exportAllAssets.writes = [locks.GENERATOR];
     exportAllAssets.transfers = [updateLayerExportAsset];
 

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -212,7 +212,7 @@ define(function (require, exports, module) {
                         layer={layer}
                         layerExports={layerExports}
                         freshState={freshState}
-                        key={"layer-" + layer.id} />
+                        key={"layer-" + layer.key} />
                 );
             };
 
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
                                         onChange={this._setAllArtboardsExportEnabled} />
                                 </div>
                                 <Gutter />
-                                All&nbsp;{strings.EXPORT.EXPORT_LIST_ARTBOARDS}
+                                {strings.EXPORT.EXPORT_LIST_ALL_ARTBOARDS}
                             </div>
                             <div className="exports-panel__asset-list__list">
                                 {allArtboardsExportComponents}
@@ -249,7 +249,7 @@ define(function (require, exports, module) {
                                         onChange={this._setAllNonABLayersExportEnabled} />
                                 </div>
                                 <Gutter />
-                                All&nbsp;{strings.EXPORT.EXPORT_LIST_ASSETS}
+                                {strings.EXPORT.EXPORT_LIST_ALL_ASSETS}
                             </div>
                             <div className="exports-panel__asset-list__list">
                                 {allNonABLayerExportComponents}
@@ -261,7 +261,7 @@ define(function (require, exports, module) {
                             onClick={this.props.dismissDialog}>
                             {strings.EXPORT.BUTTON_CANCEL}
                         </Button>
-                        <div className="exports-panel__button-group__separator" ></div>
+                        <div className="exports-panel__button-group__separator"></div>
                         <Button
                             onClick={this._exportAllAssets}>
                             {strings.EXPORT.BUTTON_EXPORT}

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -33,10 +33,14 @@ define(function (require, exports, module) {
         _ = require("lodash");
 
     var Button = require("jsx!js/jsx/shared/Button"),
+        Gutter = require("jsx!js/jsx/shared/Gutter"),
         CheckBox = require("jsx!js/jsx/shared/CheckBox"),
-        TitleHeader = require("jsx!js/jsx/shared/TitleHeader");
+        TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
+        SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
 
     var strings = require("i18n!nls/strings"),
+        svgUtil = require("js/util/svg"),
+        collection = require("js/util/collection"),
         ExportAsset = require("js/models/exportasset");
 
     /**
@@ -58,18 +62,23 @@ define(function (require, exports, module) {
 
         render: function () {
             var layer = this.props.layer,
+                layerIconId = svgUtil.getSVGClassFromLayer(layer),
                 layerExports = this.props.layerExports,
                 freshState = this.props.freshState;
 
             // The list of assets within a layer
             var assetsComponent = layerExports.map(function (asset, key) {
                 var stable = asset.status === ExportAsset.STATUS.STABLE,
+                    requested = asset.status === ExportAsset.STATUS.REQUESTED,
+                    errored = asset.status === ExportAsset.STATUS.ERROR,
                     assetTitle = asset.scale + "x";
 
                 var assetClasses = classnames({
                     "exports-panel__layer-asset": true,
-                    "exports-panel__layer-asset__stale": freshState && stable,
-                    "exports-panel__layer-asset__stable": !freshState && stable
+                    "exports-panel__layer-asset__stale": !layer.exportEnabled || (freshState && stable),
+                    "exports-panel__layer-asset__requested": !freshState && requested,
+                    "exports-panel__layer-asset__stable": layer.exportEnabled && !freshState && stable,
+                    "exports-panel__layer-asset__error": errored
                 });
 
                 return (
@@ -81,10 +90,17 @@ define(function (require, exports, module) {
 
             return (
                 <div className="exports-panel__layer-wrapper" >
-                    <CheckBox
-                        checked={layer.exportEnabled}
-                        onChange={this._handleLayerSelectedChanged}
-                        size="column-2" />
+                    <div className="column-2">
+                        <CheckBox
+                            checked={layer.exportEnabled}
+                            onChange={this._handleLayerSelectedChanged} />
+                    </div>
+                    <Gutter />
+                    <div className="exports-panel__layer-icon" >
+                        <SVGIcon
+                            CSSID={layerIconId} />
+                    </div>
+                    <Gutter />
                     <div className="exports-panel__layer-info">
                         <div
                             className="exports-panel__layer__name"
@@ -151,41 +167,59 @@ define(function (require, exports, module) {
             }.bind(this));
         },
 
+        /**
+         * Export all assets for layers that have been enabled for export (via the checkboxes)
+         * @private
+         * @param {SyntheticEvent} event
+         * @param {boolean} enabled
+         */
+        _setAllNonABLayersExportEnabled: function (event, enabled) {
+            this.getFlux().actions.export.setAllNonABLayersExportEnabled(this.state.document, enabled);
+        },
+
+        /**
+         * Export all assets for layers that have been enabled for export (via the checkboxes)
+         * @private
+         * @param {SyntheticEvent} event
+         * @param {boolean} enabled
+         */
+        _setAllArtboardsExportEnabled: function (event, enabled) {
+            this.getFlux().actions.export.setAllArtboardsExportEnabled(this.state.document, enabled);
+        },
+
         render: function () {
             var document = this.state.document,
-                layerExportsMap = this.state.documentExports && this.state.documentExports.layerExportsMap,
+                documentExports = this.state.documentExports,
+                layerExportsMap = documentExports && documentExports.layerExportsMap,
                 freshState = this.state.fresh;
 
-            if (!document || !layerExportsMap) {
+            if (!document || !documentExports) {
                 return null;
             }
 
             // Iterate over all configured assets, build the individual components,
             // and separate into separate lists (artboards vs. non-artboards)
-            var layerExportComponents = [],
-                artboardExportComponents = [];
-            if (layerExportsMap && layerExportsMap.size > 0) {
-                layerExportsMap.forEach(function (layerExports, key) {
-                    var layer = document.layers.byID(key);
+            var artboardLayers = documentExports.getLayersWithExports(document, true),
+                nonABLayers = documentExports.getLayersWithExports(document, false);
 
-                    if (layer && layerExports && layerExports.size > 0) {
-                        var layerComponent = (
-                            <LayerExportsItem
-                                document={document}
-                                layer={layer}
-                                layerExports={layerExports}
-                                freshState={freshState}
-                                key={"layer-" + layer.id} />
-                        );
+            // Helper to generate a LayerExportsItem component
+            var layerExportComponent = function (layer) {
+                var layerExports = layerExportsMap.get(layer.id);
 
-                        if (layer.isArtboard) {
-                            artboardExportComponents.push(layerComponent);
-                        } else {
-                            layerExportComponents.push(layerComponent);
-                        }
-                    }
-                });
-            }
+                return (
+                    <LayerExportsItem
+                        document={document}
+                        layer={layer}
+                        layerExports={layerExports}
+                        freshState={freshState}
+                        key={"layer-" + layer.id} />
+                );
+            };
+
+            var allArtboardsExportComponents = artboardLayers.reverse().map(layerExportComponent),
+                allNonABLayerExportComponents = nonABLayers.reverse().map(layerExportComponent),
+                allArtboardsExportEnabled = collection.pluck(artboardLayers, "exportEnabled"),
+                allNonABLayersExportEnabled = collection.pluck(nonABLayers, "exportEnabled");
 
             return (
                 <div className="exports-panel__container">
@@ -193,26 +227,41 @@ define(function (require, exports, module) {
                         title={strings.TITLE_EXPORT} />
                     <div className="exports-panel__two-column">
                         <div className="exports-panel__asset-list__container">
-                            <TitleHeader
-                                title={strings.EXPORT.EXPORT_LIST_ARTBOARDS} />
+                            <div className="exports-panel__asset-list__quick-selection">
+                                <div className="column-2" >
+                                    <CheckBox
+                                        checked={allArtboardsExportEnabled}
+                                        onChange={this._setAllArtboardsExportEnabled} />
+                                </div>
+                                <Gutter />
+                                All&nbsp;{strings.EXPORT.EXPORT_LIST_ARTBOARDS}
+                            </div>
                             <div className="exports-panel__asset-list__list">
-                                {artboardExportComponents}
+                                {allArtboardsExportComponents}
                             </div>
                         </div>
+                        <Gutter />
                         <div className="exports-panel__asset-list__container">
-                            <TitleHeader
-                                title={strings.EXPORT.EXPORT_LIST_LAYERS} />
+                            <div className="exports-panel__asset-list__quick-selection">
+                                <div className="column-2" >
+                                    <CheckBox
+                                        checked={allNonABLayersExportEnabled}
+                                        onChange={this._setAllNonABLayersExportEnabled} />
+                                </div>
+                                <Gutter />
+                                All&nbsp;{strings.EXPORT.EXPORT_LIST_ASSETS}
+                            </div>
                             <div className="exports-panel__asset-list__list">
-                                {layerExportComponents}
+                                {allNonABLayerExportComponents}
                             </div>
                         </div>
                     </div>
-                    <hr />
                     <div className="exports-panel__button-group">
                         <Button
                             onClick={this.props.dismissDialog}>
                             {strings.EXPORT.BUTTON_CANCEL}
                         </Button>
+                        <div className="exports-panel__button-group__separator" ></div>
                         <Button
                             onClick={this._exportAllAssets}>
                             {strings.EXPORT.BUTTON_EXPORT}

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -25,7 +25,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var React = require("react"),
+    var Immutable = require("immutable"),
+        React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
@@ -39,15 +40,9 @@ define(function (require, exports, module) {
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         strings = require("i18n!nls/strings"),
+        ExportAsset = require("js/models/exportasset"),
         synchronization = require("js/util/synchronization"),
         collection = require("js/util/collection");
-
-    /**
-     * A simple array of scale values, used to determine "next" scale when adding a new asset
-     * @private
-     * @type {Array.<number>}
-     */
-    var _allScales = [0.5, 1, 1.5, 2];
 
     var ExportPanel = React.createClass({
 
@@ -118,9 +113,9 @@ define(function (require, exports, module) {
             var document = this.props.document,
                 documentExports = this.state.documentExports,
                 layerExports = documentExports && documentExports.layerExportsMap.get(layer.id),
-                existingScales = (layerExports && collection.pluck(layerExports, "scale").toArray()) || [],
-                remainingScales = _.difference(_allScales, existingScales),
-                nextScale = remainingScales.length > 0 ? remainingScales[0] : null,
+                existingScales = (layerExports && collection.pluck(layerExports, "scale")) || Immutable.List(),
+                remainingScales = collection.difference(ExportAsset.SCALES, existingScales),
+                nextScale = remainingScales.size > 0 ? remainingScales.first() : null,
                 nextAssetIndex = (layerExports && layerExports.size) || 0;
 
             this.getFlux().actions.export.addLayerAsset(document, layer, nextAssetIndex, nextScale);

--- a/src/js/jsx/sections/export/LayerExports.jsx
+++ b/src/js/jsx/sections/export/LayerExports.jsx
@@ -46,30 +46,28 @@ define(function (require, exports, module) {
      * @private
      * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
      */
-    var _scaleOptions = ExportAsset.SCALES
-        .toSeq()
-        .reduce(function (map, scale) {
+    var _scaleOptions = Immutable.OrderedMap(ExportAsset.SCALES
+        .map(function (scale) {
             var obj = {
                 id: scale.toString(),
                 title: scale.toString()
             };
-            return map.set(scale.toString(), obj);
-        }, Immutable.OrderedMap());
+            return [scale.toString(), obj];
+        }));
 
     /**
      * The options for the format datalist
      * @private
      * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
      */
-    var _formatOptions = ExportAsset.FORMATS
-        .toSeq()
-        .reduce(function (map, format) {
+    var _formatOptions = Immutable.OrderedMap(ExportAsset.FORMATS
+        .map(function (format) {
             var obj = {
                 id: format,
                 title: format.toUpperCase()
             };
-            return map.set(format, obj);
-        }, Immutable.OrderedMap());
+            return [format, obj];
+        }));
 
     /**
      * Local React Component that displays a single Export Asset, including UI elements to update its properties

--- a/src/js/jsx/sections/export/LayerExports.jsx
+++ b/src/js/jsx/sections/export/LayerExports.jsx
@@ -35,7 +35,8 @@ define(function (require, exports, module) {
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         Datalist = require("jsx!js/jsx/shared/Datalist"),
-        TextInput = require("jsx!js/jsx/shared/TextInput");
+        TextInput = require("jsx!js/jsx/shared/TextInput"),
+        ExportAsset = require("js/models/exportasset");
 
     var mathUtil = require("js/util/math"),
         strings = require("i18n!nls/strings");
@@ -45,48 +46,30 @@ define(function (require, exports, module) {
      * @private
      * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
      */
-    var _scaleOptions = Immutable.OrderedMap({
-        "0.5": {
-            id: "0.5",
-            title: "0.5x"
-        },
-        "1": {
-            id: "1",
-            title: "1x"
-        },
-        "1.5": {
-            id: "1.5",
-            title: "1.5x"
-        },
-        "2": {
-            id: "2",
-            title: "2x"
-        }
-    });
+    var _scaleOptions = ExportAsset.SCALES
+        .toSeq()
+        .reduce(function (map, scale) {
+            var obj = {
+                id: scale.toString(),
+                title: scale.toString()
+            };
+            return map.set(scale.toString(), obj);
+        }, Immutable.OrderedMap());
 
     /**
      * The options for the format datalist
      * @private
      * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
      */
-    var _formatOptions = Immutable.OrderedMap({
-        "png": {
-            id: "png",
-            title: "PNG"
-        },
-        "jpg": {
-            id: "jpg",
-            title: "JPG"
-        },
-        "svg": {
-            id: "svg",
-            title: "SVG"
-        },
-        "pdf": {
-            id: "pdf",
-            title: "PDF"
-        }
-    });
+    var _formatOptions = ExportAsset.FORMATS
+        .toSeq()
+        .reduce(function (map, format) {
+            var obj = {
+                id: format,
+                title: format.toUpperCase()
+            };
+            return map.set(format, obj);
+        }, Immutable.OrderedMap());
 
     /**
      * Local React Component that displays a single Export Asset, including UI elements to update its properties

--- a/src/js/jsx/shared/CheckBox.jsx
+++ b/src/js/jsx/shared/CheckBox.jsx
@@ -26,7 +26,8 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Immutable = require("immutable"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var collection = require("js/util/collection");
 
@@ -39,8 +40,8 @@ define(function (require, exports, module) {
      * @return {boolean}
      */
     var _normalizeSelected = function (selected) {
-        return !!(selected === true ||
-            (Immutable.Iterable.isIterable(selected) && collection.uniformValue(selected)));
+        return selected === true ||
+            (Immutable.Iterable.isIterable(selected) && collection.uniformValue(selected));
     };
 
     var CheckBox = React.createClass({
@@ -64,6 +65,12 @@ define(function (require, exports, module) {
             };
         },
 
+        getInitialState: function () {
+            return {
+                uniqueId: _.uniqueId("button-checkbox")
+            };
+        },
+
         /**
          * Handle a toggle of the checkbox, call props.onChange(event, checked) if it exists
          * @private
@@ -77,10 +84,11 @@ define(function (require, exports, module) {
 
         render: function () {
             var checked = _normalizeSelected(this.props.checked),
-                size = this.props.size || "column-1",
+                size = this.props.size,
                 classNameSet = {
                     "button-checkbox": true,
-                    "button-checkbox__disabled": this.props.disabled
+                    "button-checkbox__disabled": this.props.disabled,
+                    "button-checkbox__mixed": checked === null
                 },
                 className = classnames(size, this.props.className, classNameSet);
                 
@@ -89,9 +97,11 @@ define(function (require, exports, module) {
                     title={this.props.title}
                     className={className} >
                     <input
+                        id={this.state.uniqueId}
                         type="checkbox"
                         checked={checked}
                         onChange={!this.props.disabled && this._handleClick} />
+                    <label htmlFor={this.state.uniqueId}></label>
                 </div>
             );
         }

--- a/src/js/jsx/shared/Gutter.jsx
+++ b/src/js/jsx/shared/Gutter.jsx
@@ -24,16 +24,18 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var React = require("react");
+    var React = require("react"),
+        classnames = require("classnames");
 
     var Gutter = React.createClass({
         mixins: [React.addons.PureRenderMixin],
 
         render: function () {
-            var size = this.props.size || "column-1";
+            var size = this.props.size || "column-1",
+                className = classnames("layout-gutter", size, this.props.className);
 
             return (
-                <div className={size}>
+                <div className={className}>
                     &nbsp;
                 </div>
             );

--- a/src/js/locks.js
+++ b/src/js/locks.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
         JS_HISTORY: "jsHistory",
         JS_STYLE: "jsStyle",
         JS_LIBRARIES: "jsLibraries",
+        JS_EXPORT: "jsExport",
         CC_LIBRARIES: "ccLibraries",
         OS_CLIPBOARD: "osClipboard",
         GENERATOR: "generator"

--- a/src/js/models/documentexports.js
+++ b/src/js/models/documentexports.js
@@ -51,47 +51,17 @@ define(function (require, exports, module) {
 
     Object.defineProperties(DocumentExports.prototype, objUtil.cachedGetSpecs({
         /**
-         * Produce an array of ExportAssets for the root of this document, converted to a JS object
-         * This is used for serializing the data to Ps metadata store
-         *
-         * @return {Array.<object>} An array of ExportAsset-like JS objects
-         */
-        rootExportsArray: function () {
-            if (this.rootExports && this.rootExports.size > 0) {
-                return this.rootExports.toJS();
-            } else {
-                return [];
-            }
-        },
-
-        /**
          * Get a list of layer IDs that have a non-empty set of configured export assets
          *
-         * @return {Immutable.IndexedSeq.<number>}
+         * @return {Immutable.List.<number>}
          */
         layerIDsWithExports: function () {
             return this.layerExportsMap
                 .filterNot(function (layerExports) {
                     return layerExports.isEmpty();
                 })
-                .keySeq();
-        }
-    }));
-
-    /**
-     * Produce an array of ExportAssets for the given layerID, converted to a JS object
-     * This is used for serializing the data to Ps metadata store
-     *
-     * @param {number} layerID
-     * @return {Array.<object>} An array of ExportAsset-like JS objects
-     */
-    Object.defineProperty(DocumentExports.prototype, "layerExportsArray", objUtil.cachedLookupSpec(function (layerID) {
-        var layerExports = this.layerExportsMap.get(layerID);
-
-        if (layerExports && layerExports.size > 0) {
-            return layerExports.toJS();
-        } else {
-            return [];
+                .keySeq()
+                .toList();
         }
     }));
 
@@ -120,6 +90,16 @@ define(function (require, exports, module) {
         });
         
         return new DocumentExports({ layerExportsMap: Immutable.Map(layerExportsMap) });
+    };
+
+    /**
+     * Get a List of ExportAssets for the given layerID
+     *
+     * @param {number} layerID
+     * @return {?Immutable.List.<ExportAsset>}
+     */
+    DocumentExports.prototype.getLayerExports = function (layerID) {
+        return this.layerExportsMap.get(layerID);
     };
 
     /**

--- a/src/js/models/exportasset.js
+++ b/src/js/models/exportasset.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      *
      * @type {Imutable.List.<number>}
      */
-    var SCALES = Immutable.List([0.5, 1, 1.5, 2]);
+    var SCALES = Immutable.List([0.5, 1, 1.5, 2, 3]);
 
     /**
      * @constructor

--- a/src/js/models/exportasset.js
+++ b/src/js/models/exportasset.js
@@ -35,8 +35,23 @@ define(function (require, exports, module) {
     var STATUS = {
         NEW: "new",
         REQUESTED: "requested",
-        STABLE: "stable"
+        STABLE: "stable",
+        ERROR: "error"
     };
+
+    /**
+     * Supported formats of export assets
+     *
+     * @type {Imutable.List.<string>}
+     */
+    var FORMATS = Immutable.List(["png", "jpg", "svg", "pdf"]);
+
+    /**
+     * Supported scales of export assets
+     *
+     * @type {Imutable.List.<number>}
+     */
+    var SCALES = Immutable.List([0.5, 1, 1.5, 2]);
 
     /**
      * @constructor
@@ -132,10 +147,11 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Attach the set of possible status values statically to this object;
-     * @type {object}
+     * Attach some enums to the export
      */
     ExportAsset.STATUS = STATUS;
+    ExportAsset.FORMATS = FORMATS;
+    ExportAsset.SCALES = SCALES;
     
     module.exports = ExportAsset;
 });

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -124,6 +124,7 @@ define(function (require, exports, module) {
         }
 
         return this._spacesDomain.exec("exportLayer", payload)
+            .timeout(CONNECTION_TIMEOUT_MS)
             .then(function (exportResponse) {
                 if (Array.isArray(exportResponse) && exportResponse.length > 0) {
                     return exportResponse;
@@ -131,6 +132,9 @@ define(function (require, exports, module) {
                     log.error("Export failed for layer [%s], asset %s", layer.name, JSON.stringify(asset));
                     return Promise.reject("Export Failed");
                 }
+            })
+            .catch(Promise.TimeoutError, function () {
+                return Promise.reject("Generator call exportLayer has timed out");
             });
     };
 

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -353,7 +353,7 @@
     },
     "EXPORT": {
         "EXPORT_LIST_ARTBOARDS": "Artboards",
-        "EXPORT_LIST_LAYERS": "Layers",
+        "EXPORT_LIST_ASSETS": "Assets",
         "BUTTON_EXPORT": "Export",
         "BUTTON_CANCEL": "Cancel",
         "SELECT_SINGLE_LAYER": "Please select a single layer",

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -352,8 +352,8 @@
         "PASTE": "Paste style"
     },
     "EXPORT": {
-        "EXPORT_LIST_ARTBOARDS": "Artboards",
-        "EXPORT_LIST_ASSETS": "Assets",
+        "EXPORT_LIST_ALL_ARTBOARDS": "All Artboards",
+        "EXPORT_LIST_ALL_ASSETS": "All Assets",
         "BUTTON_EXPORT": "Export",
         "BUTTON_CANCEL": "Cancel",
         "SELECT_SINGLE_LAYER": "Please select a single layer",

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -34,6 +34,9 @@
 }
 
 .exports-panel__container {
+    display: flex;
+    align-content: stretch;
+    flex-direction: column;
     margin-left: 5rem;
     margin-right: 5rem;
     width: 56rem;
@@ -42,57 +45,121 @@
 
 .exports-panel__two-column {
     display: flex;
+    flex-grow: 1;
     justify-content: space-between;
+
+    .layout-gutter {
+        flex-grow: 0;
+    }
+}
+
+.exports-panel__asset-list__container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+
+.exports-panel__asset-list__quick-selection {
+    display: flex;
+    flex-direction: row;
 }
 
 .exports-panel__asset-list__list {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    max-height: 51rem;
+    overflow-y: auto;
+    border: @hairline solid @color-subsection-rule;
+    border-left: none;
+    border-right: none;
+    margin: 1rem 0px;
+    padding: 1rem 0px;
 }
 
 .exports-panel__layer-wrapper {
     display: flex;
+    align-items: center;
     flex-wrap: nowrap;
+    margin: 0.5rem 0rem;
+}
+
+.exports-panel__layer-icon {
+    margin-top: 0.2rem;
+    svg {
+        width: 3rem;
+        height: 3rem;
+        fill:  @color-subsection-rule;
+        stroke: none;
+    }
 }
 
 .exports-panel__layer {}
 
 .exports-panel__layer__name {
-    font-size: 2rem;
+    font-size: 1.5rem;
 }
 
 .exports-panel__layer-assets {
-    margin-left: 2rem;
+    font-size: 1.3rem;
     display: flex;
 }
 
 .exports-panel__layer-asset {
-    color: red;
+    color: @warm-gray;
     margin-right: 0.5rem;
 }
 
-.exports-panel__layer-asset__stable {
-    color: green;
+.exports-panel__layer-asset__stale {
+    opacity: 0.5;
 }
 
-.exports-panel__layer-asset__stale {
-    color: yellow;
+.exports-panel__layer-asset__stable {
+    color: @warm-gray;
+    opacity: 1;
+    transition: opacity .5s ease-in;
+}
+
+.exports-panel__layer-asset__requested {
+    opacity: 0.2;
+    transition: opacity .5s ease-out;
+}
+
+.exports-panel__layer-asset__error {
+    opacity: 0.7;
+    color: @label-error-color;
 }
 
 .exports-panel__button-group {
     display: flex;
+    flex-grow: 0;
     justify-content: flex-end;
+    margin: .5rem 0rem;
 }
 
 .exports-panel__button-group .button-simple {
     margin: 0.5rem;
     padding: 1rem;
-    border: @hairline solid!important;
-    .button-radius();
-    display: flex;
+    font-size: 1.5rem;
     justify-content: center;
+    opacity: 0.9;
+
+    &:hover {
+        opacity: 1;
+    }
 }
 
+.exports-panel__button-group__separator {
+    margin: 0.5rem 0;
+    height: 3rem;
+    width: 0.7rem;
+    margin-left: .6rem;
+    border-left: @hairline solid @color-subsection-rule;
+}
+
+/**
+ * Exports Panel
+ */
 .layer-exports__workflow-buttons {
     display: flex;
     flex-direction: row;

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -73,8 +73,8 @@
     border: @hairline solid @color-subsection-rule;
     border-left: none;
     border-right: none;
-    margin: 1rem 0px;
-    padding: 1rem 0px;
+    margin: 1rem 0;
+    padding: 1rem 0;
 }
 
 .exports-panel__layer-wrapper {

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -201,26 +201,26 @@ button {
 }
 
 .button-checkbox {
-    width: 15px;
-    height: 15px;
+    width: 1.5rem;
+    height: 1.5rem;
     position: relative;
     label {
-        width: 15px;
-        height: 15px;
+        width: 1.5rem;
+        height: 1.5rem;
         cursor: pointer;
         position: absolute;
         top: 0;
         left: 0;
         background-color: @warm-gray;
-        border-radius: 2px;
+        border-radius: .2rem;
         &:after {
             content: '';
-            width: 7px;
-            height: 4px;
+            width: 0.7rem;
+            height: 0.4rem;
             position: absolute;
-            top: 3px;
-            left: 3px;
-            border: 3px solid @warm-black;
+            top: 0.3rem;
+            left: 0.3rem;
+            border: 0.3rem solid @warm-black;
             border-top: none;
             border-right: none;
             background: transparent;
@@ -242,8 +242,8 @@ button {
 .button-checkbox__mixed {
     label {
         &:after {
-            top: 2px;
-            left: 4px;
+            top: 0.2rem;
+            left: 0.4rem;
             border-left: none;
             opacity: 1;
             transform: rotate(0);

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -199,3 +199,55 @@ button {
 .button-tool-options button:last-child {
     padding: 0 0 0 1.5rem;
 }
+
+.button-checkbox {
+    width: 15px;
+    height: 15px;
+    position: relative;
+    label {
+        width: 15px;
+        height: 15px;
+        cursor: pointer;
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-color: @warm-gray;
+        border-radius: 2px;
+        &:after {
+            content: '';
+            width: 7px;
+            height: 4px;
+            position: absolute;
+            top: 3px;
+            left: 3px;
+            border: 3px solid @warm-black;
+            border-top: none;
+            border-right: none;
+            background: transparent;
+            opacity: 0;
+            transform: rotate(-45deg);
+        }
+        &:hover::after {
+            opacity: 0.3;
+        }
+    }
+    input[type=checkbox] {
+        visibility: hidden;
+        &:checked + label:after {
+          opacity: 1;
+        } 
+    }
+}
+
+.button-checkbox__mixed {
+    label {
+        &:after {
+            top: 2px;
+            left: 4px;
+            border-left: none;
+            opacity: 1;
+            transform: rotate(0);
+        }
+    }
+}
+


### PR DESCRIPTION
Export All panel:

- Improved UI including grey tri-state checkboxes!
- Added two new checkboxes to quickly select (mark for export) All artboards, and All non-artboards
- Layers are listed in proper layer order, including artboards in reverse (per dave, I think)

Tech Debt Payments:

- Moved the definition of supported scales and formats into the model
- Improved error handling of asset export, including adding a timeout since generator seems to sometimes just not respond

http://cl.ly/2w3z3U350J2i