### PR TITLE
Fixed the keyboard shortcut for Toggle Guides

### DIFF
--- a/src/nls/root/shortcuts-mac.json
+++ b/src/nls/root/shortcuts-mac.json
@@ -50,7 +50,7 @@
             "ZOOM_TO_SELECTION": "2",
             "CENTER_SELECTION": "3",
             "TOGGLE_SMART_GUIDES": ";",
-            "TOGGLE_GUIDES": "g"
+            "TOGGLE_GUIDES": ";"
         },
         "WINDOW": {
             "NEXT_DOCUMENT": "`",

--- a/src/nls/root/shortcuts-win.json
+++ b/src/nls/root/shortcuts-win.json
@@ -46,7 +46,7 @@
             "ZOOM_TO_SELECTION": "2",
             "CENTER_SELECTION": "3",
             "TOGGLE_SMART_GUIDES": ";",
-            "TOGGLE_GUIDES": "g"
+            "TOGGLE_GUIDES": ";"
         },
         "WINDOW": {
             "NEXT_DOCUMENT": "`",


### PR DESCRIPTION
Previously it was CMD + g. Now it is corrected to CTRL/CMD ; 
Regarding issue #1938 