### PR TITLE
Safety checks for updateMouserOverHighlights calls during DOM updates

### DIFF
--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -480,6 +480,10 @@ define(function (require, exports, module) {
          * @private
          */
         updateMouseOverHighlights: function () {
+            if (!this.state.document) {
+                return;
+            }
+
             var scale = this._scale,
                 layerTree = this.state.document.layers,
                 uiStore = this.getFlux().store("ui"),
@@ -493,8 +497,14 @@ define(function (require, exports, module) {
                 var layer = d3.select(element),
                     layerID = mathUtil.parseNumber(layer.attr("layer-id")),
                     layerSelected = layer.attr("layer-selected") === "true",
-                    layerModel = layerTree.byID(layerID),
-                    visibleBounds = layerTree.boundsWithinArtboard(layerModel),
+                    layerModel = layerTree.byID(layerID);
+
+                // Sometimes, the DOM elements may be out of date, and be of different documents
+                if (!layerModel) {
+                    return;
+                }
+
+                var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
                     intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
                         visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -506,8 +506,8 @@ define(function (require, exports, module) {
 
                 var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
                     intersects = visibleBounds &&
-                        visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
-                        visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
+                        visibleBounds.left <= canvasMouse.x && visibleBounds.right >= canvasMouse.x &&
+                        visibleBounds.top <= canvasMouse.y && visibleBounds.bottom >= canvasMouse.y;
 
                 if (!highlightFound && intersects) {
                     if (!layerSelected) {

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -505,7 +505,8 @@ define(function (require, exports, module) {
                 }
 
                 var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
-                    intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
+                    intersects = visibleBounds &&
+                        visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
                         visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 
                 if (!highlightFound && intersects) {

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -454,8 +454,8 @@ define(function (require, exports, module) {
                 
                 var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
                     intersects = visibleBounds &&
-                        visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
-                        visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
+                        visibleBounds.left <= canvasMouse.x && visibleBounds.right >= canvasMouse.x &&
+                        visibleBounds.top <= canvasMouse.y && visibleBounds.bottom >= canvasMouse.y;
 
                 if (!marquee && !highlightFound && intersects) {
                     if (!layerSelected) {

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -404,6 +404,10 @@ define(function (require, exports, module) {
          * Goes through all layer bounds and highlights the top one the cursor is on
          */
         updateMouseOverHighlights: function () {
+            if (!this.state.document) {
+                return;
+            }
+
             var marquee = this.state.marqueeEnabled,
                 layerTree = this.state.document.layers,
                 scale = this._scale,
@@ -441,8 +445,14 @@ define(function (require, exports, module) {
                 var layer = d3.select(element),
                     layerID = mathUtil.parseNumber(layer.attr("layer-id")),
                     layerSelected = layer.attr("layer-selected") === "true",
-                    layerModel = layerTree.byID(layerID),
-                    visibleBounds = layerTree.boundsWithinArtboard(layerModel),
+                    layerModel = layerTree.byID(layerID);
+
+                // Sometimes, the DOM elements may be out of date, and be of different documents
+                if (!layerModel) {
+                    return;
+                }
+                
+                var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
                     intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
                         visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -453,7 +453,8 @@ define(function (require, exports, module) {
                 }
                 
                 var visibleBounds = layerTree.boundsWithinArtboard(layerModel),
-                    intersects = visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
+                    intersects = visibleBounds &&
+                        visibleBounds.left < canvasMouse.x && visibleBounds.right > canvasMouse.x &&
                         visibleBounds.top < canvasMouse.y && visibleBounds.bottom > canvasMouse.y;
 
                 if (!marquee && !highlightFound && intersects) {


### PR DESCRIPTION
Fixes issues that happened when opening new documents that DOM elements would be out of date and we'd be trying to retrieve their layer models from an invalid document layer tree.

Argh