### PR TITLE
Fix initial type properties in modal state

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -341,6 +341,7 @@ define(function (require, exports) {
                 return nextLayerCount !== naiveLayerCount;
             });
     };
+    addLayers.modal = true;
     addLayers.reads = [locks.PS_DOC];
     addLayers.writes = [locks.JS_DOC];
     addLayers.post = [_verifyLayerIndex, _verifyLayerSelection];

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -523,7 +523,7 @@ define(function (require, exports, module) {
                     modalPromise;
 
                 if (toolStore.getModalToolState() && !modal) {
-                    log.debug("Killing modal state for action %s", actionName);
+                    log.warn("Killing modal state for action %s", actionName);
                     modalPromise = ps.endModalToolState(true);
                 } else {
                     modalPromise = Promise.resolve();


### PR DESCRIPTION
There are a variety of problems when creating a new type layer in a modal state. After we learn about the new layer from the `createTextLayer` event, we call `addLayers` to initialize the model, but that model does not yet have any style information due to a PS bug. However, we do get an `updateTextProperties` event with the initial style information, but we were previously losing that because it came before the `addLayers` call had finished. This works around those problems by saving the style properties from this event and applying it to the new layer model as soon as it has been created.

Note that, in a perfect world, all these handlers would be actions managed by the flux controller. Unfortunately I think a bigger refactoring job will be needed to convert all these handlers to actions because of the way they're intertwined (see, e.g., the `_layersReplaced` variable). So I'm going to leave that to a different day, and instead use this single-purpose fix to work around the race and address the open issue.

Unrelated change: `addLayers` is now marked as safe to execute in modal states. Previously it wasn't, and in some cases this caused the modal state to be killed by the controller right after clicking to create the type layer. That bug has caused a lot of consternation over the last few weeks. To help ensure that this does not happen again, I've upgraded the "Killing modal tool state" log message emitted by the controller from "debug" to "warning" status, since this is probably a condition we want to know about and explicitly address if it happens again.

Addresses #1880.