### PR TITLE
Suppress double click events in title header buttons

### DIFF
--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -121,6 +121,16 @@ define(function (require, exports, module) {
             this.getFlux().actions.export.addLayerAsset(document, layer, nextAssetIndex, nextScale);
         },
 
+        /**
+         * Stop event propagation to prevent double-clicks from collapsing the panel.
+         *
+         * @private
+         * @param {SyntheticEvent} event
+         */
+        _addAssetDoubleClickHandler: function (event) {
+            event.stopPropagation();
+        },
+
         render: function () {
             var document = this.props.document,
                 disabled = this.props.disabled,
@@ -169,12 +179,13 @@ define(function (require, exports, module) {
                         title={strings.TITLE_EXPORT}
                         visible={this.props.visible}
                         disabled={disabled}
-                        onDoubleClick={this.props.onVisibilityToggle} >
+                        onDoubleClick={this.props.onVisibilityToggle}>
                         <div className="layer-exports__workflow-buttons">
                             <Button
                                 className="button-plus"
                                 title={strings.TOOLTIPS.EXPORT_ADD_ASSET}
-                                onClick={addAssetClickHandler || _.noop}>
+                                onClick={addAssetClickHandler || _.noop}
+                                onDoubleClick={this._addAssetDoubleClickHandler}>
                                 <SVGIcon
                                     viewbox="0 0 12 12"
                                     CSSID="plus" />

--- a/src/js/jsx/sections/style/StylePanel.jsx
+++ b/src/js/jsx/sections/style/StylePanel.jsx
@@ -194,7 +194,6 @@ define(function (require, exports, module) {
                 </div>
             );
 
-            
             return (
                 <section
                     className={sectionClasses}
@@ -209,8 +208,10 @@ define(function (require, exports, module) {
                                 className={copyStyleClasses}
                                 title={strings.STYLE.COPY}
                                 disabled={copyStyleDisabled}
+                                onClick={this._handleStyleCopy}
+                                onDisabledClick={this._blockInput}
                                 onDoubleClick={this._blockInput}
-                                onClick={this._handleStyleCopy}>
+                                onDisabledDoubleClick={this._blockInput}>
                                 <SVGIcon
                                     viewbox="0 0 24 24"
                                     CSSID="style-copy" />
@@ -219,8 +220,10 @@ define(function (require, exports, module) {
                                 className={pasteStyleClasses}
                                 title={strings.STYLE.PASTE}
                                 disabled={pasteStyleDisabled}
+                                onClick={this._handleStylePaste}
+                                onDisabledClick={this._blockInput}
                                 onDoubleClick={this._blockInput}
-                                onClick={this._handleStylePaste}>
+                                onDisabledDoubleClick={this._blockInput}>
                                 <SVGIcon
                                     viewbox="0 0 24 24"
                                     CSSID="style-paste" />

--- a/src/js/jsx/shared/Button.jsx
+++ b/src/js/jsx/shared/Button.jsx
@@ -37,8 +37,8 @@ define(function (require, exports, module) {
             };
 
             var className = classnames(classNameSet, this.props.className),
-                handleClick = !this.props.disabled && this.props.onClick,
-                handleDoubleClick = !this.props.disabled && this.props.onDoubleClick;
+                handleClick = this.props.disabled ? this.props.onDisabledClick : this.props.onClick,
+                handleDoubleClick = this.props.disabled ? this.props.onDisabledDoubleClick : this.props.onDoubleClick;
 
             return (
                 <div {...this.props}


### PR DESCRIPTION
Stop event propagation of double click events in title header buttons (Export add asset and Style copy/paste), even when disabled, the latter with new `onDisabledClick` and `onDisabledDoubleClick` event handlers on `Button`.

Addresses #2149. 