### PR TITLE
Added attribute to designate the help menu as the OSX help menu

### DIFF
--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -599,6 +599,7 @@
         },
         {
             "id": "HELP",
+            "isOSHelpMenu": true,
             "submenu": [
                 {
                     "id": "HELPX"


### PR DESCRIPTION
Add submenu attribute to designate the "help" menu as the OSX help menu.
The functionality require CL: 1037599 in team sandbox