### PR TITLE
After type layer commit, 'make' event handler resets Layers and then amends current history with the result

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -386,9 +386,10 @@ define(function (require, exports) {
      *
      * @param {Document} document
      * @param {Layer|Immutable.Iterable.<Layer>} layers
+     * @param {boolean=} amendHistory If truthy, update the current history state with latest document
      * @return {Promise}
      */
-    var resetLayers = function (document, layers) {
+    var resetLayers = function (document, layers, amendHistory) {
         if (layers instanceof Layer) {
             layers = Immutable.List.of(layers);
         } else if (layers.isEmpty()) {
@@ -416,7 +417,11 @@ define(function (require, exports) {
                         descriptor: descriptors[index++]
                     };
                 });
-                this.dispatch(events.document.RESET_LAYERS, payload);
+                if (amendHistory) {
+                    this.dispatch(events.document.history.amendment.RESET_LAYERS, payload);
+                } else {
+                    this.dispatch(events.document.RESET_LAYERS, payload);
+                }
             });
     };
     resetLayers.reads = [locks.PS_DOC];
@@ -1654,7 +1659,7 @@ define(function (require, exports) {
                 if (typeof event.layerID === "number") {
                     var curLayer = currentDocument.layers.byID(event.layerID);
                     if (curLayer) {
-                        this.flux.actions.layers.resetLayers(currentDocument, curLayer);
+                        this.flux.actions.layers.resetLayers(currentDocument, curLayer, true);
                     } else {
                         this.flux.actions.layers.addLayers(currentDocument, event.layerID);
                     }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -73,7 +73,8 @@ define(function (require, exports, module) {
                 },
                 amendment: {
                     TYPE_COLOR_CHANGED: "typeColorChangedAmendment",
-                    REORDER_LAYERS: "reorderLayersAmendment"
+                    REORDER_LAYERS: "reorderLayersAmendment",
+                    RESET_LAYERS: "resetLayersAmendement"
                 }
             },
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.ADD_LAYERS, this._handleLayerAdd,
                 events.document.GUIDES_VISIBILITY_CHANGED, this._updateDocumentGuidesVisibility,
                 events.document.RESET_LAYERS, this._handleLayerReset,
+                events.document.history.amendment.RESET_LAYERS, this._handleLayerReset,
                 events.document.RESET_LAYERS_BY_INDEX, this._handleLayerResetByIndex,
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._handleBoundsReset,
                 events.document.RESET_BOUNDS, this._handleBoundsReset,

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -568,10 +568,18 @@ define(function (require, exports, module) {
                     nextState = new HistoryState({ document: document });
 
                 if (!document) {
-                    throw new Error("Could not push history state, document not found: " + documentID);
+                    throw new Error("Could not amend history state, document not found: " + documentID);
                 }
 
-                return this._pushHistoryState.call(this, nextState, true);
+                var history = this._history.get(documentID) || Immutable.List(),
+                    current = this._current.get(documentID) || -1,
+                    currentState = history.get(current);
+
+                if (history && currentState && current > -1) {
+                    history = history.splice(current, 1, currentState.merge(nextState));
+                    this._history = this._history.set(documentID, history);
+                    this.emit("change");
+                }
             });
         },
 


### PR DESCRIPTION
After committing a new text layer, some time in the future get a 'make' event.  If we determine that this event is related to the type layer we've just added to the model (and for which we've already captured a history state), then we need to *amend* the history state with the late-breaking information.

In practice this means the layer name has changed.  It is now informed by the type layer's text content.

This PR also spruces up history state 'amendment' handling;  it is now generally handled more efficiently, and less chatty.

addresses #2092