### PR TITLE
Reset guide policies AFTER border policies are installed

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -112,11 +112,12 @@ define(function (require, exports) {
             currentTool = toolStore.getCurrentTool(),
             removePromise = currentPolicy ?
                 this.transfer(policy.removePointerPolicies, currentPolicy, true) : Promise.resolve(),
-            guidePromise = this.transfer(guides.resetGuidePolicies);
+            guidePromise; // We want to set these after border policies
 
         // Make sure to always remove the remaining policies
         if (!currentDocument || !currentTool || currentTool.id !== "newSelect") {
             _currentTransformPolicyID = null;
+            guidePromise = this.transfer(guides.resetGuidePolicies);
 
             return Promise.join(removePromise, guidePromise);
         }
@@ -130,6 +131,7 @@ define(function (require, exports) {
         // If selection is empty, remove existing policy
         if (!selection || selection.empty) {
             _currentTransformPolicyID = null;
+            guidePromise = this.transfer(guides.resetGuidePolicies);
 
             return Promise.join(removePromise, guidePromise);
         }
@@ -193,12 +195,14 @@ define(function (require, exports) {
         
         _currentTransformPolicyID = null;
         
-        return Promise.join(guidePromise, removePromise)
+        return removePromise
             .bind(this)
             .then(function () {
                 return this.transfer(policy.addPointerPolicies, pointerPolicyList);
             }).then(function (policyID) {
                 _currentTransformPolicyID = policyID;
+            
+                return this.transfer(guides.resetGuidePolicies);
             });
     };
     resetBorderPolicies.reads = [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI];

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -231,6 +231,10 @@ define(function (require, exports, module) {
      * @return {Bounds} Intersection of boundsOne and boundsTwo
      */
     Bounds.intersection = function (boundsOne, boundsTwo) {
+        if (!boundsOne || !boundsTwo) {
+            return null;
+        }
+        
         var model = {
             top: boundsTwo.top < boundsOne.top ? boundsOne.top : boundsTwo.top,
             left: boundsTwo.left < boundsOne.left ? boundsOne.left : boundsTwo.left,


### PR DESCRIPTION
We were installing border policies before guide policies, which gave them precedence. So a guide within the selected layers' border would not be clickable (clicks would come to us). #2170 

Now we install guide policies AFTER border policies so they are higher priority.