### PR TITLE
Reset type size after resizing text layers in the transform panel

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -57,7 +57,6 @@ define(function (require, exports) {
         quality: "draft"
     };
 
-
     /**
      * Helper function that will break down a given layer to all it's children
      * and return layerActionsUtil compatible layer actions to move all the kids
@@ -423,53 +422,6 @@ define(function (require, exports) {
     swapLayers.transfers = [toolActions.resetBorderPolicies];
 
     /**
-     * Sets the bounds of currently selected layer group in the given document
-     *
-     * @param {Document} document Target document to run action in
-     * @param {Bounds} oldBounds The original bounding box of selected layers
-     * @param {Bounds} newBounds Bounds to transform to
-     */
-    var setBounds = function (document, oldBounds, newBounds) {
-        var selected = document.layers.selected,
-            documentRef = documentLib.referenceBy.id(document.id),
-            layerRef = [documentRef, layerLib.referenceBy.current],
-            resizeObj;
-        
-        // Special case for artboards where we only resize the artboard
-        if (selected.size === 1 && selected.first().isArtboard) {
-            var normalBounds = newBounds.normalize(),
-                boundingBox = {
-                    top: normalBounds.top,
-                    bottom: normalBounds.bottom,
-                    left: normalBounds.left,
-                    right: normalBounds.right
-                };
-            resizeObj = artboardLib.transform(layerRef, boundingBox);
-        } else {
-            var pixelWidth = newBounds.width,
-                pixelHeight = newBounds.height,
-                pixelTop = newBounds.top,
-                pixelLeft = newBounds.left;
-            
-            resizeObj = layerLib.setSize(layerRef, pixelWidth, pixelHeight, false, pixelLeft, pixelTop);
-        }
-        // No need for lock/hide/select dance for this because this is only 
-        // called from transform overlay
-        return descriptor.playObject(resizeObj)
-            .bind(this)
-            .then(function () {
-                var descendants = selected.flatMap(document.layers.descendants, document.layers);
-
-                return this.transfer(layerActions.resetBounds, document, descendants);
-            })
-            // HACK: Artboard resize fails if it's a no-op, so temporarily, we're catching it here
-            .catch(function () {});
-    };
-    setBounds.reads = [locks.PS_DOC, locks.JS_DOC];
-    setBounds.writes = [locks.PS_DOC, locks.JS_DOC];
-    setBounds.transfers = [layerActions.resetBounds];
-    
-    /**
      * Sets the given layers' sizes
      * @private
      * @param {Document} document Owner document
@@ -527,12 +479,22 @@ define(function (require, exports) {
         return Promise.join(dispatchPromise, sizePromise)
             .bind(this)
             .then(function () {
-                return this.transfer(toolActions.resetBorderPolicies);
+                var typeLayers = layerSpec.filter(function (layer) {
+                    return layer.kind === layer.layerKinds.TEXT;
+                });
+
+                // Reset type layers to pick up their implicit font size changes.
+                // Final true parameter indicates that history should be amended
+                // with this change.
+                var typePromise = this.transfer(layerActions.resetLayers, document, typeLayers, true),
+                    policyPromise = this.transfer(toolActions.resetBorderPolicies);
+
+                return Promise.join(typePromise, policyPromise);
             });
     };
     setSize.reads = [];
     setSize.writes = [locks.PS_DOC, locks.JS_DOC];
-    setSize.transfers = [toolActions.resetBorderPolicies];
+    setSize.transfers = [toolActions.resetBorderPolicies, layerActions.resetLayers];
     
     /**
      * Asks photoshop to flip, either horizontally or vertically.
@@ -1179,7 +1141,6 @@ define(function (require, exports) {
     exports.swapLayers = swapLayers;
     exports.swapLayersCurrentDocument = swapLayersCurrentDocument;
     exports.setRadius = setRadius;
-    exports.setBounds = setBounds;
     exports.rotate = rotate;
     exports.rotateLayersInCurrentDocument = rotateLayersInCurrentDocument;
     exports.nudgeLayers = nudgeLayers;


### PR DESCRIPTION
Calls `resetLayers` on type layers at the end of `transform.setSize`. Also, removes `transform.setBounds`, which was dead code.

Note for testing: Photoshop doesn't change the implied font size if you just change the layer's width; it seems to only actually care about the height. (I'm not sure if that's guaranteed though, so I'm not factoring that into the logic here.)

Addresses #2093.