### PR TITLE
CC Libraries - improvements and bug fixes

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -404,7 +404,7 @@ define(function (require, exports) {
     };
     disposeDocument.reads = [];
     disposeDocument.writes = [locks.JS_DOC, locks.JS_APP];
-    disposeDocument.transfers = [layerActions.resetLinkedLayers, application.updateRecentFiles, ui.updateTransform];
+    disposeDocument.transfers = ["layers.resetLinkedLayers", application.updateRecentFiles, ui.updateTransform];
     disposeDocument.lockUI = true;
 
     /**
@@ -605,7 +605,7 @@ define(function (require, exports) {
     };
     selectDocument.reads = [locks.JS_TOOL];
     selectDocument.writes = [locks.JS_APP];
-    selectDocument.transfers = [layerActions.resetLinkedLayers, historyActions.queryCurrentHistory,
+    selectDocument.transfers = ["layers.resetLinkedLayers", historyActions.queryCurrentHistory,
         ui.updateTransform, toolActions.select, ui.cloak, guideActions.queryCurrentGuides];
     selectDocument.lockUI = true;
     selectDocument.post = [_verifyActiveDocument];

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -567,7 +567,7 @@ define(function (require, exports) {
                 return _.difference(nextLayerIDs, existingLayerIDs).reverse();
             })
             .then(function (newLayerIDs) {
-                return this.transfer(layerActions.addLayers, currentDocument, newLayerIDs, true, false);
+                return this.transfer(layerActions.addLayers, currentDocument, newLayerIDs, true);
             });
     };
     createLayerFromElement.reads = [locks.CC_LIBRARIES, locks.JS_DOC, locks.JS_UI, locks.JS_APP];

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -268,7 +268,7 @@ define(function (require, exports) {
                 return descriptor.playObject(createObj);
             })
             .then(function () {
-                return this.transfer(layerActions.resetLayers, currentDocument, 
+                return this.transfer(layerActions.resetLayers, currentDocument,
                     currentDocument.layers.selected);
             })
             .then(function () {

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -123,8 +123,12 @@ define(function (require, exports) {
     /**
      * Dimention of asset's preview image. Content is guaranteed to fit into a square of `size` x `size` pixels.
      * This should be use in AdobeLibraryElement#getRenditionPath and AdobeLibraryElement#setRenditionCache across DS. 
+     *
+     * For graphic asset, we have to follow the size used in CEP; it guarantees that we will get the latest rendition 
+     * from AdobeLibraryElement#getRenditionPath when an element is edited outside of DS. 
      */
-    var RENDITION_SIZE = 80;
+    var RENDITION_DEFAULT_SIZE = 80,
+        RENDITION_GRAPHIC_SIZE = 202;
 
     /**
      * Finds a usable representation for the image element that PS will accept
@@ -225,7 +229,7 @@ define(function (require, exports) {
             .then(function (paths) {
                 // Export the selected layers
 
-                var previewSize = { w: RENDITION_SIZE, h: RENDITION_SIZE },
+                var previewSize = { w: RENDITION_GRAPHIC_SIZE, h: RENDITION_GRAPHIC_SIZE },
                     exportObj = libraryAdapter.exportLayer(paths.tempBasePath, paths.tempPreviewPath,
                         paths.tempName, previewSize);
 
@@ -246,7 +250,7 @@ define(function (require, exports) {
 
                     representation.updateContentFromPath(paths.exportedLayerPath, false, done);
                 }).then(function () {
-                    newElement.setRenditionCache(RENDITION_SIZE, paths.tempPreviewPath);
+                    newElement.setRenditionCache(RENDITION_GRAPHIC_SIZE, paths.tempPreviewPath);
                 }).finally(function () {
                     currentLibrary.endOperation();
                 }).then(function () {
@@ -324,7 +328,7 @@ define(function (require, exports) {
                     tempPreviewPath,
                     typeData.adbeFont.postScriptName,
                     "Aa",
-                    RENDITION_SIZE,
+                    RENDITION_DEFAULT_SIZE,
                     colorAdapter.colorObject([0, 0, 0])
                 );
                 
@@ -347,7 +351,7 @@ define(function (require, exports) {
                         imageRepresentation.updateContentFromPath(tempPreviewPath, false, done);
                     })
                     .then(function () {
-                        newElement.setRenditionCache(RENDITION_SIZE, tempPreviewPath);
+                        newElement.setRenditionCache(RENDITION_DEFAULT_SIZE, tempPreviewPath);
                     })
                     .finally(function () {
                         currentLibrary.endOperation();
@@ -415,7 +419,7 @@ define(function (require, exports) {
                         });
                     })
                     .then(function () {
-                        newElement.setRenditionCache(RENDITION_SIZE, tempPreviewPath);
+                        newElement.setRenditionCache(RENDITION_DEFAULT_SIZE, tempPreviewPath);
                     })
                     .finally(function () {
                         currentLibrary.endOperation();
@@ -869,7 +873,8 @@ define(function (require, exports) {
     afterStartup.reads = [locks.JS_PREF, locks.CC_LIBRARIES];
     afterStartup.writes = [locks.JS_LIBRARIES];
     
-    exports.RENDITION_SIZE = RENDITION_SIZE;
+    exports.RENDITION_DEFAULT_SIZE = RENDITION_DEFAULT_SIZE;
+    exports.RENDITION_GRAPHIC_SIZE = RENDITION_GRAPHIC_SIZE;
     exports.ELEMENT_CHARACTERSTYLE_TYPE = ELEMENT_CHARACTERSTYLE_TYPE;
     exports.ELEMENT_GRAPHIC_TYPE = ELEMENT_GRAPHIC_TYPE;
     exports.ELEMENT_LAYERSTYLE_TYPE = ELEMENT_LAYERSTYLE_TYPE;

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -44,7 +44,6 @@ define(function (require, exports) {
         pathUtil = require("js/util/path"),
         layerActionsUtil = require("js/util/layeractions"),
         collection = require("js/util/collection"),
-        documentActions = require("./documents"),
         layerActions = require("./layers"),
         searchActions = require("./search/libraries"),
         shapeActions = require("./shapes"),
@@ -269,8 +268,8 @@ define(function (require, exports) {
                 return descriptor.playObject(createObj);
             })
             .then(function () {
-                // FIXME: Find a way around this update Document
-                return this.transfer(documentActions.updateDocument);
+                return this.transfer(layerActions.resetLayers, currentDocument, 
+                    currentDocument.layers.selected);
             })
             .then(function () {
                 var payload = {
@@ -285,7 +284,7 @@ define(function (require, exports) {
     };
     createElementFromSelectedLayer.reads = [locks.JS_DOC, locks.JS_APP];
     createElementFromSelectedLayer.writes = [locks.JS_LIBRARIES, locks.CC_LIBRARIES];
-    createElementFromSelectedLayer.transfers = [documentActions.updateDocument];
+    createElementFromSelectedLayer.transfers = [layerActions.resetLayers];
 
     /**
      * Uploads the selected single layer's character style to the current library

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -228,6 +228,9 @@ define(function (require, exports) {
             .bind(this)
             .then(function (paths) {
                 // Export the selected layers
+                
+                // Add an extra 'p' to the end of the preview filename incase the exported layer is also a PNG.
+                paths.tempPreviewPath = paths.tempPreviewPath.replace(".png", "p.png");
 
                 var previewSize = { w: RENDITION_GRAPHIC_SIZE, h: RENDITION_GRAPHIC_SIZE },
                     exportObj = libraryAdapter.exportLayer(paths.tempBasePath, paths.tempPreviewPath,

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -215,31 +215,6 @@ define(function (require, exports, module) {
             event.stopPropagation();
         },
 
-        /**
-         * When not editing a layer name, prevent the layer names from scrolling
-         * horizontally while scrolling the layers panel by preventing the default
-         * wheel action if there is a non-zero deltaX and instead firing a new
-         * wheel action with deltaX set to 0.
-         *
-         * @private
-         * @param {SyntheticEvent} event
-         */
-        _handleWheel: function (event) {
-            var layerName = this.refs.layerName;
-            if (!layerName.isEditing() && event.target === React.findDOMNode(layerName)) {
-                if (event.deltaX) {
-                    var nativeEvent = event.nativeEvent,
-                        domEvent = new window.WheelEvent(event.type, {
-                            deltaX: 0.0,
-                            deltaY: nativeEvent.deltaY
-                        });
-
-                    event.preventDefault();
-                    event.target.dispatchEvent(domEvent);
-                }
-            }
-        },
-
         render: function () {
             var doc = this.props.document,
                 layer = this.props.layer,
@@ -359,8 +334,8 @@ define(function (require, exports, module) {
                                 type="text"
                                 value={layer.name}
                                 editable={!this.props.disabled && nameEditable}
+                                preventHorizontalScrolling={true}
                                 onKeyDown={this._skipToNextLayerName}
-                                onWheel={this._handleWheel}
                                 onChange={this._handleLayerNameChange}>
                             </TextInput>
                             {showHideButton}

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -69,6 +69,18 @@ define(function (require, exports, module) {
 
         componentWillMount: function () {
             this._setTooltipThrottled = synchronization.throttle(os.setTooltip, os, 500);
+            this._libraryLastModified = this.props.library.modified;
+        },
+        
+        shouldComponentUpdate: function (nextProps) {
+            // Library's modified time reflects itself and its elements, so there is no need to check its element's 
+            // modified time.
+            return this._libraryLastModified !== nextProps.library.modified ||
+                !_.isEqual(this.state, nextState);
+        },
+        
+        componentWillUpdate: function () {
+            this._libraryLastModified = this.props.library.modified;
         },
 
         /**

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -25,7 +25,8 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var os = require("adapter/os"),
         synchronization = require("js/util/synchronization"),
@@ -72,7 +73,7 @@ define(function (require, exports, module) {
             this._libraryLastModified = this.props.library.modified;
         },
         
-        shouldComponentUpdate: function (nextProps) {
+        shouldComponentUpdate: function (nextProps, nextState) {
             // Library's modified time reflects itself and its elements, so there is no need to check its element's 
             // modified time.
             return this._libraryLastModified !== nextProps.library.modified ||

--- a/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
             this._elementLastModified = this.props.element.modified;
             
             var element = this.props.element,
-                renditionSize = element.type === librariesAction.ELEMENT_GRAPHIC_TYPE ? 
+                renditionSize = element.type === librariesAction.ELEMENT_GRAPHIC_TYPE ?
                     librariesAction.RENDITION_GRAPHIC_SIZE : librariesAction.RENDITION_DEFAULT_SIZE;
 
             Promise.fromNode(function (cb) {

--- a/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
@@ -41,6 +41,15 @@ define(function (require, exports, module) {
             onComplete: React.PropTypes.func
         },
         
+        /**
+         * Timestamp of the element's modified time. The "_updateRenditionPath" function uses this timestamp to 
+         * decide whether to re-fetch element's rendition.
+         *
+         * @private
+         * @type {number}
+         */
+        _elementLastModified: 0,
+        
         getInitialState: function () {
             return {
                 loading: true,
@@ -49,24 +58,54 @@ define(function (require, exports, module) {
         },
         
         componentWillMount: function () {
-            // On mount, get the rendition of this element
-            var element = this.props.element;
+            this._updateRenditionPath();
+        },
+        
+        componentWillUpdate: function () {
+            this._updateRenditionPath();
+        },
+        
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return this._elementLastModified !== nextProps.element.modified ||
+                   this.state.loading !== nextState.loading ||
+                   this.state.renditionPath !== nextState.renditionPath;
+        },
+        
+        /**
+         * Update asset's rendition path for its initial display or new content.
+         *
+         * @private
+         */
+        _updateRenditionPath: function () {
+            if (this._elementLastModified === this.props.element.modified) {
+                return;
+            }
+            
+            this.setState({
+                loading: true,
+                renditionPath: null
+            });
+            
+            this._elementLastModified = this.props.element.modified;
+            
+            var element = this.props.element,
+                renditionSize = element.type === librariesAction.ELEMENT_GRAPHIC_TYPE ? 
+                    librariesAction.RENDITION_GRAPHIC_SIZE : librariesAction.RENDITION_DEFAULT_SIZE;
 
             Promise.fromNode(function (cb) {
-                element.getRenditionPath(librariesAction.RENDITION_SIZE, cb);
+                element.getRenditionPath(renditionSize, cb);
             })
             .bind(this)
             .then(function (path) {
                 // path will be undefined when the element is a graphic and its representation 
                 // is empty (e.g. an empty artboard).
                 this.setState({
-                    hasRendition: !!path,
-                    renditionPath: path,
+                    renditionPath: path ? (path + "?cachebuster=" + this._elementLastModified) : null,
                     loading: false
                 });
                 
                 if (this.props.onComplete) {
-                    this.props.onComplete(this.state.hasRendition, this.state.renditionPath);
+                    this.props.onComplete(this.state.renditionPath);
                 }
             });
         },
@@ -79,7 +118,7 @@ define(function (require, exports, module) {
                 </div>);
             }
             
-            if (!this.state.hasRendition) {
+            if (!this.state.renditionPath) {
                 return (<div className="libraries__asset__preview-image
                     libraries__asset__preview-image-blank"/>);
             }

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -160,6 +160,7 @@ define(function (require, exports, module) {
                             editable={true}
                             title={this.props.title}
                             value={this.props.title}
+                            preventHorizontalScrolling={true}
                             onClick={this._handleClickTitle}
                             onChange={this._handleRename}/>
                         {subTitle}

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -69,11 +69,10 @@ define(function (require, exports, module) {
          * Handle completion of loading asset preview.
          *
          * @private
-         * @param  {Boolean} hasRendition
          * @param  {string} renditionPath
          */
-        _handlePreviewCompleted: function (hasRendition, renditionPath) {
-            if (hasRendition) {
+        _handlePreviewCompleted: function (renditionPath) {
+            if (renditionPath) {
                 this.setState({ renditionPath: renditionPath });
             }
         },

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -64,7 +64,12 @@ define(function (require, exports, module) {
             onFocus: React.PropTypes.func,
             editable: React.PropTypes.bool,
             placeholderText: React.PropTypes.string,
-            neverSelectAll: React.PropTypes.bool // never highlight text, regardless of this.state.selectDisabled
+            
+            // prevent the text input from scrolling horizontally when it is not editable.
+            preventHorizontalScrolling: React.PropTypes.bool,
+            
+            // never highlight text, regardless of this.state.selectDisabled
+            neverSelectAll: React.PropTypes.bool
         },
 
         getDefaultProps: function () {
@@ -347,6 +352,29 @@ define(function (require, exports, module) {
                 this._suppressMouseUp = false;
             }
         },
+        
+        /**
+         * When TextInput is not editable, prevent it from scrolling horizontally 
+         * by preventing the default wheel action if there is a non-zero deltaX 
+         * and instead firing a new wheel action with deltaX set to 0.
+         *
+         * @private
+         * @param {SyntheticEvent} event
+         */
+        _handleWheel: function (event) {
+            if (this.props.preventHorizontalScrolling) {
+                if (event.deltaX) {
+                    var nativeEvent = event.nativeEvent,
+                        domEvent = new window.WheelEvent(event.type, {
+                            deltaX: 0.0,
+                            deltaY: nativeEvent.deltaY
+                        });
+
+                    event.preventDefault();
+                    event.target.dispatchEvent(domEvent);
+                }
+            }
+        },
 
         render: function () {
             var className = classnames(_typeToClass[this.props.valueType], this.props.className, this.props.size);
@@ -385,7 +413,8 @@ define(function (require, exports, module) {
                         readOnly={true}
                         className={className}
                         onDoubleClick={this._handleDoubleClick}
-                        onClick={this._handleClick}>
+                        onClick={this._handleClick}
+                        onWheel={this._handleWheel}>
                     </input>
                 );
             }

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -822,10 +822,13 @@ define(function (require, exports, module) {
             if (Number.isInteger(replace)) {
                 // if explicitly replacing, then replace by current ID
                 replaceLayer = this.byID(replace);
-            } else {
-                // otherwise, replace the selected layer
-                var selectedLayers = document.layers.selected;
-                replaceLayer = selectedLayers && selectedLayers.size === 1 && selectedLayers.first();
+            } else if (this.selected && this.selected.size === 1){
+                // otherwise, replace the selected layer if it has the same index with the new layer.
+                var selectedLayer = this.selected.first(),
+                    selectedLayerIndex = this.indexOf(selectedLayer),
+                    newLayerIndex = descriptors[0].itemIndex;
+                    
+                replaceLayer = selectedLayerIndex === newLayerIndex && selectedLayer;
             }
 
             // The selected layer should be empty and a non-background layer unless replace is explicitly provided true

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -822,7 +822,7 @@ define(function (require, exports, module) {
             if (Number.isInteger(replace)) {
                 // if explicitly replacing, then replace by current ID
                 replaceLayer = this.byID(replace);
-            } else if (this.selected && this.selected.size === 1){
+            } else if (this.selected && this.selected.size === 1) {
                 // otherwise, replace the selected layer if it has the same index with the new layer.
                 var selectedLayer = this.selected.first(),
                     selectedLayerIndex = this.indexOf(selectedLayer),

--- a/src/js/models/library_sync_status.js
+++ b/src/js/models/library_sync_status.js
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
             libraryNumber: libraries.length
         };
         
-        if (!_.isEqual(this._status, newStatus)) {
+        if (newStatus.isSyncing || !_.isEqual(this._status, newStatus)) {
             var libNumberChanged = this._status.libraryNumber !== newStatus.libraryNumber;
             
             this._emitter.emit("sync", newStatus.isSyncing, libNumberChanged);

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -118,14 +118,16 @@
 
         .libraries__split-button-list {
             flex: none;
-            width: 10rem;
             flex-shrink: 0;
             flex-grow: 0;
+            width: auto;
             justify-content: space-between;
 
             .split-button__item {
                 justify-content: flex-end;
                 margin: 0;
+                margin-left: 1.5rem;
+                flex-grow: 0;
             }
 
             .libraries__split-button-collaborate {
@@ -171,12 +173,12 @@
 
         .libraries-bar__section__right {
             flex: none;
-            width: 6rem;
             justify-content: space-between;
 
             .split-button__item {
                 justify-content: flex-end;
                 margin: 0;
+                margin-left: 1.5rem;
             }
         }
     }


### PR DESCRIPTION
## Improvements

* Make sure to update asset's preview image when it is edited outside of DS (e.g. Ai, or win Ps)
* Remove the last "updateDocument" in libraries actions.
* Prevent long asset title from scrolling horizontally when scrolling the asset list.

## Resolved issues

#1860 CC Lib: adding a vector smart object imports into library incorrectly (hopefully)
#2230 Positions of icons are off from clickable regions in Libraries panel header
#2201 Stale empty layer remains after placing cloud-linked smart object in new artboard


