### PR TITLE
Set stroke options correctly and apply stroke

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -453,13 +453,13 @@ define(function (require, exports) {
         }
 
         var fillColor = null,
-            strokeColor = null,
+            stroke = null,
             typeStyle = null;
 
         switch (source.kind) {
         case source.layerKinds.VECTOR:
             fillColor = source.fill && source.fill.color;
-            strokeColor = source.stroke && source.stroke.color;
+            stroke = source.stroke;
 
             break;
         case source.layerKinds.TEXT:
@@ -479,7 +479,7 @@ define(function (require, exports) {
                     dropShadows: source.dropShadows
                 },
                 fillColor: fillColor,
-                strokeColor: strokeColor,
+                stroke: stroke,
                 typeStyle: typeStyle
             }
         };

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -155,8 +155,8 @@ define(function (require, exports, module) {
                 isEnabledChanging = !collection.uniformValue(collection.pluck(strokes, "enabled")),
                 enabled = isEnabledChanging || undefined,
                 options = {
-                    coalesce: coalesce,
-                    ignoreAlpha: ignoreAlpha,
+                    coalesce: !!coalesce,
+                    ignoreAlpha: !!ignoreAlpha,
                     enabled: enabled
                 };
 

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -390,7 +390,7 @@ define(function (require, exports, module) {
                         .attr("height", iconSize)
                         .on("click", function () {
                             // Apply the color to selected layers
-                            fluxActions.sampler.applyColor(this.state.document, null, sample.value);
+                            fluxActions.sampler.applyStroke(this.state.document, null, stroke);
                             d3.event.stopPropagation();
                         }.bind(this));
                     


### PR DESCRIPTION
One more for the count... Stroke.jsx was not assigning some options in certain cases, causing an undefined value to go to PS. #2246

Also, the inside stroke in Sampler HUD was calling applyColor instead of applyStroke, so fixed that too.
#2234

Also copies stroke into the clipboard, instead of just strokeColor (which was no longer used)