### PR TITLE
SuperHack: Fix graphic placement from search bar

### DIFF
--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -125,17 +125,15 @@ define(function (require, exports) {
      * @param {string} id ID of layer to select
     */
     var _confirmSearch = function (id) {
-        var libActions = this.flux.actions.libraries,
-            elementInfo = _idMap[id];
-
-        var appStore = this.flux.store("application"),
+        var elementInfo = _idMap[id],
+            appStore = this.flux.store("application"),
             currentDocument = appStore.getCurrentDocument(),
             currentLayers = currentDocument.layers.selected,
             currentLayer = currentLayers.first();
 
         if (elementInfo) {
-            var asset = elementInfo.asset;
-            libActions.selectLibrary(asset.library.id);
+            var asset = elementInfo.asset,
+                selectPromise = this.flux.actions.libraries.selectLibrary(asset.library.id);
 
             switch (elementInfo.type) {
                 case "GRAPHIC":
@@ -145,20 +143,33 @@ define(function (require, exports) {
                         midY = (window.document.body.clientHeight + centerOffsets.top - centerOffsets.bottom) / 2,
                         location = uiStore.transformWindowToCanvas(midX, midY);
                     
-                    libActions.createLayerFromElement(asset, location);
+                    selectPromise
+                        .bind(this)
+                        .then(function () {
+                            this.flux.actions.libraries.createLayerFromElement(asset, location);
+                        });
+                    
                     break;
                 case "LAYERSTYLE":
                     // Only try to apply layer style if a single layer is selected
                     // Should probably be handled in applyLayerStyle 
                     if (currentLayers.size === 1) {
-                        libActions.applyLayerStyle(asset);
+                        selectPromise
+                            .bind(this)
+                            .then(function () {
+                                this.flux.actions.libraries.applyLayerStyle(asset);
+                            });
                     }
                     break;
                 case "CHARACTERSTYLE":
                     // Only try to apply character style if a single text layer is selected
                     // Should probably be handled in applyCharacterStyle 
                     if (currentLayers.size === 1 && currentLayer.isTextLayer()) {
-                        libActions.applyCharacterStyle(asset);
+                        selectPromise
+                            .bind(this)
+                            .then(function () {
+                                this.flux.actions.libraries.applyCharacterStyle(asset);
+                            });
                     }
                     break;
             }

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -54,9 +54,10 @@ define(function (require, exports, module) {
          * TODO Note that in React v13 this could be injected by the Dialog directly into the children components
          *
          * @private
+         * @return {Promise}
          */
         _closeSearchBar: function () {
-            this.getFlux().actions.dialog.closeDialog(SEARCH_BAR_DIALOG_ID);
+            return this.getFlux().actions.dialog.closeDialog(SEARCH_BAR_DIALOG_ID);
         },
 
         /**
@@ -67,9 +68,13 @@ define(function (require, exports, module) {
          * @param {string} itemID ID of selected option
          */
         _handleOption: function (itemID) {
-            this._closeSearchBar();
-            var searchStore = this.getFlux().store("search");
-            searchStore.handleExecute(itemID);
+            this._closeSearchBar()
+                .bind(this)
+                .delay(100) // HACK: See #2177
+                .then(function () {
+                    var searchStore = this.getFlux().store("search");
+                    searchStore.handleExecute(itemID);
+                });
         },
 
         render: function () {


### PR DESCRIPTION
Work around a combined React-and-PS bug in which we can't block actions until React rendering has finished, and PS stops running CEF entirely during the place-graphic modal tool state. More details in #2177, which this "addresses."