### PR TITLE
Guides in Design Space!

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -255,7 +255,7 @@ define(function (require, exports) {
                     .then(_getLayersForDocument)
                     .then(function (payload) {
                         this.dispatch(events.document.DOCUMENT_UPDATED, payload);
-                    }.bind(this));
+                    });
             }, this);
 
         return Promise.all(otherDocPromises);
@@ -691,10 +691,15 @@ define(function (require, exports) {
         var playObject = documentLib.setGuidesVisibility(newVisibility),
             playPromise = descriptor.playObject(playObject);
 
-        return Promise.join(dispatchPromise, playPromise);
+        return Promise.join(dispatchPromise, playPromise)
+            .bind(this)
+            .then(function () {
+                return this.transfer(guideActions.resetGuidePolicies);
+            });
     };
     toggleGuidesVisibility.reads = [locks.JS_DOC, locks.JS_APP];
     toggleGuidesVisibility.writes = [locks.JS_DOC, locks.PS_DOC];
+    toggleGuidesVisibility.transfers = [guideActions.resetGuidePolicies];
 
     /**
      * Toggle the visibility of smart guides on the current document

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var Promise = require("bluebird"),
+        _ = require("lodash");
+        
+    var descriptor = require("adapter/ps/descriptor"),
+        adapterUI = require("adapter/ps/ui"),
+        adapterOS = require("adapter/os");
+
+    var locks = require("js/locks"),
+        events = require("js/events"),
+        policy = require("./policy"),
+        EventPolicy = require("js/models/eventpolicy"),
+        PointerEventPolicy = EventPolicy.PointerEventPolicy;
+
+
+    /**
+     * Properties to be included when requesting guide
+     * descriptors from Photoshop.
+     * @private
+     * @type {Array.<string>} 
+     */
+    var _guideProperties = [
+        "ID",
+        "orientation",
+        "position",
+        "itemIndex"
+    ];
+
+    /**
+     * Get all the guide descriptors in the given document.
+     * 
+     * @private
+     * @param {object} docRef A document reference
+     * @param {number} numberOfGuides
+     * @return {Promise.<Array.<object>>}
+     */
+    var _getGuidesForDocumentRef = function (docRef, numberOfGuides) {
+        var rangeOpts = {
+                range: "guide",
+                index: 1,
+                count: numberOfGuides
+            },
+            getOpts = {
+                failOnMissingProperty: true
+            };
+
+        // FIXME: Should we reverse these?
+        return descriptor.getPropertiesRange(docRef, rangeOpts, _guideProperties, getOpts);
+    };
+
+    var _currentGuidePolicyID = null;
+
+    /**
+     * Draws pointer policies around existing guides letting the mouse through to Photoshop
+     *
+     * @return {Promise}
+     */
+    var resetGuidePolicies = function () {
+        var toolStore = this.flux.store("tool"),
+            appStore = this.flux.store("application"),
+            uiStore = this.flux.store("ui"),
+            currentDocument = appStore.getCurrentDocument(),
+            currentPolicy = _currentGuidePolicyID,
+            currentTool = toolStore.getCurrentTool();
+
+        // Make sure to always remove the remaining policies
+        if (!currentDocument || !currentTool || currentTool.id !== "newSelect") {
+            if (currentPolicy) {
+                _currentGuidePolicyID = null;
+                return this.transfer(policy.removePointerPolicies,
+                    currentPolicy, true);
+            } else {
+                return Promise.resolve();
+            }
+        }
+
+        var guides = currentDocument.guides;
+
+        // If selection is empty, remove existing policy
+        if (!guides || guides.empty) {
+            if (currentPolicy) {
+                _currentGuidePolicyID = null;
+                return this.transfer(policy.removePointerPolicies,
+                    currentPolicy, true);
+            } else {
+                return Promise.resolve();
+            }
+        }
+
+        // How thick the policy line should be while defined as an area around the guide
+        var policyThickness = 2,
+            canvasBounds = uiStore.getCloakRect();
+
+        // Each guide is either horizontal or vertical with a specific position on canvas space
+        // We need to create a rectangle around this guide that fits the window boundaries
+        // that lets the mouse clicks go to Photoshop (ALWAYS_PROPAGATE)
+        var guidePolicyList = guides.map(function (guide) {
+            var horizontal = guide.orientation === "horizontal",
+                guideTL = uiStore.transformCanvasToWindow(
+                    horizontal ? 0 : guide.position,
+                    horizontal ? guide.position : 0
+                ),
+                guideArea;
+
+            if (horizontal) {
+                guideArea = {
+                    x: canvasBounds.left,
+                    y: guideTL.y - policyThickness - 1,
+                    width: canvasBounds.right - canvasBounds.left,
+                    height: policyThickness * 2 + 1
+                };
+            } else {
+                guideArea = {
+                    x: guideTL.x - policyThickness,
+                    y: canvasBounds.top,
+                    width: policyThickness * 2 + 1,
+                    height: canvasBounds.bottom - canvasBounds.top
+                };
+            }
+            
+            return new PointerEventPolicy(adapterUI.policyAction.ALWAYS_PROPAGATE,
+                adapterOS.eventKind.LEFT_MOUSE_DOWN,
+                {}, // no modifiers
+                guideArea);
+        }).toArray();
+
+        var removePromise;
+        if (currentPolicy) {
+            _currentGuidePolicyID = null;
+            removePromise = this.transfer(policy.removePointerPolicies,
+                currentPolicy, false);
+        } else {
+            removePromise = Promise.resolve();
+        }
+
+        return removePromise.bind(this).then(function () {
+            return this.transfer(policy.addPointerPolicies, guidePolicyList);
+        }).then(function (policyID) {
+            _currentGuidePolicyID = policyID;
+        });
+    };
+    resetGuidePolicies.reads = [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI];
+    resetGuidePolicies.writes = [];
+    resetGuidePolicies.transfers = [policy.removePointerPolicies, policy.addPointerPolicies];
+
+    /**
+     * Updates the given guide's position
+     *
+     * @param {object} payload
+     * @param {number} payload.documentID Owner document ID
+     * @param {number} payload.index Index of the edited guide
+     * @param {string} payload.orientation New orientation of the guide
+     * @param {number} payload.position New position of the guide
+     *
+     * @return {Promise}
+     */
+    var moveGuide = function (payload) {
+        return this.dispatchAsync(events.document.history.nonOptimistic.GUIDE_MOVED, payload)
+            .bind(this)
+            .then(function () {
+                return this.transfer(resetGuidePolicies);
+            });
+    };
+    moveGuide.reads = [];
+    moveGuide.writes = [locks.JS_DOC];
+    moveGuide.transfers = [resetGuidePolicies];
+
+    /**
+     * Deletes the given guide
+     *
+     * @param {object} payload
+     * @param {number} payload.documentID Owner document ID
+     * @param {number} payload.index Index of the edited guide
+     *
+     * @return {Promise}
+     */
+    var deleteGuide = function (payload) {
+        return this.dispatchAsync(events.document.history.nonOptimistic.GUIDE_DELETED, payload)
+            .bind(this)
+            .then(function () {
+                return this.transfer(resetGuidePolicies);
+            });
+    };
+    deleteGuide.reads = [];
+    deleteGuide.writes = [locks.JS_DOC];
+    deleteGuide.transfers = [resetGuidePolicies];
+
+    // Event handlers for guides
+    var _guideSetHandler = null,
+        _guideDeleteHandler = null;
+
+    /**
+     * Register event listeners for guide edit/delete events
+     * 
+     * @return {Promise}
+     */
+    var beforeStartup = function () {
+        // Listen for guide set events
+        _guideSetHandler = function (event) {
+            var target = event.null._ref;
+
+            if (_.isArray(target) && target[0]._ref === "document" && target[1]._ref === "good") {
+                var payload = {
+                    documentID: target[0]._id,
+                    index: target[1]._index - 1, // PS indices guides starting at 1
+                    orientation: event.orientation._value,
+                    position: event.position._value
+                };
+
+                this.flux.actions.guides.moveGuide(payload);
+            }
+        }.bind(this);
+        descriptor.addListener("set", _guideSetHandler);
+
+        // Listen for guide delete events
+        _guideDeleteHandler = function (event) {
+            var target = event.null._ref;
+
+            // Mind the reversal of references compared to "set"
+            if (_.isArray(target) && target[1]._ref === "document" && target[0]._ref === "good") {
+                var payload = {
+                    documentID: target[1]._id,
+                    index: target[0]._index - 1 // PS indices guides starting at 1
+                };
+
+                this.flux.actions.guides.deleteGuide(payload);
+            }
+        }.bind(this);
+        descriptor.addListener("delete", _guideDeleteHandler);
+
+        return Promise.resolve();
+    };
+    beforeStartup.modal = true;
+    beforeStartup.reads = [];
+    beforeStartup.writes = [];
+    beforeStartup.transfers = [];
+    
+    /**
+     * Remove event handlers.
+     *
+     * @return {Promise}
+     */
+    var onReset = function () {
+        descriptor.removeListener("set", _guideSetHandler);
+        descriptor.removeListener("delete", _guideDeleteHandler);
+
+        return Promise.resolve();
+    };
+    onReset.reads = [];
+    onReset.writes = [];
+
+    exports._getGuidesForDocumentRef = _getGuidesForDocumentRef;
+
+    exports.moveGuide = moveGuide;
+    exports.deleteGuide = deleteGuide;
+    exports.resetGuidePolicies = resetGuidePolicies;
+
+
+    exports.beforeStartup = beforeStartup;
+    exports.onReset = onReset;
+});

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -93,7 +93,8 @@ define(function (require, exports) {
             currentTool = toolStore.getCurrentTool();
 
         // Make sure to always remove the remaining policies
-        if (!currentDocument || !currentTool || currentTool.id !== "newSelect") {
+        if (!currentDocument || !currentDocument.guidesVisible ||
+            !currentTool || currentTool.id !== "newSelect") {
             if (currentPolicy) {
                 _currentGuidePolicyID = null;
                 return this.transfer(policy.removePointerPolicies,
@@ -106,7 +107,7 @@ define(function (require, exports) {
         var guides = currentDocument.guides;
 
         // If selection is empty, remove existing policy
-        if (!guides || guides.empty) {
+        if (!guides || guides.isEmpty()) {
             if (currentPolicy) {
                 _currentGuidePolicyID = null;
                 return this.transfer(policy.removePointerPolicies,

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
         edit: require("./edit"),
         example: require("./example"),
         export: require("./export"),
+        guides: require("./guides"),
         help: require("./help"),
         history: require("./history"),
         keyevents: require("./keyevents"),

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
                     ADD_LAYERS: "addLayers",
                     COMBINE_SHAPES: "combineShapes",
                     DELETE_LAYERS: "deleteLayersNonOptimistic", // eg: ps deletes the entire layer after last path del,
-                    GUIDE_MOVED: "guideMoved",
+                    GUIDE_SET: "guideSet",
                     GUIDE_DELETED: "guideDeleted"
                 },
                 amendment: {
@@ -97,6 +97,7 @@ define(function (require, exports, module) {
             CLOSE_DOCUMENT: "closeDocument",
             DOCUMENT_RENAMED: "renameDocument",
             DOCUMENT_UPDATED: "updateDocument",
+            GUIDES_UPDATED: "guidesUpdated",
             // The following stroke/type events rely on subsequent bounds fetch
             STROKE_ENABLED_CHANGED: "strokeEnabledChanged",
             STROKE_WIDTH_CHANGED: "strokeWidthChanged",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -69,7 +69,9 @@ define(function (require, exports, module) {
                     UNGROUP_SELECTED: "ungroupSelectedLayers",
                     ADD_LAYERS: "addLayers",
                     COMBINE_SHAPES: "combineShapes",
-                    DELETE_LAYERS: "deleteLayersNonOptimistic" // eg: ps deletes the entire layer after last path del
+                    DELETE_LAYERS: "deleteLayersNonOptimistic", // eg: ps deletes the entire layer after last path del,
+                    GUIDE_MOVED: "guideMoved",
+                    GUIDE_DELETED: "guideDeleted"
                 },
                 amendment: {
                     TYPE_COLOR_CHANGED: "typeColorChangedAmendment",

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
     var adapterOS = require("adapter/os");
 
     var PolicyOverlay = require("jsx!js/jsx/tools/PolicyOverlay"),
+        GuidesOverlay = require("jsx!js/jsx/tools/GuidesOverlay"),
         Droppable = require("jsx!js/jsx/shared/Droppable");
     
     var Scrim = React.createClass({
@@ -295,6 +296,7 @@ define(function (require, exports, module) {
                         <g id="overlay" width="100%" height="100%">
                             {toolOverlay}
                             {policyOverlay}
+                            <GuidesOverlay />
                         </g>
                     </svg>
                 </div>

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
                 // because the gap might not necessarily be exactly one pixel.
                 // This calculation should be improved in the next UI refactor.
                 var toolbarWidth = React.findDOMNode(this).clientWidth,
-                    newWidth = pinned ? toolbarWidth + 1 : 0;
+                    newWidth = pinned ? toolbarWidth : 0;
 
                 flux.actions.ui.updateToolbarWidth(newWidth);
             }
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
             if (this.state.pinned !== nextState.pinned) {
                 // NOTE: See comment above about the width offset below.
                 var toolbarWidth = React.findDOMNode(this).clientWidth,
-                    newWidth = nextState.pinned ? toolbarWidth + 1 : 0;
+                    newWidth = nextState.pinned ? toolbarWidth : 0;
 
                 flux.actions.ui.updateToolbarWidth(newWidth);
             }

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
     var DEBOUNCE_DELAY = 200;
 
     var GuidesOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("tool", "application", "ui")],
+        mixins: [FluxMixin, StoreWatchMixin("document", "tool", "application", "ui")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -145,6 +145,7 @@ define(function (require, exports, module) {
             svg.selectAll(".guide-edges").remove();
 
             if (!currentDocument || this.state.modalState ||
+                !currentDocument.guidesVisible ||
                 !currentTool || currentTool.id !== "newSelect") {
                 return null;
             }

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
                         guideTop < mouseY && guideBottom > mouseY;
 
                 if (!highlightFound && intersects) {
-                    guide.classed("guide-edges-hover", true)
+                    guide.classed("guide-edges__hover", true)
                         .on("mousedown", function () {
                             self.getFlux().actions.guides.createGuideAndTrack(
                                 self.state.document, orientation, mouseX, mouseY
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
 
                     highlightFound = true;
                 } else {
-                    guide.classed("guide-edges-hover", false);
+                    guide.classed("guide-edges__hover", false);
                 }
             });
         },

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React),
+        StoreWatchMixin = Fluxxor.StoreWatchMixin,
+        d3 = require("d3"),
+        _ = require("lodash");
+
+    var OS = require("adapter/os");
+
+    var mathUtil = require("js/util/math");
+
+    // Used for debouncing the overlay drawing
+    var DEBOUNCE_DELAY = 200;
+
+    var GuidesOverlay = React.createClass({
+        mixins: [FluxMixin, StoreWatchMixin("tool", "application", "ui")],
+
+        /**
+         * Keeps track of current mouse position so we can rerender the overlaid layers correctly
+         * @type {number}
+         */
+        _currentMouseX: null,
+
+        /**
+         * Keeps track of current mouse position so we can rerender the overlaid layers correctly
+         * @type {number}
+         */
+        _currentMouseY: null,
+
+        /**
+         * Owner group for all the overlay svg elements
+         *
+         * @type {SVGElement}
+         */
+        _scrimGroup: null,
+
+        /**
+         * Debounced draw function, for performance
+         * 
+         * @type {function}
+         */
+        _drawDebounced: null,
+
+        getStateFromFlux: function () {
+            var flux = this.getFlux(),
+                applicationStore = flux.store("application"),
+                toolStore = flux.store("tool"),
+                modalState = toolStore.getModalToolState(),
+                currentTool = toolStore.getCurrentTool(),
+                currentDocument = applicationStore.getCurrentDocument();
+
+            return {
+                document: currentDocument,
+                tool: currentTool,
+                modalState: modalState
+            };
+        },
+
+        componentWillMount: function () {
+            this._drawDebounced = _.debounce(this.drawOverlay, DEBOUNCE_DELAY);
+        },
+
+        componentWillUnmount: function () {
+            OS.removeListener("externalMouseMove", this.mouseMoveHandler);
+        },
+
+        componentDidMount: function () {
+            this._currentMouseX = null;
+            this._currentMouseY = null;
+            
+            this._drawDebounced();
+            
+            // Marquee mouse handlers
+            OS.addListener("externalMouseMove", this.mouseMoveHandler);
+        },
+
+        componentDidUpdate: function () {
+            // Redraw immediately when we're in a modal state
+            if (this.state.modalState) {
+                this.drawOverlay();
+            } else {
+                this._drawDebounced();
+            }
+        },
+
+        /**
+         * Attaches to mouse move events coming from Photoshop
+         * so we can set highlights manually. We have to resort to this
+         * because external mouse move events do not cause :hover states
+         * in DOM elements
+         *
+         * @private
+         * @param {CustomEvent} event EXTERNAL_MOUSE_MOVE event coming from _spaces.OS
+         */
+        mouseMoveHandler: function (event) {
+            if (this.isMounted()) {
+                this._currentMouseX = event.location[0];
+                this._currentMouseY = event.location[1];
+                
+                this.updateMouseOverHighlights();
+            }
+        },
+
+        /**
+         * Calls all helper functions to draw sampler overlay
+         * Cleans it first
+         * @private
+         */
+        drawOverlay: function () {
+            if (!this.isMounted()) {
+                return;
+            }
+
+            var currentDocument = this.state.document,
+                currentTool = this.state.tool,
+                svg = d3.select(React.findDOMNode(this));
+
+            svg.selectAll(".guide-edges").remove();
+
+            if (!currentDocument || this.state.modalState ||
+                !currentTool || currentTool.id !== "newSelect") {
+                return null;
+            }
+
+            this._scrimGroup = svg.insert("g", ".transform-control-group")
+                .classed("guide-edges", true);
+
+            this.drawGuideEdges();
+        },
+
+        // Draws the guide edge areas
+        drawGuideEdges: function () {
+            var uiStore = this.getFlux().store("ui"),
+                canvasBounds = uiStore.getCloakRect(),
+                edgeThickness = 20, // How wide/tall the guide creation edges are
+                canvasWidth = canvasBounds.right - canvasBounds.left,
+                canvasHeight = canvasBounds.bottom - canvasBounds.top;
+
+            // Top edge
+            this._scrimGroup
+                .append("rect")
+                .attr("x", canvasBounds.left)
+                .attr("y", canvasBounds.top)
+                .attr("width", canvasWidth)
+                .attr("height", edgeThickness)
+                .attr("orientation", "horizontal")
+                .classed("guide-edges", true);
+
+            // Left edge
+            this._scrimGroup
+                .append("rect")
+                .attr("x", canvasBounds.left)
+                .attr("y", canvasBounds.top)
+                .attr("width", edgeThickness)
+                .attr("height", canvasHeight)
+                .attr("orientation", "vertical")
+                .classed("guide-edges", true);
+
+            // Bottom edge
+            this._scrimGroup
+                .append("rect")
+                .attr("x", canvasBounds.left)
+                .attr("y", canvasBounds.bottom - edgeThickness)
+                .attr("width", canvasWidth)
+                .attr("height", edgeThickness)
+                .attr("orientation", "horizontal")
+                .classed("guide-edges", true);
+
+            // Right edge
+            this._scrimGroup
+                .append("rect")
+                .attr("x", canvasBounds.right - edgeThickness)
+                .attr("y", canvasBounds.top)
+                .attr("width", edgeThickness)
+                .attr("height", canvasHeight)
+                .attr("orientation", "vertical")
+                .classed("guide-edges", true);
+        },
+
+        /**
+         * Goes through all layer bounds and highlights the top one the cursor is on
+         *
+         * @private
+         */
+        updateMouseOverHighlights: function () {
+            var mouseX = this._currentMouseX,
+                mouseY = this._currentMouseY,
+                highlightFound = false,
+                self = this;
+
+            d3.selectAll(".guide-edges").each(function () {
+                var guide = d3.select(this),
+                    guideLeft = mathUtil.parseNumber(guide.attr("x")),
+                    guideTop = mathUtil.parseNumber(guide.attr("y")),
+                    guideRight = guideLeft + mathUtil.parseNumber(guide.attr("width")),
+                    guideBottom = guideTop + mathUtil.parseNumber(guide.attr("height")),
+                    orientation = guide.attr("orientation"),
+                    intersects = guideLeft < mouseX && guideRight > mouseX &&
+                        guideTop < mouseY && guideBottom > mouseY;
+
+                if (!highlightFound && intersects) {
+                    guide.classed("guide-edges-hover", true)
+                        .on("mousedown", function () {
+                            self.getFlux().actions.guides.createGuideAndTrack(
+                                self.state.document, orientation, mouseX, mouseY
+                            );
+                            d3.event.stopPropagation();
+                        });
+
+                    highlightFound = true;
+                } else {
+                    guide.classed("guide-edges-hover", false);
+                }
+            });
+        },
+
+        render: function () {
+            return (<g />);
+        }
+    });
+
+    module.exports = GuidesOverlay;
+});

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -150,7 +150,8 @@ define(function (require, exports, module) {
         model.smartGuidesVisible = documentDescriptor.smartGuidesVisibility;
         model.bounds = Bounds.fromDocumentDescriptor(documentDescriptor);
         model.layers = LayerStructure.fromDescriptors(documentDescriptor, layerDescriptors);
-        model.guides = Guide.fromDescriptors(documentDescriptor, guideDescriptors);
+        model.guides = guideDescriptors ? Guide.fromDescriptors(documentDescriptor, guideDescriptors) :
+            Immutable.List();
 
         if (documentDescriptor.format) {
             model.format = documentDescriptor.format;

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
 
     var object = require("js/util/object"),
         LayerStructure = require("./layerstructure"),
+        Guide = require("./guide"),
         Bounds = require("./bounds");
 
     /**
@@ -97,6 +98,12 @@ define(function (require, exports, module) {
          */
         smartGuidesVisible: null,
 
+        /**
+         * Current guides of the document
+         *
+         * @type {Immutable.List.<Guide>}
+         */
+        guides: null,
 
         /**
          * If file is saved, contains the file type (e.g. "Photoshop" for PSD)
@@ -123,13 +130,14 @@ define(function (require, exports, module) {
 
     /**
      * Construct a new document model from a Photoshop document descriptor and
-     * a list of layer descriptors.
+     * a list of layer and guide descriptors.
      * 
      * @param {object} documentDescriptor
      * @param {Immutable.Iterator.<object>} layerDescriptors
+     * @param {Immutable.Iterator.<object>} guideDescriptors
      * @return {Document}
      */
-    Document.fromDescriptors = function (documentDescriptor, layerDescriptors) {
+    Document.fromDescriptors = function (documentDescriptor, layerDescriptors, guideDescriptors) {
         var model = {};
 
         model.id = documentDescriptor.documentID;
@@ -142,6 +150,7 @@ define(function (require, exports, module) {
         model.smartGuidesVisible = documentDescriptor.smartGuidesVisibility;
         model.bounds = Bounds.fromDocumentDescriptor(documentDescriptor);
         model.layers = LayerStructure.fromDescriptors(documentDescriptor, layerDescriptors);
+        model.guides = Guide.fromDescriptors(documentDescriptor, guideDescriptors);
 
         if (documentDescriptor.format) {
             model.format = documentDescriptor.format;

--- a/src/js/models/guide.js
+++ b/src/js/models/guide.js
@@ -89,11 +89,9 @@ define(function (require, exports, module) {
      * @return {Immutable.List.<number, Guide>}
      */
     Guide.fromDescriptors = function (documentDescriptor, guideDescriptors) {
-        return guideDescriptors.reduce(function (guides, descriptor) {
-            var guide = Guide.fromDescriptor(documentDescriptor, descriptor);
-            
-            return guides.push(guide);
-        }, Immutable.List());
+        return Immutable.List(guideDescriptors.map(function (descriptor) {
+            return Guide.fromDescriptor(documentDescriptor, descriptor);
+        }));
     };
 
     module.exports = Guide;

--- a/src/js/models/guide.js
+++ b/src/js/models/guide.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Immutable = require("immutable");
+
+    /**
+     * @constructor
+     * @param {object} model
+     */
+    var Guide = Immutable.Record({
+        /**
+         * ID of the owner document for this guide
+         * 
+         * @type {number}
+         */
+        documentID: null,
+
+        /**
+         * Position of the guide in pixels
+         * 
+         * @type {number}
+         */
+        position: null,
+
+        /**
+         * Orientation of the guide ("horizontal" or "vertical")
+         * 
+         * @type {string}
+         */
+        orientation: null
+
+    });
+
+    /**
+     * Construct a Guide model from a Photoshop document and a guide descriptor.
+     *
+     * @param {object|Immutable.Record} document Document descriptor or Document model
+     * @param {object} guideDescriptor
+     * @return {Guide}
+     */
+    Guide.fromDescriptor = function (document, guideDescriptor) {
+        var documentID;
+
+        // handle either style of document param
+        if (document instanceof Immutable.Record) {
+            documentID = document.id;
+        } else {
+            documentID = document.documentID;
+        }
+
+        var model = {
+            documentID: documentID,
+            // id: guideDescriptor.ID, // commented out because guide IDs change when you move them.
+            orientation: guideDescriptor.orientation._value,
+            position: guideDescriptor.position._value
+        };
+
+        return new Guide(model);
+    };
+
+    /**
+     * Constructs the guide descriptors of a document into a list of Guide objects
+     *
+     * @param {object|Immutable.Record} documentDescriptor
+     * @param {Array.<object>} guideDescriptors
+     * @return {Immutable.List.<number, Guide>}
+     */
+    Guide.fromDescriptors = function (documentDescriptor, guideDescriptors) {
+        return guideDescriptors.reduce(function (guides, descriptor) {
+            var guide = Guide.fromDescriptor(documentDescriptor, descriptor);
+            
+            return guides.push(guide);
+        }, Immutable.List());
+    };
+
+    module.exports = Guide;
+});

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -1064,8 +1064,7 @@ define(function (require, exports, module) {
                 nextGuide = new Guide(model);
             }
 
-            var nextGuides = document.guides.set(index, nextGuide),
-                nextDocument = document.set("guides", nextGuides);
+            var nextDocument = document.setIn(["guides", index], nextGuide);
 
             this.setDocument(nextDocument, true);
         },

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -1087,7 +1087,5 @@ define(function (require, exports, module) {
         }
     });
 
-
-
     module.exports = DocumentStore;
 });

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -66,6 +66,7 @@
 
 @import "./tools/super-select.less";
 @import "./tools/sampler.less";
+@import "./tools/guides.less";
 
 @import "./help/first-launch.less";
 

--- a/src/style/tools/guides.less
+++ b/src/style/tools/guides.less
@@ -26,7 +26,7 @@
     stroke-opacity: 0.0;
 }
 
-.guide-edges-hover {
+.guide-edges__hover {
     fill: @highlight;
     fill-opacity: 0.5;
 }

--- a/src/style/tools/guides.less
+++ b/src/style/tools/guides.less
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+.guide-edges {
+    fill-opacity: 0.0;
+    stroke-opacity: 0.0;
+}
+
+.guide-edges-hover {
+    fill: @highlight;
+    fill-opacity: 0.5;
+}


### PR DESCRIPTION
Allows: 
- Dragging of existing guides
- Dragging a guide off screen to delete
- Overlay at the edges of canvas, allowing new guide creation

Technicals:
- Policies are created around each guide to allow mouse events to go to Photoshop during move tool
- Because guides of inactive documents can't be read, we re-read guides every time document changes
- Because guides are 1 indexed, rangeOpts fails if there are 0 guides, so we immediately return empty array in no guide cases

Requires latest spaces-adapter#134