### PR TITLE
Skip the selection dance if possible

### DIFF
--- a/src/js/util/layeractions.js
+++ b/src/js/util/layeractions.js
@@ -151,6 +151,16 @@ define(function (require, exports) {
      * @return {Promise} returns the photoshop response from the first played action(s)
      */
     var playSimpleLayerActions = function (document, layers, playObject, overrideLocks, options) {
+        // Skip the selection dance in case we want to play an action on the lone, selected layer.
+        var selected = document.layers.selected;
+        if (layers.size === 1 && selected.size === 1 && layers.first().equals(selected.first())) {
+            if (overrideLocks) {
+                return lockingUtil.playWithLockOverride(document, layers, playObject, options);
+            } else {
+                return descriptor.playObject(playObject, options);
+            }
+        }
+
         var layerActions = layers.map(function (layer) {
             return {
                 layer: layer,


### PR DESCRIPTION
This adds a short-circuit return to `playSimpleLayerActions` when the one target layer is equal to the one selected layer. This helps avoid problems with selecting layers in modal tool states. Presumably this could be pushed into `playLayerActions` more made more wide-ranging, but I couldn't immediately convince myself that that was safe. (E.g., I think if there is more than one layer, the existing function will play the play object once for each layer, in each case with only the one layer selected, and so we can't necessarily skip the dance in that case?)

Addresses #1881.