### PR TITLE
Barkin/sampler fixes

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -316,19 +316,27 @@ define(function (require, exports) {
                     clickedLeafLayers = layerTree.leaves.filter(function (layer) {
                         return hitLayerMap.has(layer.id);
                     }),
-                    topLayer = clickedLeafLayers.last();
+                    topLayer = clickedLeafLayers.last(),
+                    selected = layerTree.selected;
+
+                // If we're trying to sample the only selected layer, surely it's a no-op
+                if (selected.size === 1 && selected.first() === topLayer) {
+                    return [];
+                }
 
                 return _calculateSampleTypes.call(this, doc, topLayer, x, y);
             })
             .then(function (sampleTypes) {
-                var payload = {
-                    document: doc,
-                    sampleTypes: sampleTypes,
-                    x: x,
-                    y: y
-                };
+                if (sampleTypes.length > 0) {
+                    var payload = {
+                        document: doc,
+                        sampleTypes: sampleTypes,
+                        x: x,
+                        y: y
+                    };
 
-                return this.dispatchAsync(events.style.SHOW_HUD, payload);
+                    return this.dispatchAsync(events.style.SHOW_HUD, payload);
+                }
             });
     };
     showHUD.reads = [locks.PS_DOC, locks.JS_UI];

--- a/src/js/tools/sampler.js
+++ b/src/js/tools/sampler.js
@@ -115,6 +115,8 @@ define(function (require, exports, module) {
             
         if (event.detail.keyChar === " ") {
             flux.actions.sampler.showHUD(currentDocument, _currentMouseX, _currentMouseY);
+        } else if (event.detail.keyCode === OS.eventKeyCode.ESCAPE) {
+            flux.actions.sampler.hideHUD();
         }
     };
 


### PR DESCRIPTION
Addresses #2136 and also disallows self-sampling the only selected layer.