### PR TITLE
Disable type sampling in multi-text-runs since they don't have type info

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -131,7 +131,11 @@ define(function (require, exports) {
                 if (source.isTextLayer() && allTextLayers) {
                     var fontStore = this.flux.store("font");
 
-                    typeStyle = fontStore.getTypeObjectFromLayer(source);
+                    try {
+                        typeStyle = fontStore.getTypeObjectFromLayer(source);
+                    } catch (err) {
+                        // For mixed type styles, this function throws, so we ignore!
+                    }
                 }
 
                 result.push({


### PR DESCRIPTION
Apparently it's a design choice. So we disable type sampling

Addresses #2137 