### PR TITLE
Allow the user to choose an export folder during each export

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -38,6 +38,7 @@ define(function (require, exports) {
         globalUtil = require("js/util/global"),
         objUtil = require("js/util/object"),
         collection = require("js/util/collection"),
+        strings = require("i18n!nls/strings"),
         log = require("js/util/log"),
         ExportAsset = require("js/models/exportasset"),
         ExportService = require("js/util/exportservice");
@@ -101,7 +102,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var _exportAsset = function (document, layer, assetIndex, asset, baseDir) {
-        return _exportService.exportLayerAsset(document, layer, asset, baseDir)
+        var fileName = (layer ? layer.name : strings.EXPORT.EXPORT_DOCUMENT_FILENAME) + asset.suffix;
+        return _exportService.exportLayerAsset(document, layer, asset, fileName, baseDir)
             .bind(this)
             .then(function (pathArray) {
                 // Do we need to be aware of exports that return >1 file path?

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -56,7 +56,12 @@ define(function (require, exports) {
      */
     var _exportService;
 
-    var _lastFolderPath;
+    /**
+     * The previous folder into which assets were saved.
+     * If populated, initialize the OS folder chooser here
+     * @type {?string}
+     */
+    var _lastFolderPath = null;
 
     /**
      * Fetch relevant data from both the document and export stores, and sync the metadata to
@@ -442,18 +447,11 @@ define(function (require, exports) {
     setAllNonABLayersExportEnabled.writes = [];
     setAllNonABLayersExportEnabled.transfers = [setLayerExportEnabled];
 
-    var promptForFolder = function () {
-        return _exportService.promptForFolder();
-    };
-    promptForFolder.reads = [];
-    promptForFolder.writes = [locks.GENERATOR];
-    promptForFolder.transfers = [];
-
     /**
      * Export all assets for the given document for which export has been enabled (layer.exportEnabled)
      *
      * @param {Document} document
-     * @return {Promise} resolves when all assets have been exported
+     * @return {Promise} Resolves when all assets have been exported, or if canceled via the file chooser
      */
     var exportAllAssets = function (document) {
         if (!document) {
@@ -493,6 +491,7 @@ define(function (require, exports) {
                     // promptForFolder rejected, probably just user-canceled
                     if (err.message && err.message.startsWith("cancelError: cancel")) {
                         log.warn("Prompt for folder failed, and it wasn't a simple 'cancel'");
+                        throw new Error("Failed to open an OS folder chooser dialog: " + err.message);
                     }
                     return Promise.resolve();
                 });
@@ -617,7 +616,6 @@ define(function (require, exports) {
     exports.setLayerExportEnabled = setLayerExportEnabled;
     exports.setAllArtboardsExportEnabled = setAllArtboardsExportEnabled;
     exports.setAllNonABLayersExportEnabled = setAllNonABLayersExportEnabled;
-    exports.promptForFolder = promptForFolder;
     exports.exportAllAssets = exportAllAssets;
     exports.afterStartup = afterStartup;
     exports.onReset = onReset;

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
             baseDir: baseDir
         };
 
-        return this._spacesDomain.exec("exportLayer", payload)
+        return this._spacesDomain.exec("export", payload)
             .timeout(CONNECTION_TIMEOUT_MS)
             .then(function (exportResponse) {
                 if (Array.isArray(exportResponse) && exportResponse.length > 0) {

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -120,16 +120,17 @@ define(function (require, exports, module) {
      * @param {Document} document
      * @param {Layer} layer
      * @param {ExportAsset} asset
-     *
+     * @param {string} fileName
+     * @param {string=} baseDir optional directory path in to which assets should be exported
      * @return {Promise.<string>} Promise of a File Path of the exported asset
      */
-    ExportService.prototype.exportLayerAsset = function (document, layer, asset, baseDir) {
+    ExportService.prototype.exportLayerAsset = function (document, layer, asset, fileName, baseDir) {
         var payload = {
             documentID: document.id,
-            layer: layer,
+            layerID: layer && layer.id,
             scale: asset.scale,
-            suffix: asset.suffix,
             format: asset.format,
+            fileName: fileName,
             baseDir: baseDir
         };
 

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -117,22 +117,21 @@ define(function (require, exports, module) {
     /**
      * Export a layer asset
      *
+     * @param {Document} document
      * @param {Layer} layer
      * @param {ExportAsset} asset
      *
      * @return {Promise.<string>} Promise of a File Path of the exported asset
      */
-    ExportService.prototype.exportLayerAsset = function (layer, asset) {
+    ExportService.prototype.exportLayerAsset = function (document, layer, asset, baseDir) {
         var payload = {
+            documentID: document.id,
             layer: layer,
             scale: asset.scale,
             suffix: asset.suffix,
-            format: asset.format
+            format: asset.format,
+            baseDir: baseDir
         };
-
-        if (!this._spacesDomain) {
-            throw new Error ("Can not exportLayerAsset prior to ExportService.init()");
-        }
 
         return this._spacesDomain.exec("exportLayer", payload)
             .timeout(CONNECTION_TIMEOUT_MS)
@@ -154,6 +153,15 @@ define(function (require, exports, module) {
      * @type {string}
      */
     ExportService.domainPrefKey = GeneratorConnection.domainPrefKey(GENERATOR_DOMAIN_NAME);
+
+    /**
+     * Pop the folder chooser
+     *
+     * @return {Promise.<string>} Promise of a File Path of the chosen folder
+     */
+    ExportService.prototype.promptForFolder = function (folderPath) {
+        return this._spacesDomain.exec("promptForFolder", { folderPath: folderPath });
+    };
 
     module.exports = ExportService;
 });

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -375,7 +375,8 @@
         "SELECT_SINGLE_LAYER": "Please select a single layer",
         "TITLE_SCALE": "Scale",
         "TITLE_SUFFIX": "Suffix",
-        "TITLE_SETTINGS": "Settings"
+        "TITLE_SETTINGS": "Settings",
+        "EXPORT_DOCUMENT_FILENAME": "document"
     },
     "TEMPLATES": {
         "IPHONE_6_PLUS": "iPhone 6+",


### PR DESCRIPTION
This PR contains two major things:

1. When a user initiates an export, they are presented with a "folder chooser" dialog to choose where the assets should be exported.  This starts in their home directory, but then should remember their choice during this session.  (improvements to follow).
1. Consistency with the new version of the generator-spaces plugin that went through a few breaking changes in order to clean things up.

Requires generator-spaces PR
merged ~~https://github.com/adobe-photoshop/generator-spaces/pull/3~~
min version:  jenkins playground-dev builds (~535win / 538mac) 

One particular caveat:
When in the OS folder chooser dialog, do NOT try to create a new folder.  Choose an existing one.