### PR TITLE
Color picker opaque mode

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -204,9 +204,10 @@ define(function (require, exports) {
      * @param {Color} color
      * @param {boolean=} coalesce Whether to coalesce this operation's history state
      * @param {boolean=} optimisticHistory Whether this event will be included in our history model
+     * @param {boolean=} ignoreAlpha
      * @return {Promise}
      */
-    var updateColor = function (document, layers, color, coalesce, optimisticHistory) {
+    var updateColor = function (document, layers, color, coalesce, optimisticHistory, ignoreAlpha) {
         var layerIDs = collection.pluck(layers, "id"),
             normalizedColor = null;
 
@@ -215,11 +216,12 @@ define(function (require, exports) {
         }
 
         var payload = {
-                documentID: document.id,
-                layerIDs: layerIDs,
-                color: normalizedColor,
-                calesce: coalesce
-            };
+            documentID: document.id,
+            layerIDs: layerIDs,
+            color: normalizedColor,
+            coalesce: coalesce,
+            ignoreAlpha: ignoreAlpha
+        };
 
         if (optimisticHistory) {
             return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
@@ -264,7 +266,7 @@ define(function (require, exports) {
 
             playObject = [playObject].concat(setOpacityPlayObjects);
         }
-        var updatePromise = this.transfer(updateColor, document, layers, color, coalesce, true),
+        var updatePromise = this.transfer(updateColor, document, layers, color, coalesce, true, ignoreAlpha),
             setColorPromise = layerActionsUtil.playSimpleLayerActions(document, layers, playObject, true, typeOptions);
 
         return Promise.join(updatePromise, setColorPromise);

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
             };
 
             if (!Immutable.is(this.state.postScriptMap, nextState.postScriptMap)) {
-                if (nextState.postMap) {
+                if (nextState.postScriptMap) {
                     // The list of all selectable type faces
                     var typefaces = nextState.postScriptMap
                         .entrySeq()

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         textLayer = require("adapter/lib/textLayer");
 
     var Type = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("font")],
+        mixins: [FluxMixin, StoreWatchMixin("font", "tool")],
 
         shouldComponentUpdate: function (nextProps, nextState) {
             var getTexts = function (document) {
@@ -63,36 +63,55 @@ define(function (require, exports, module) {
                 return collection.pluck(document.layers.selected, "opacity");
             };
 
+            if (!Immutable.is(this.state.postScriptMap, nextState.postScriptMap)) {
+                if (nextState.postMap) {
+                    // The list of all selectable type faces
+                    var typefaces = nextState.postScriptMap
+                        .entrySeq()
+                        .sortBy(function (entry) {
+                            return entry[0];
+                        })
+                        .map(function (entry) {
+                            var psName = entry[0],
+                                fontObj = entry[1];
+
+                            return {
+                                id: psName,
+                                title: fontObj.font
+                            };
+                        })
+                        .toList();
+
+                    this.setState({
+                        typefaces: typefaces
+                    });
+                }
+
+                return true;
+            }
+
+            if (this.state.opaque !== nextState.opaque) {
+                return true;
+            }
+
             return !Immutable.is(this.state.typefaces, nextState.typefaces) ||
                 !Immutable.is(getTexts(this.props.document), getTexts(nextProps.document)) ||
                 !Immutable.is(getOpacities(this.props.document), getOpacities(nextProps.document));
         },
 
         getStateFromFlux: function () {
-            var fontStore = this.getFlux().store("font"),
+            var flux = this.getFlux(),
+                fontStore = flux.store("font"),
+                toolStore = flux.store("tool"),
                 fontState = fontStore.getState();
-            
-            // The list of all selectable type faces
-            fontState.typefaces = fontState.postScriptMap
-                .entrySeq()
-                .sortBy(function (entry) {
-                    return entry[0];
-                })
-                .map(function (entry) {
-                    var psName = entry[0],
-                        fontObj = entry[1];
-                    // FIXME: The style attribute is disabled below for performance reasons.
-                    return {
-                        id: psName,
-                        title: fontObj.font,
-                        style: {
-                            // "font-family": fontObj.family
-                        }
-                    };
-                })
-                .toList();
 
-            return fontState;
+            return {
+                initialized: fontState.initialized,
+                postScriptMap: fontState.postScriptMap,
+                familyMap: fontState.familyMap,
+                // Force opacity while in the type modal tool state
+                opaque: toolStore.getModalToolState()
+            };
         },
 
         /**
@@ -190,7 +209,7 @@ define(function (require, exports, module) {
                     return layer.kind === layer.layerKinds.TEXT;
                 });
 
-            flux.actions.type.setColorThrottled(document, layers, color, coalesce);
+            flux.actions.type.setColorThrottled(document, layers, color, coalesce, this.state.opaque);
         },
 
         /**
@@ -223,6 +242,10 @@ define(function (require, exports, module) {
                 layers = document.layers.selected.filter(function (layer) {
                     return layer.kind === layer.layerKinds.TEXT;
                 });
+
+            if (this.state.opaque) {
+                return;
+            }
 
             flux.actions.layers.setOpacityThrottled(document, layers, color.opacity, coalesce);
         },
@@ -577,6 +600,7 @@ define(function (require, exports, module) {
                             title={strings.TOOLTIPS.SET_TYPE_COLOR}
                             editable={!this.props.disabled}
                             defaultValue={colors}
+                            opaque={this.state.opaque}
                             onChange={this._handleColorChange}
                             onColorChange={this._handleOpaqueColorChange}
                             onAlphaChange={this._handleAlphaChange}

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -122,6 +122,11 @@ define(function (require, exports, module) {
                 color = Color.fromTinycolor(colorTiny),
                 colorFormat;
 
+            // Only allow fully opaque colors
+            if (this.props.opaque) {
+                color = color.opaque();
+            }
+
             if (colorTiny.isValid()) {
                 colorFormat = colorTiny.getFormat();
 
@@ -226,6 +231,10 @@ define(function (require, exports, module) {
                     color = Color.DEFAULT;
                     swatchClassProps["color-input__invalid-color"] = true;
                 } else {
+                    if (this.props.opaque) {
+                        value = value.opaque();
+                    }
+
                     // naive tinycolor toString
                     colorTiny = tinycolor(value.toJS());
                     color = value;
@@ -282,6 +291,7 @@ define(function (require, exports, module) {
                         dismissOnWindowClick>
                         <ColorPicker
                             ref="colorpicker"
+                            opaque={this.props.opaque}
                             color={color}
                             onMouseDown={this.startCoalescing}
                             onMouseUp={this.stopCoalescing}

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -223,7 +223,8 @@ define(function (require, exports, module) {
         propTypes: {
             vertical: React.PropTypes.bool.isRequired,
             value: React.PropTypes.number.isRequired,
-            hue: React.PropTypes.number
+            hue: React.PropTypes.number,
+            disabled: React.PropTypes.bool
         },
 
         getDefaultProps: function () {
@@ -294,7 +295,8 @@ define(function (require, exports, module) {
             var classes = classnames({
                 "color-picker-slider": true,
                 "color-picker-slider__vertical": this.props.vertical,
-                "color-picker-slider__horizontal": !this.props.vertical
+                "color-picker-slider__horizontal": !this.props.vertical,
+                "color-picker-slider__disabled": this.props.disabled
             });
 
             var overlay;
@@ -315,9 +317,9 @@ define(function (require, exports, module) {
             return (
                 <div
                     className={classes}
-                    onMouseUp={this._handleMouseUp}
-                    onMouseDown={this._handleMouseDown}
-                    onTouchStart={this._startUpdates}>
+                    onMouseUp={!this.props.disabled && this._handleMouseUp}
+                    onMouseDown={!this.props.disabled && this._handleMouseDown}
+                    onTouchStart={!this.props.disabled && this._startUpdates}>
                     <div className="color-picker-slider__track" />
                     {overlay}
                     <div className="color-picker-slider__pointer" style={this._getSliderPositionCss()} />
@@ -618,6 +620,7 @@ define(function (require, exports, module) {
                             value={color.a}
                             hue={color.h}
                             max={1}
+                            disabled={this.props.opaque}
                             onMouseUp={this._handleMouseUp}
                             onMouseDown={this._handleMouseDown}
                             onChange={this._handleTransparencyChange} />

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -907,6 +907,7 @@ define(function (require, exports, module) {
                 color = payload.color,
                 opaqueColor = null,
                 opacity = null,
+                ignoreAlpha = payload.ignoreAlpha,
                 document = this._openDocuments[documentID];
 
             if (color !== null) {
@@ -914,10 +915,17 @@ define(function (require, exports, module) {
                 opacity = color.opacity;
             }
             
-            var nextLayers = document.layers
-                    .setCharacterStyleProperties(layerIDs, { color: opaqueColor })
-                    .setProperties(layerIDs, { opacity: opacity }),
-                nextDocument = document.set("layers", nextLayers);
+            var nextLayers = document.layers.setCharacterStyleProperties(layerIDs, {
+                color: opaqueColor
+            });
+
+            if (!ignoreAlpha) {
+                nextLayers = nextLayers.setProperties(layerIDs, {
+                    opacity: opacity
+                });
+            }
+
+            var nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);
         },

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -223,6 +223,12 @@
     }
 }
 
+.color-picker-slider__disabled {
+    .color-picker-slider__pointer {
+        background: darken(whitesmoke, 20%);
+    }
+}
+
 // Fix for rounding errors with rems on Retina that makes weird circles
 @base-slider-size: 1.2;
 .pointer-size(@pointer-size){


### PR DESCRIPTION
This adds an opaque mode to the `ColorInput` and `ColorPicker` that constrains selectable colors to be opaque and disables the opacity slider. The `ColorInput` used by the `Type` component now uses opaque mode when in a modal tool state.

This is definitely imperfect, but I think it's an improvement. Sometimes the non-opaque color flashes in the input before switching to an opaque color because it takes a while for PS to send us the modal state change notification. There's also nothing we can really do about people typing in non-opaque colors. 

Also, in opaque mode we force 100% opacity, but my first attempt just froze the existing opacity. After trying it out, it seemed like 100% opacity was preferable because it was more clear that the opacity was completely disabled.

Addresses #1914.