### PR TITLE
Improved select tool selection criteria

### DIFF
--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -481,6 +481,7 @@ define(function (require, exports, module) {
          */
         updateMouseOverHighlights: function () {
             var scale = this._scale,
+                layerTree = this.state.document.layers,
                 uiStore = this.getFlux().store("ui"),
                 mouseX = this._currentMouseX,
                 mouseY = this._currentMouseY,
@@ -490,13 +491,12 @@ define(function (require, exports, module) {
             // Yuck, we gotta traverse the list backwards, and D3 doesn't offer reverse iteration
             _.forEachRight(d3.selectAll(".sampler-bounds")[0], function (element) {
                 var layer = d3.select(element),
+                    layerID = mathUtil.parseNumber(layer.attr("layer-id")),
                     layerSelected = layer.attr("layer-selected") === "true",
-                    layerLeft = mathUtil.parseNumber(layer.attr("x")),
-                    layerTop = mathUtil.parseNumber(layer.attr("y")),
-                    layerRight = layerLeft + mathUtil.parseNumber(layer.attr("width")),
-                    layerBottom = layerTop + mathUtil.parseNumber(layer.attr("height")),
-                    intersects = layerLeft < canvasMouse.x && layerRight > canvasMouse.x &&
-                        layerTop < canvasMouse.y && layerBottom > canvasMouse.y;
+                    layerModel = layerTree.byID(layerID),
+                    visibleBounds = layerTree.boundsWithinArtboard(layerModel),
+                    intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
+                        visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 
                 if (!highlightFound && intersects) {
                     if (!layerSelected) {

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -405,6 +405,7 @@ define(function (require, exports, module) {
          */
         updateMouseOverHighlights: function () {
             var marquee = this.state.marqueeEnabled,
+                layerTree = this.state.document.layers,
                 scale = this._scale,
                 uiStore = this.getFlux().store("ui"),
                 mouseX = this._currentMouseX,
@@ -438,13 +439,12 @@ define(function (require, exports, module) {
             // Yuck, we gotta traverse the list backwards, and D3 doesn't offer reverse iteration
             _.forEachRight(d3.selectAll(".layer-bounds")[0], function (element) {
                 var layer = d3.select(element),
+                    layerID = mathUtil.parseNumber(layer.attr("layer-id")),
                     layerSelected = layer.attr("layer-selected") === "true",
-                    layerLeft = mathUtil.parseNumber(layer.attr("x")),
-                    layerTop = mathUtil.parseNumber(layer.attr("y")),
-                    layerRight = layerLeft + mathUtil.parseNumber(layer.attr("width")),
-                    layerBottom = layerTop + mathUtil.parseNumber(layer.attr("height")),
-                    intersects = layerLeft < canvasMouse.x && layerRight > canvasMouse.x &&
-                        layerTop < canvasMouse.y && layerBottom > canvasMouse.y;
+                    layerModel = layerTree.byID(layerID),
+                    visibleBounds = layerTree.boundsWithinArtboard(layerModel),
+                    intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
+                        visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 
                 if (!marquee && !highlightFound && intersects) {
                     if (!layerSelected) {

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -223,6 +223,29 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Creates a new bounds object from the intersection of the given bounds objects.
+     * Returns null if they don't intersect 
+     *
+     * @param {Bounds} boundsOne
+     * @param {Bounds} boundsTwo
+     * @return {Bounds} Intersection of boundsOne and boundsTwo
+     */
+    Bounds.intersection = function (boundsOne, boundsTwo) {
+        var model = {
+            top: boundsTwo.top < boundsOne.top ? boundsOne.top : boundsTwo.top,
+            left: boundsTwo.left < boundsOne.left ? boundsOne.left : boundsTwo.left,
+            bottom: boundsTwo.bottom < boundsOne.bottom ? boundsTwo.bottom : boundsOne.bottom,
+            right: boundsTwo.right < boundsOne.right ? boundsTwo.right : boundsOne.right
+        };
+
+        if (model.bottom < model.top || model.right < model.left) {
+            return null;
+        }
+
+        return new Bounds(model);
+    };
+
+    /**
      * Indicates whether the given point is contained in the bounding box.
      *
      * @param {number} x

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -598,22 +598,6 @@ define(function (require, exports, module) {
     }));
 
     /**
-     * Find the top ancestor of the given layer.
-     *
-     * @param {Layer} layer
-     * @return {Layer}
-     */
-    Object.defineProperty(LayerStructure.prototype, "topAncestor", objUtil.cachedLookupSpec(function (layer) {
-        var ancestor = layer;
-
-        while (this.parent(ancestor)) {
-            ancestor = this.parent(ancestor);
-        }
-
-        return ancestor;
-    }));
-
-    /**
      * Find all locked ancestors of the given layer, including itself.
      *
      * @param {Layer} layer
@@ -797,6 +781,25 @@ define(function (require, exports, module) {
                 return layer.bounds;
         }
     }));
+
+    /**
+     * Calculate the bounds of a layer visible within it's parent artboard,
+     * layer's own bounds if it's not in an artboard
+     *
+     * @param {Layer} layer
+     * @return {?Bounds}
+     */
+    Object.defineProperty(LayerStructure.prototype, "boundsWithinArtboard", objUtil.cachedLookupSpec(function (layer) {
+        var bounds = this.childBounds(layer),
+            topAncestor = this.topAncestor(layer);
+
+        if (topAncestor.isArtboard) {
+            bounds = Bounds.intersection(this.childBounds(topAncestor), bounds);
+        }
+
+        return bounds;
+    }));
+
 
     /**
      * Create a new non-group layer model from a Photoshop layer descriptor and

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -598,6 +598,22 @@ define(function (require, exports, module) {
     }));
 
     /**
+     * Find the top ancestor of the given layer.
+     *
+     * @param {Layer} layer
+     * @return {Layer}
+     */
+    Object.defineProperty(LayerStructure.prototype, "topAncestor", objUtil.cachedLookupSpec(function (layer) {
+        var ancestor = layer;
+
+        while (this.parent(ancestor)) {
+            ancestor = this.parent(ancestor);
+        }
+
+        return ancestor;
+    }));
+
+    /**
      * Find all locked ancestors of the given layer, including itself.
      *
      * @param {Layer} layer


### PR DESCRIPTION
Updated the rules for superselect a bit. Back in April, to make layers outside canvas selectable I made changes and used PS's hitTest only for z-order sorting. Well, it caused bugs like #2112 and #2113 where bigger layers in other artboards, that are higher in the z-order would highlight over the layer user was visibly hovering on.

Now we restrict superselect with artboards:

- A layer is highlighted only when the mouse is over it in the artboard. Highlight is still for the full layer bounds, but doesn't get lit unless the mouse is in the artboard.
- Superselect clicks can only select layers on visible pixels.

@iwehrman Please review, as I've bothered you the most about this issue.