### PR TITLE
Fix initial artboard creation from non-artboard documents

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1179,9 +1179,15 @@ define(function (require, exports, module) {
             });
 
         // Add the new layers, and the new order
-        return newLayerStructure
-            .updateSelection(Immutable.Set.of(groupID))
-            .updateOrder(newIDs);
+        newLayerStructure = newLayerStructure
+            .updateSelection(Immutable.Set.of(groupID));
+
+        if (!isArtboard) {
+            newLayerStructure = newLayerStructure
+                .updateOrder(newIDs);
+        }
+
+        return newLayerStructure;
     };
 
     /**


### PR DESCRIPTION
Addresses #2090, which was actually two bugs in one:

1. When creating an artboard from a document with a locked background layer, PS first unlocks the background layer, which implicitly replaces the background with a new layer, and then Design Space panicked when resetting the z-index because it observed that the new z-index had layers that weren't in the old z-index. This fixes that problem by first explicitly unlocking the background layer (and our model) before creating the artboard.
2. The response from PS when creating an artboard was different depending on whether or not there was already an existing artboard in the document. The change in #2065 wasn't tested against the "first artboard" case until recently, which is why this inconsistency just became apparently. As of CL 1037057, which first landed in Mac pgdev.480, the output from PS is consistent across both cases. So, testers will need 480 to test this.
