### PR TITLE
Support artboard guides

### DIFF
--- a/src/js/models/guide.js
+++ b/src/js/models/guide.js
@@ -39,6 +39,14 @@ define(function (require, exports, module) {
         documentID: null,
 
         /**
+         * ID of the owner layer for this guide,
+         * should always be an ID of an artboard layer, or 0 otherwise
+         *
+         * @type {number}
+         */
+        layerID: null,
+
+        /**
          * Position of the guide in pixels
          * 
          * @type {number}
@@ -73,6 +81,7 @@ define(function (require, exports, module) {
 
         var model = {
             documentID: documentID,
+            layerID: guideDescriptor.layerID,
             // id: guideDescriptor.ID, // commented out because guide IDs change when you move them.
             orientation: guideDescriptor.orientation._value,
             position: guideDescriptor.position._value

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -295,11 +295,22 @@ define(function (require, exports, module) {
 
         /**
          * The set of artboards in the document
+         * @type {Immutable.List.<Layer>}
          */
         "artboards": function () {
             return this.top.filter(function (layer) {
                 return layer.isArtboard;
             });
+        },
+
+        /**
+         * The set of top level ancestors of all selected layers
+         * @type {Immutable.Set.<Layer>}
+         */
+        "selectedTopAncestors": function () {
+            return this.selected.map(function (layer) {
+                return this.topAncestor(layer);
+            }, this).toSet();
         },
 
         /**
@@ -551,6 +562,22 @@ define(function (require, exports, module) {
     Object.defineProperty(LayerStructure.prototype, "ancestors", objUtil.cachedLookupSpec(function (layer) {
         return this.strictAncestors(layer)
             .push(layer);
+    }));
+
+    /**
+     * Find the top ancestor of the given layer.
+     *
+     * @param {Layer} layer
+     * @return {Layer}
+     */
+    Object.defineProperty(LayerStructure.prototype, "topAncestor", objUtil.cachedLookupSpec(function (layer) {
+        var ancestor = layer;
+
+        while (this.parent(ancestor)) {
+            ancestor = this.parent(ancestor);
+        }
+
+        return ancestor;
     }));
 
     /**

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -1045,7 +1045,8 @@ define(function (require, exports, module) {
                 index = payload.index,
                 document = this._openDocuments[documentID],
                 orientation = payload.orientation,
-                position = payload.position;
+                position = payload.position,
+                layerID = payload.layerID;
 
             var nextGuide = document.guides.get(index);
 
@@ -1058,7 +1059,8 @@ define(function (require, exports, module) {
                 var model = {
                     documentID: documentID,
                     orientation: orientation,
-                    position: position
+                    position: position,
+                    layerID: layerID
                 };
                 
                 nextGuide = new Guide(model);

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -99,8 +99,9 @@ define(function (require, exports, module) {
     ExportService.prototype.close = function () {
         if (this._spacesDomain && this._spacesDomain.ready()) {
             this._spacesDomain.connection.disconnect();
-            return Promise.resolve();
         }
+        
+        return Promise.resolve();
     };
 
     /**


### PR DESCRIPTION
Requires Playground-dev-mac#499 and https://github.com/adobe-photoshop/spaces-adapter/pull/135

- If all selected layers are part of the same artboard, guides created will be artboard guides
- Correctly sets policies for guides based on selection
 
![guides](https://cloud.githubusercontent.com/assets/386714/9417099/8026294e-47fe-11e5-8e5d-e58b1a6bcad4.gif)
