### PR TITLE
Set the default blend mode for shadows to be "Normal"

### DIFF
--- a/src/js/models/shadow.js
+++ b/src/js/models/shadow.js
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
          * Blend mode of the shadow
          * @type {BlendMode}
          */
-        blendMode: "multiply"
+        blendMode: "normal"
 
     });
 


### PR DESCRIPTION
Ability to achieve lighter colors is impossible with current default
set to "multiply". This is a stop gap until we can get blend modes into
effects panel options.

This will take forever to review.

addresses #2087 