### PR TITLE
On autoCanvasResizeShift events, enqueue the dispatch asynchronously …

### DIFF
--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -139,14 +139,15 @@ define(function (require, exports, module) {
         // Draws the guide edge areas
         drawGuideEdges: function () {
             var uiStore = this.getFlux().store("ui"),
-                canvasBounds = uiStore.getCloakRect(),
-                edgeThickness = 20, // How wide/tall the guide creation edges are
-                canvasWidth = canvasBounds.right - canvasBounds.left,
-                canvasHeight = canvasBounds.bottom - canvasBounds.top;
-
+                canvasBounds = uiStore.getCloakRect();
+                
             if (!canvasBounds) {
                 return;
             }
+
+            var canvasWidth = canvasBounds.right - canvasBounds.left,
+                canvasHeight = canvasBounds.bottom - canvasBounds.top,
+                edgeThickness = 20; // How wide/tall the guide creation edges are
 
             // Top edge
             this._scrimGroup


### PR DESCRIPTION
…through an action

Addresses #2209 
Also a bug in `GuidesOverlay.jsx` that would sometimes cause a throw.
