### PR TITLE
Type modal history fixes

### DIFF
--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -386,6 +386,7 @@ define(function (require, exports) {
     undo.reads = [locks.JS_APP, locks.JS_DOC];
     undo.writes = [locks.JS_UI];
     undo.transfers = [history.decrementHistory];
+    undo.modal = true;
 
     /**
      * Step Forward by transferring to the appropriate history action
@@ -409,6 +410,7 @@ define(function (require, exports) {
     redo.reads = [locks.JS_APP, locks.JS_DOC];
     redo.writes = [locks.JS_UI];
     redo.transfers = [history.incrementHistory];
+    undo.modal = true;
 
     exports.nativeCut = nativeCut;
     exports.nativeCopy = nativeCopy;

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -28,6 +28,7 @@ define(function (require, exports) {
         _ = require("lodash");
 
     var descriptor = require("adapter/ps/descriptor"),
+        ps = require("adapter/ps"),
         documentLib = require("adapter/lib/document"),
         historyLib = require("adapter/lib/history"),
         layerActions = require("./layers"),
@@ -37,6 +38,12 @@ define(function (require, exports) {
     var events = require("js/events"),
         locks = require("js/locks"),
         log = require("js/util/log");
+
+    /**
+     * Photoshop command ID for "undo"
+     * @const {number}
+     */
+    var UNDO_NATIVE_MENU_COMMMAND_ID = 101;
 
     /**
      * Query the current history state for the current document
@@ -184,7 +191,15 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var incrementHistory = function (document) {
-        return _navigateHistory.call(this, document, 1);
+        var modal = this.flux.store("tool").getModalToolState();
+
+        if (modal) {
+            // For now, don't support "redo" in modal text state
+            // Currently we are not disabling this menu action correctly, so this is for safety
+            return Promise.resolve();
+        } else {
+            return _navigateHistory.call(this, document, 1);
+        }
     };
     incrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
     incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];
@@ -193,12 +208,24 @@ define(function (require, exports) {
 
     /**
      * Navigate to the previous history state
+     * If we're in a modal text edit state, play the native UNDO command.
+     * Otherwise use the history store
      *
      * @param {Document} document
      * @return {Promise}
      */
     var decrementHistory = function (document) {
-        return _navigateHistory.call(this, document, -1);
+        var modal = this.flux.store("tool").getModalToolState();
+
+        if (modal) {
+            var payload = {
+                commandId: UNDO_NATIVE_MENU_COMMMAND_ID,
+                waitForCompletion: true
+            };
+            return ps.performMenuCommand(payload);
+        } else {
+            return _navigateHistory.call(this, document, -1);
+        }
     };
     decrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
     decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1842,8 +1842,9 @@ define(function (require, exports) {
                     log.warn("Received layer set event without a current document", event);
                     return;
                 }
-
-                this.flux.actions.layers.resetLayers(currentDocument, currentDocument.layers.selected);
+                
+                // reset layers, and AMEND history
+                this.flux.actions.layers.resetLayers(currentDocument, currentDocument.layers.selected, true);
                 break;
             }
         }.bind(this);

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -57,24 +57,30 @@ define(function (require, exports) {
      * @private
      * @param {number} documentID
      * @param {string} name localized name to put into the history state
+     * @param {boolean} modal is the app in a modal state
      * @param {boolean=} coalesce Whether to coalesce this operations history state
      * @return {object} options
      */
-    var _getTypeOptions = function (documentID, name, coalesce) {
-        return {
+    var _getTypeOptions = function (documentID, name, modal, coalesce) {
+        var options = {
             paintOptions: {
                 immediateUpdate: true,
                 quality: "draft"
             },
-            historyStateInfo: {
+            canExecuteWhileModal: true,
+            ignoreTargetWhenModal: true
+        };
+
+        if (!modal) {
+            options.historyStateInfo = {
                 name: name,
                 target: documentLib.referenceBy.id(documentID),
                 coalesce: !!coalesce,
                 suppressHistoryStateNotification: !!coalesce
-            },
-            canExecuteWhileModal: true,
-            ignoreTargetWhenModal: true
-        };
+            };
+        }
+
+        return options;
     };
 
     /**
@@ -117,10 +123,11 @@ define(function (require, exports) {
      */
     var setPostScript = function (document, layers, postscript, family, style) {
         var layerIDs = collection.pluck(layers, "id"),
-            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
+            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState();
 
         var setFacePlayObject = textLayerLib.setPostScript(layerRefs, postscript),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
             setFacePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -175,10 +182,11 @@ define(function (require, exports) {
      */
     var setFace = function (document, layers, family, style) {
         var layerIDs = collection.pluck(layers, "id"),
-            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
+            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState();
 
         var setFacePlayObject = textLayerLib.setFace(layerRefs, family, style),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
             setFacePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -203,12 +211,12 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.Iterable.<Layers>} layers
      * @param {Color} color
-     * @param {boolean=} optimisticHistory Whether this event will be included in our history model
+     * @param {boolean} modal is the app in a modal state, which effects history
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @param {boolean=} options.ignoreAlpha
      * @return {Promise}
      */
-    var updateColor = function (document, layers, color, optimisticHistory, options) {
+    var updateColor = function (document, layers, color, modal, options) {
         var layerIDs = collection.pluck(layers, "id"),
             normalizedColor = null;
 
@@ -224,7 +232,7 @@ define(function (require, exports) {
             ignoreAlpha: options.ignoreAlpha
         };
 
-        if (optimisticHistory) {
+        if (!modal) {
             return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
         } else {
             return this.dispatchAsync(events.document.history.amendment.TYPE_COLOR_CHANGED, payload);
@@ -252,8 +260,9 @@ define(function (require, exports) {
             normalizedColor = color.normalizeAlpha(),
             opaqueColor = normalizedColor.opaque(),
             playObject = textLayerLib.setColor(layerRefs, opaqueColor),
+            modal = this.flux.store("tool").getModalToolState(),
             typeOptions = _.merge(options,
-                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_COLOR, options.coalesce));
+                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_COLOR, modal, options.coalesce));
 
         if (!options.ignoreAlpha) {
             var opacity = Math.round(normalizedColor.opacity),
@@ -269,7 +278,7 @@ define(function (require, exports) {
             playObject = [playObject].concat(setOpacityPlayObjects);
         }
         
-        var updatePromise = this.transfer(updateColor, document, layers, color, true, options),
+        var updatePromise = this.transfer(updateColor, document, layers, color, modal, options),
             setColorPromise = layerActionsUtil.playSimpleLayerActions(document, layers, playObject, true, typeOptions);
 
         return Promise.join(updatePromise, setColorPromise);
@@ -312,13 +321,14 @@ define(function (require, exports) {
      */
     var setSize = function (document, layers, size) {
         var layerIDs = collection.pluck(layers, "id"),
-            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
+            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState();
 
         // Ensure that size does not exceed PS font size bounds
         size = math.clamp(size, PS_MIN_FONT_SIZE, PS_MAX_FONT_SIZE);
 
         var setSizePlayObject = textLayerLib.setSize(layerRefs, size, "px"),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_SIZE),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_SIZE, modal),
             setSizePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -370,10 +380,11 @@ define(function (require, exports) {
     var setTracking = function (document, layers, tracking) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState(),
             psTracking = tracking / 1000; // PS expects tracking values that are 1/1000 what is shown in the UI
 
         var setTrackingPlayObject = textLayerLib.setTracking(layerRefs, psTracking),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_TRACKING),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_TRACKING, modal),
             setTrackingPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -425,6 +436,7 @@ define(function (require, exports) {
     var setLeading = function (document, layers, leading) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState(),
             autoLeading = leading === -1;
 
         if (!autoLeading && leading < 0.1) {
@@ -432,7 +444,7 @@ define(function (require, exports) {
         }
 
         var setLeadingPlayObject = textLayerLib.setLeading(layerRefs, autoLeading, leading, "px"),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_LEADING),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_LEADING, modal),
             setLeadingPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -484,11 +496,12 @@ define(function (require, exports) {
      */
     var setAlignment = function (document, layers, alignment, options) {
         var layerIDs = collection.pluck(layers, "id"),
-            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray();
+            layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
+            modal = this.flux.store("tool").getModalToolState();
 
         var setAlignmentPlayObject = textLayerLib.setAlignment(layerRefs, alignment),
             typeOptions = _.merge(options,
-                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT)),
+                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT, modal)),
             setAlignmentPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {
@@ -509,6 +522,7 @@ define(function (require, exports) {
     /**
      * Update the given layer models with all the provided text properties.
      * TODO: Ideally, this would subsume all the other type update actions.
+     * Note: this is action does NOT update history
      *
      * @param {Document} document
      * @param {Immutable.Iterable.<Layer>} layers

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -135,10 +135,11 @@ define(function (require, exports) {
                 }),
             updatePromise = this.transfer(updatePostScript, document, layers, postscript, family, style);
 
-        return Promise.join(updatePromise, setFacePromise,
-                function () {
-                    return this.transfer(layerActions.resetBounds, document, layers);
-                }.bind(this));
+        return Promise.join(updatePromise, setFacePromise).bind(this).then(function () {
+            if (!modal) {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }
+        });
     };
     setPostScript.reads = [locks.JS_DOC];
     setPostScript.writes = [locks.PS_DOC, locks.JS_UI];
@@ -194,10 +195,11 @@ define(function (require, exports) {
                 }),
             updatePromise = this.transfer(updateFace, document, layers, family, style);
 
-        return Promise.join(updatePromise, setFacePromise,
-                function () {
-                    return this.transfer(layerActions.resetBounds, document, layers);
-                }.bind(this));
+        return Promise.join(updatePromise, setFacePromise).bind(this).then(function () {
+            if (!modal) {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }
+        });
     };
     setFace.reads = [locks.JS_DOC];
     setFace.writes = [locks.JS_UI, locks.PS_DOC];
@@ -336,10 +338,11 @@ define(function (require, exports) {
                 }),
             updatePromise = this.transfer(updateSize, document, layers, size);
 
-        return Promise.join(updatePromise, setSizePromise,
-            function () {
+        return Promise.join(updatePromise, setSizePromise).bind(this).then(function () {
+            if (!modal) {
                 return this.transfer(layerActions.resetBounds, document, layers);
-            }.bind(this));
+            }
+        });
     };
     setSize.reads = [locks.JS_DOC];
     setSize.writes = [locks.JS_UI, locks.PS_DOC];
@@ -392,10 +395,11 @@ define(function (require, exports) {
                 }),
             updatePromise = this.transfer(updateTracking, document, layers, tracking);
 
-        return Promise.join(updatePromise, setTrackingPromise,
-                function () {
-                    return this.transfer(layerActions.resetBounds, document, layers);
-                }.bind(this));
+        return Promise.join(updatePromise, setTrackingPromise).bind(this).then(function () {
+            if (!modal) {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }
+        });
     };
     setTracking.reads = [locks.JS_DOC];
     setTracking.writes = [locks.PS_DOC, locks.JS_UI];
@@ -452,10 +456,11 @@ define(function (require, exports) {
                 }),
             updatePromise = this.transfer(updateLeading, document, layers, leading);
 
-        return Promise.join(updatePromise, setLeadingPromise,
-                function () {
-                    return this.transfer(layerActions.resetBounds, document, layers);
-                }.bind(this));
+        return Promise.join(updatePromise, setLeadingPromise).bind(this).then(function () {
+            if (!modal) {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }
+        });
     };
     setLeading.reads = [locks.JS_DOC];
     setLeading.writes = [locks.PS_DOC, locks.JS_UI];
@@ -509,10 +514,11 @@ define(function (require, exports) {
                 }),
             transferPromise = this.transfer(updateAlignment, document, layers, alignment);
 
-        return Promise.join(transferPromise, setAlignmentPromise,
-                function () {
-                    return this.transfer(layerActions.resetBounds, document, layers);
-                }.bind(this));
+        return Promise.join(transferPromise, setAlignmentPromise).bind(this).then(function () {
+            if (!modal) {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }
+        });
     };
     setAlignment.reads = [locks.JS_DOC];
     setAlignment.writes = [locks.PS_DOC, locks.JS_UI];
@@ -536,7 +542,7 @@ define(function (require, exports) {
             properties: properties
         };
 
-        return this.dispatchAsync(events.document.history.amendment.TYPE_PROPERTIES_CHANGED, payload);
+        return this.dispatchAsync(events.document.TYPE_PROPERTIES_CHANGED, payload);
     };
     updateProperties.reads = [];
     updateProperties.writes = [locks.JS_DOC];

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -237,7 +237,7 @@ define(function (require, exports) {
         if (!modal) {
             return this.dispatchAsync(events.document.history.optimistic.TYPE_COLOR_CHANGED, payload);
         } else {
-            return this.dispatchAsync(events.document.history.amendment.TYPE_COLOR_CHANGED, payload);
+            return this.dispatchAsync(events.document.TYPE_COLOR_CHANGED, payload);
         }
     };
     updateColor.reads = [];

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -76,8 +76,7 @@ define(function (require, exports, module) {
                 amendment: {
                     TYPE_COLOR_CHANGED: "typeColorChangedAmendment",
                     REORDER_LAYERS: "reorderLayersAmendment",
-                    RESET_LAYERS: "resetLayersAmendement",
-                    TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
+                    RESET_LAYERS: "resetLayersAmendement"
                 }
             },
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",
@@ -107,7 +106,8 @@ define(function (require, exports, module) {
             TYPE_SIZE_CHANGED: "typeSizeChanged",
             TYPE_TRACKING_CHANGED: "typeTrackingChanged",
             TYPE_LEADING_CHANGED: "typeLeadingChanged",
-            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged"
+            TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged",
+            TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
         },
         export: {
             ASSET_CHANGED: "exportAssetChanged",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -74,7 +74,6 @@ define(function (require, exports, module) {
                     GUIDE_DELETED: "guideDeleted"
                 },
                 amendment: {
-                    TYPE_COLOR_CHANGED: "typeColorChangedAmendment",
                     REORDER_LAYERS: "reorderLayersAmendment",
                     RESET_LAYERS: "resetLayersAmendement"
                 }
@@ -107,7 +106,8 @@ define(function (require, exports, module) {
             TYPE_TRACKING_CHANGED: "typeTrackingChanged",
             TYPE_LEADING_CHANGED: "typeLeadingChanged",
             TYPE_ALIGNMENT_CHANGED: "typeAlignmentChanged",
-            TYPE_PROPERTIES_CHANGED: "typePropertiesChanged"
+            TYPE_PROPERTIES_CHANGED: "typePropertiesChanged",
+            TYPE_COLOR_CHANGED: "typeColorChangedNoHistory"
         },
         export: {
             ASSET_CHANGED: "exportAssetChanged",

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -103,14 +103,15 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 fontStore = flux.store("font"),
                 toolStore = flux.store("tool"),
-                fontState = fontStore.getState();
+                fontState = fontStore.getState(),
+                modalState = toolStore.getModalToolState();
 
             return {
                 initialized: fontState.initialized,
                 postScriptMap: fontState.postScriptMap,
                 familyMap: fontState.familyMap,
                 // Force opacity while in the type modal tool state
-                opaque: toolStore.getModalToolState()
+                opaque: modalState
             };
         },
 

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_TRACKING_CHANGED, this._handleTypeTrackingChanged,
                 events.document.TYPE_LEADING_CHANGED, this._handleTypeLeadingChanged,
                 events.document.TYPE_ALIGNMENT_CHANGED, this._handleTypeAlignmentChanged,
-                events.document.history.amendment.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
+                events.document.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
                 events.document.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
                 events.document.history.nonOptimistic.GUIDE_SET, this._handleGuideSet,
                 events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_FACE_CHANGED, this._handleTypeFaceChanged,
                 events.document.TYPE_SIZE_CHANGED, this._handleTypeSizeChanged,
                 events.document.history.optimistic.TYPE_COLOR_CHANGED, this._handleTypeColorChanged,
-                events.document.history.amendment.TYPE_COLOR_CHANGED, this._handleTypeColorChanged,
+                events.document.TYPE_COLOR_CHANGED, this._handleTypeColorChanged,
                 events.document.TYPE_TRACKING_CHANGED, this._handleTypeTrackingChanged,
                 events.document.TYPE_LEADING_CHANGED, this._handleTypeLeadingChanged,
                 events.document.TYPE_ALIGNMENT_CHANGED, this._handleTypeAlignmentChanged,


### PR DESCRIPTION
undo/redo
- While in modal state* the UNDO action will now play the actual 101 command in photoshop.  This is OK because photoshop deals with history differently in the text world.  More improvements possible, but this is a decent first step.
- Still has minor bug with showing menu item in the correct situations

updating text properties while modal will **NOT**:
- Send `historyStateInfo` as a play option to photoshop
- Amend history (admittedly I was confused on this matter coming in to this bug work)
- Reset bounds (which, awkwardly, is the thing that *correctly* creates history state when non-modal)

Committing an existing text layer will now AMEND history (via the "set" event).  As an example, this means that the correct "mixed" state will be captured after a multi-color-text run is committed.  So that an undo/redo pair will result in "mixed".

this should address #1848

*as ian pointed out, the definition of "modal state" may need to be tightened up... although some immediate tests have been positive.

I started a wiki on the subject: https://github.com/adobe-photoshop/spaces-design/wiki/History-&-modal-text-editing