### PR TITLE
Do not return keyboard focus to PS on blur

### DIFF
--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -26,17 +26,14 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Immutable = require("immutable"),
-        _ = require("lodash"),
-        collection = require("js/util/collection");
-
-    var os = require("adapter/os"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var TextInput = require("jsx!js/jsx/shared/TextInput"),
         Select = require("jsx!js/jsx/shared/Select"),
         Dialog = require("jsx!js/jsx/shared/Dialog"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        log = require("js/util/log");
+        collection = require("js/util/collection");
 
     /**
      * Approximates an HTML <datalist> element. (CEF does not support datalist
@@ -207,20 +204,6 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Blur the input and release focus to Photoshop.
-         *
-         * @private
-         */
-        _releaseFocus: function () {
-            os.releaseKeyboardFocus()
-                .catch(function (err) {
-                    var message = err instanceof Error ? (err.stack || err.message) : err;
-
-                    log.error("Failed to release keyboard focus on reset:", message);
-                });
-        },
-
-        /**
          * Enables keyboard navigation of the open select menu.
          *
          * @private
@@ -374,7 +357,6 @@ define(function (require, exports, module) {
             this.setState({
                 active: false
             });
-            this._releaseFocus();
         },
 
         /**

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -25,14 +25,14 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable"),
         mathjs = require("mathjs"),
         classnames = require("classnames"),
         _ = require("lodash");
 
     var Focusable = require("../mixin/Focusable"),
-        Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
         math = require("js/util/math"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -25,13 +25,13 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable"),
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
-        Focusable = require("../mixin/Focusable");
+    var Focusable = require("../mixin/Focusable");
 
     var _typeToClass = {
         simple: "column-4",


### PR DESCRIPTION
Revert focus-handling changes from 9285681 so that keyboard focus isn't returned to PS after tabbing away from a datalist. This broke tabbing through datalists, as described in #1877.

There are still issues with focus in modal type states, but @jfitz-adobe is working on a different solution for that. There are also still issues with keyboard navigation and `Datalist`, which this does not address. If you find other concrete issues, please file them separately.

Addresses #1877.