### PR TITLE
Type tool API update

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -522,7 +522,7 @@ define(function (require, exports) {
             properties: properties
         };
 
-        return this.dispatchAsync(events.document.TYPE_PROPERTIES_CHANGED, payload);
+        return this.dispatchAsync(events.document.history.amendment.TYPE_PROPERTIES_CHANGED, payload);
     };
     updateProperties.reads = [];
     updateProperties.writes = [locks.JS_DOC];

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -76,7 +76,8 @@ define(function (require, exports, module) {
                 amendment: {
                     TYPE_COLOR_CHANGED: "typeColorChangedAmendment",
                     REORDER_LAYERS: "reorderLayersAmendment",
-                    RESET_LAYERS: "resetLayersAmendement"
+                    RESET_LAYERS: "resetLayersAmendement",
+                    TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
                 }
             },
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",
@@ -106,8 +107,7 @@ define(function (require, exports, module) {
             TYPE_SIZE_CHANGED: "typeSizeChanged",
             TYPE_TRACKING_CHANGED: "typeTrackingChanged",
             TYPE_LEADING_CHANGED: "typeLeadingChanged",
-            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged",
-            TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
+            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged"
         },
         export: {
             ASSET_CHANGED: "exportAssetChanged",

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_TRACKING_CHANGED, this._handleTypeTrackingChanged,
                 events.document.TYPE_LEADING_CHANGED, this._handleTypeLeadingChanged,
                 events.document.TYPE_ALIGNMENT_CHANGED, this._handleTypeAlignmentChanged,
-                events.document.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
+                events.document.history.amendment.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
                 events.document.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
                 events.document.history.nonOptimistic.GUIDE_SET, this._handleGuideSet,
                 events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted


### PR DESCRIPTION
1. Parse style properties from `createdTextLayer` event as well as the `updateTextProperties` event, instead of having to back-patch the properties from the latter event after calling `addLayers`. This reverts the garbage from #2242.
2. Removes the `resetLayers` call from the type tool deselect handler because I have no idea why it does that. Addresses #1936. 

Requires Mac Jenkins build pgdev.541 from Thursday evening. 
