### PR TITLE
Fix for Fill, Stroke and Effects icons bug

### DIFF
--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -256,6 +256,7 @@ define(function (require, exports, module) {
                                     name="toggleFillEnabled"
                                     buttonType="layer-not-visible"
                                     selected={fill.enabledFlags}
+                                    selectedButtonType={"layer-visible"}
                                     onClick={!this.props.disabled ? this._toggleFillEnabled : _.noop}
                                     size="column-2"
                                 />

--- a/src/js/jsx/sections/style/Shadow.jsx
+++ b/src/js/jsx/sections/style/Shadow.jsx
@@ -396,16 +396,16 @@ define(function (require, exports) {
                                 name="toggleShadowEnabled"
                                 buttonType="layer-not-visible"
                                 selected={downsample.enabledFlags}
+                                selectedButtonType={"layer-visible"}
                                 onFocus={this.props.onFocus}
                                 onClick={!this.props.readOnly ? this._enabledChanged : _.noop}
                                 size="column-2"
                             />
-
                             <ToggleButton
                                 title={shadowDeleteTooltip}
                                 name="deleteDropShadowEnabled"
-                                buttonType="layer-delete"
-                                className="layer-delete"
+                                buttonType="delete"
+                                className="delete"
                                 selected={true}
                                 onFocus={this.props.onFocus}
                                 onClick={!this.props.readOnly ? this._handleDelete : _.noop}

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -308,8 +308,9 @@ define(function (require, exports, module) {
                                 <ToggleButton
                                     title={strings.TOOLTIPS.TOGGLE_STROKE}
                                     name="toggleStrokeEnabled"
-                                    buttonType="layer-not-visible"
+                                    buttonType={"layer-not-visible"}
                                     selected={stroke.enabledFlags}
+                                    selectedButtonType={"layer-visible"}
                                     onClick={!this.props.disabled ? this._toggleStrokeEnabled : _.noop}
                                     size="column-2"
                                 />


### PR DESCRIPTION
Addresses #2079

This is really a temporary fix for this bug, as we are changing the looks for these panels right now. Also seeing if switching the visibility icons like this is any better...not sure it is