### PR TITLE
Disable auto expand during swap

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -726,26 +726,6 @@ define(function (require, exports) {
     toggleSmartGuidesVisibility.writes = [locks.JS_DOC, locks.PS_DOC];
 
     /**
-     * Sets artboard auto nesting for the given document ID
-     *
-     * @param {number} documentID
-     * @param {boolean} enabled Whether layers should be automatically nested
-     * @return {Promise}
-     */
-    var setAutoNesting = function (documentID, enabled) {
-        if (enabled) {
-            log.warn("In current version of Design Space, we shouldn't enable artboard auto-nesting!");
-        }
-
-        var documentRef = documentLib.referenceBy.id(documentID),
-            nestingObj = documentLib.setArtboardAutoAttributes(documentRef, enabled);
-
-        return descriptor.playObject(nestingObj);
-    };
-    setAutoNesting.reads = [];
-    setAutoNesting.writes = [locks.PS_DOC];
-
-    /**
      * Event handlers initialized in beforeStartup.
      *
      * @private
@@ -964,7 +944,6 @@ define(function (require, exports) {
     exports.initActiveDocument = initActiveDocument;
     exports.initInactiveDocuments = initInactiveDocuments;
     exports.packageDocument = packageDocument;
-    exports.setAutoNesting = setAutoNesting;
     exports.toggleGuidesVisibility = toggleGuidesVisibility;
     exports.toggleSmartGuidesVisibility = toggleSmartGuidesVisibility;
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -412,8 +412,36 @@ define(function (require, exports) {
             }
         };
 
+        var autoExpandEnabled = false;
+
         headlights.logEvent("edit", "layers", "swap_layers");
-        var swapPromise = layerActionsUtil.playLayerActions(document, translateActions, true, options);
+        var swapPromise = descriptor.getProperty(documentRef, "artboards")
+            .bind(this)
+            .then(function (artboardInfo) {
+                autoExpandEnabled = artboardInfo.autoExpandEnabled;
+
+                if (!autoExpandEnabled) {
+                    return Promise.resolve();
+                } else {
+                    var setObj = documentLib.setArtboardAutoAttributes(documentRef, {
+                        autoExpandEnabled: false
+                    });
+
+                    return descriptor.playObject(setObj);
+                }
+            })
+            .then(function () {
+                return layerActionsUtil.playLayerActions(document, translateActions, true, options);
+            })
+            .then(function () {
+                if (autoExpandEnabled) {
+                    var setObj = documentLib.setArtboardAutoAttributes(documentRef, {
+                        autoExpandEnabled: true
+                    });
+
+                    return descriptor.playObject(setObj);
+                }
+            });
 
         return Promise.join(dispatchPromise, swapPromise);
     };


### PR DESCRIPTION
Idea for this fix came to me during the design meeting... We can just disable auto expand during swap, so the PS canvas size does not shift underneath us in between swap operations!

Addresses #1532, so happy to finally fix it.

Requires https://github.com/adobe-photoshop/spaces-adapter/pull/136