### PR TITLE
Get lineHeight from a text style only if it's positive

### DIFF
--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
                 };
             }
 
-            if (textStyle.leading) {
+            if (textStyle.leading >= 0) {
                 obj.lineHeight = {
                     type: "pt",
                     value: textStyle.leading


### PR DESCRIPTION
On autoLeading, leading would be -1, and `if (leading)` would return true causing the multi line text cramming issue.