### PR TITLE
KBSC change for Ungroup layers on Mac and Windows

### DIFF
--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -466,7 +466,7 @@
                         "keyChar": true,
                         "modifiers": {
                             "command": true,
-                            "option": true
+                            "shift": true
 
                         }
                     }

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -430,7 +430,7 @@
                         "keyChar": true,
                         "modifiers": {
                             "control": true,
-                            "alt": true
+                            "shift": true
                         }
                     }
                 }


### PR DESCRIPTION
Changed the KBSC for Ungroup to CMD + SHIFT + g (Mac) and CTL + SHIFT + g (Windows). Note, the previous KBSC on Windows was ALT + CTL + g. Not sure if that was on purpose but changed it to SHIFT + CTL + g for now, let me know if that is not correct. 

Regarding issue #1491 