### PR TITLE
Fix modal text alignment

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -59,10 +59,11 @@ define(function (require, exports) {
      * @param {string} name localized name to put into the history state
      * @param {boolean} modal is the app in a modal state
      * @param {boolean=} coalesce Whether to coalesce this operations history state
+     * @param {object=} options Inherited into the type options returned, if present
      * @return {object} options
      */
-    var _getTypeOptions = function (documentID, name, modal, coalesce) {
-        var options = {
+    var _getTypeOptions = function (documentID, name, modal, coalesce, options) {
+        var typeOptions = {
             paintOptions: {
                 immediateUpdate: true,
                 quality: "draft"
@@ -72,7 +73,7 @@ define(function (require, exports) {
         };
 
         if (!modal) {
-            options.historyStateInfo = {
+            typeOptions.historyStateInfo = {
                 name: name,
                 target: documentLib.referenceBy.id(documentID),
                 coalesce: !!coalesce,
@@ -80,7 +81,7 @@ define(function (require, exports) {
             };
         }
 
-        return options;
+        return _.merge({}, options, typeOptions);
     };
 
     /**
@@ -263,8 +264,8 @@ define(function (require, exports) {
             opaqueColor = normalizedColor.opaque(),
             playObject = textLayerLib.setColor(layerRefs, opaqueColor),
             modal = this.flux.store("tool").getModalToolState(),
-            typeOptions = _.merge(options,
-                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_COLOR, modal, options.coalesce));
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_COLOR,
+                modal, options.coalesce, options);
 
         if (!options.ignoreAlpha) {
             var opacity = Math.round(normalizedColor.opacity),
@@ -505,8 +506,8 @@ define(function (require, exports) {
             modal = this.flux.store("tool").getModalToolState();
 
         var setAlignmentPlayObject = textLayerLib.setAlignment(layerRefs, alignment),
-            typeOptions = _.merge(options,
-                _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT, modal)),
+            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT,
+                modal, false, options),
             setAlignmentPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
                 .bind(this)
                 .then(function () {

--- a/src/style/shared/split-button.less
+++ b/src/style/shared/split-button.less
@@ -21,14 +21,6 @@
  *
  */
 
-.split-button__item__selected {
-    //opacity: 0.95 !important;
-    color: @item-hover;
-    svg {
-        fill: @item-hover;
-    }
-}
-
 /*.split-button__item__disabled, .split-button__item__disabled:hover {
     color: @item-disabled;
     svg {
@@ -70,11 +62,17 @@
         &__disabled, &__disabled:hover {
             color: @item-disabled;
             svg {
-        fill: @item-disabled;
-    }
+                fill: @item-disabled;
+            }
         }
     }
-    
+}
+
+.split-button__item__selected {
+    color: @item-hover;
+    svg {
+        fill: @item-hover;
+    }
 }
 
 .vector-operations {


### PR DESCRIPTION
The problem was that we were trying to merge type options into another `undefined` set of options, which results in undefined. That is, `_.merge(undefined, x) === undefined`. This broke the alignment action because the `canExecuteWhileModal` option is required in the modal state. This fixes the problem by having `_getTypeOptions` perform the merge into a fresh object.

Addresses #1882.

**Update:** Also pushed dccdd8b to address #2277. 