### PR TITLE
Update type properties after canceling edits

### DIFF
--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -50,6 +50,7 @@ define(function (require, exports, module) {
         tools: require("./tools"),
         transform: require("./transform"),
         type: require("./type"),
+        typetool: require("./typetool"),
         ui: require("./ui")
     };
 });

--- a/src/js/actions/typetool.js
+++ b/src/js/actions/typetool.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var documentActions = require("./documents"),
+        layerActions = require("./layers"),
+        locks = require("../locks"),
+        log = require("js/util/log");
+
+    /**
+     * Handle the deleteTextLayer event for the type tool by removing the
+     * client-side layer model.
+     *
+     * @param {object} event
+     * @param {boolean} layersReplaced If true, completely reset the document
+     *  instead of just deleting the referenced layer.
+     * @return {Promise}
+     */
+    var handleDeletedLayer = function (event, layersReplaced) {
+        var applicationStore = this.flux.store("application"),
+            document = applicationStore.getCurrentDocument();
+
+        if (!document) {
+            throw new Error("Unexpected deleteTextLayer event: no active document");
+        }
+
+        if (layersReplaced) {
+            return this.transfer(documentActions.updateDocument);
+        } else {
+            var layerID = event.layerID,
+                layer = document.layers.byID(layerID);
+
+            if (!layer) {
+                log.warn("Unable to handle deleted text layer because it does not exist: " + layerID);
+                return this.transfer(documentActions.updateDocument);
+            }
+
+            return this.transfer(layerActions.removeLayers, document, layer, true);
+        }
+    };
+    handleDeletedLayer.modal = true;
+    handleDeletedLayer.reads = [locks.JS_APP, locks.JS_DOC];
+    handleDeletedLayer.writes = [];
+    handleDeletedLayer.transfers = [layerActions.removeLayers, documentActions.updateDocument];
+    
+
+    /**
+     * Handle the toolModalStateChanged event, when it indicates a type tool
+     * cancelation, by resetting the selected layers.
+     *
+     * @return {Promise}
+     */
+    var handleTypeModalStateCanceled = function () {
+        var application = this.flux.store("application"),
+            document = application.getCurrentDocument();
+
+        if (!document) {
+            throw new Error("Unexpected toolModalStateChanged event: no active document");
+        }
+
+        return this.transfer(layerActions.resetLayers, document, document.layers.selected);
+    };
+    handleTypeModalStateCanceled.modal = true;
+    handleTypeModalStateCanceled.reads = [locks.JS_APP, locks.JS_DOC];
+    handleTypeModalStateCanceled.writes = [];
+    handleTypeModalStateCanceled.transfers = [layerActions.resetLayers];
+
+    exports.handleDeletedLayer = handleDeletedLayer;
+    exports.handleTypeModalStateCanceled = handleTypeModalStateCanceled;
+});

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -42,7 +42,8 @@ define(function (require, exports, module) {
     var _moveHandler,
         _typeChangedHandler,
         _layerCreatedHandler,
-        _layerDeletedHandler;
+        _layerDeletedHandler,
+        _toolModalStateChangedHandler;
 
     /**
      * The createdTextLayer event results in an addLayers action which may or
@@ -57,6 +58,18 @@ define(function (require, exports, module) {
      * @type {boolean}
      */
     var _layersReplaced = false;
+
+    /**
+     * The deleteTextLayer event is handled by removing the corresponding layer
+     * model. This event may be followed by an event that indicates a modal type
+     * state was canceled. This event should be handled by resetting the selected
+     * layers, but only if the layer wasn't just deleted. This records the deleted
+     * layer ID, and is used to short-circuit the modal cancelation handler.
+     *
+     * @private
+     * @param {?number}
+     */
+    var _layerDeleted = null;
 
     /**
      * Extract style properties from modal text events.
@@ -99,6 +112,12 @@ define(function (require, exports, module) {
             if (_layerCreatedHandler) {
                 descriptor.removeListener("createTextLayer", _layerCreatedHandler);
             }
+            if (_layerDeletedHandler) {
+                descriptor.removeListener("deleteTextLayer", _layerDeletedHandler);
+            }
+            if (_toolModalStateChangedHandler) {
+                descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
+            }
 
             _moveHandler = function () {
                 var documentStore = this.flux.store("application"),
@@ -106,11 +125,9 @@ define(function (require, exports, module) {
 
                 this.flux.actions.layers.resetBounds(currentDocument, currentDocument.layers.allSelected);
             }.bind(this);
-            
             descriptor.addListener("move", _moveHandler);
 
             _typeChangedHandler = TypeTool.updateTextPropertiesHandler.bind(this);
-
             descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
             _layerCreatedHandler = function (event) {
@@ -150,34 +167,27 @@ define(function (require, exports, module) {
                         });
                 }
             }.bind(this);
-            
             descriptor.addListener("createTextLayer", _layerCreatedHandler);
 
             _layerDeletedHandler = function (event) {
-                var documentStore = this.flux.store("application"),
-                    document = documentStore.getCurrentDocument();
+                _layerDeleted = event.layerID;
+                this.flux.actions.typetool.handleDeletedLayer(event, _layersReplaced);
+            }.bind(this);
+            descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
 
-                if (!document) {
-                    log.error("Unexpected deleteTextLayer event: no active document");
-                    return;
-                }
-
-                var layerID = event.layerID,
-                    layer = document.layers.byID(layerID);
-
-                if (layer) {
-                    if (_layersReplaced) {
-                        // See comment above at the _layersReplaced declaration
-                        this.flux.actions.documents.updateDocument();
-                    } else {
-                        this.flux.actions.layers.removeLayers(document, layer, true);
+            _toolModalStateChangedHandler = function (event) {
+                if (event.kind._value === "tool" && event.tool.ID === "txBx" &&
+                    event.state._value === "exit" && event.reason._value === "cancel") {
+                    // If there was a deleteTextLayer event, we've already updated the model.
+                    if (_layerDeleted) {
+                        _layerDeleted = null;
+                        return;
                     }
-                } else {
-                    log.warn("Unexpected deleteTextLayer event for layer " + layerID);
+
+                    this.flux.actions.typetool.handleTypeModalStateCanceled();
                 }
             }.bind(this);
-            
-            descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
+            descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);
 
             if (firstLaunch) {
                 firstLaunch = false;
@@ -191,9 +201,13 @@ define(function (require, exports, module) {
             descriptor.removeListener("updateTextProperties", _typeChangedHandler);
             descriptor.removeListener("createTextLayer", _layerCreatedHandler);
             descriptor.removeListener("deleteTextLayer", _layerDeletedHandler);
+            descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
             
             _moveHandler = null;
             _typeChangedHandler = null;
+            _layerCreatedHandler = null;
+            _layerDeletedHandler = null;
+            _toolModalStateChangedHandler = null;
         };
 
         Tool.call(this, "typeCreateOrEdit", "Type", "typeCreateOrEditTool", selectHandler, deselectHandler);


### PR DESCRIPTION
This uses the new `toolModalStateChanged` event's `reason` property to handle canceled type modal states. The goal is to reset the layers, but that should _only_ happen if there was no `deleteTextLayer` event, which handles the exit from the modal state specially by removing the layer models.

Partially addresses #2257, but note that there is [a core bug](https://watsonexp.corp.adobe.com/#bug=4045762) which notes that there is no `deleteTextLayer` event when canceling out of a modal tool state for a layer that has never been committed. This causes a Photoshop error in that case because `resetLayers` is unable to reset models for layers that have already been deleted in the Photoshop document. But, when that core bug is addressed, no further JavaScript changes should be required.