### PR TITLE
Hide the guide overlay on click so mouse events can go to PS

### DIFF
--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -229,9 +229,13 @@ define(function (require, exports, module) {
                 if (!highlightFound && intersects) {
                     guide.classed("guide-edges__hover", true)
                         .on("mousedown", function () {
+                            d3.select(this)
+                                .classed("guide-edges__hover", false);
+                            
                             self.getFlux().actions.guides.createGuideAndTrack(
                                 self.state.document, orientation, mouseX, mouseY
                             );
+
                             d3.event.stopPropagation();
                         });
 


### PR DESCRIPTION
Addresses #2128 

Problem was, because overlay was still showing, our synthesized mouse event was not going to Photoshop.Created a Watson bug for Fitz, since it goes to PS in Mac, and not in Windows, causing the issue.