### PR TITLE
Floor and ceil the guide policy areas so they sit pixel perfect

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -151,15 +151,15 @@ define(function (require, exports) {
             if (horizontal) {
                 guideArea = {
                     x: canvasBounds.left,
-                    y: guideTL.y - policyThickness - 1,
+                    y: Math.floor(guideTL.y - policyThickness - 1),
                     width: canvasBounds.right - canvasBounds.left,
-                    height: policyThickness * 2 + 1
+                    height: Math.ceil(policyThickness * 2 + 1)
                 };
             } else {
                 guideArea = {
-                    x: guideTL.x - policyThickness,
+                    x: Math.floor(guideTL.x - policyThickness - 1),
                     y: canvasBounds.top,
-                    width: policyThickness * 2 + 1,
+                    width: Math.ceil(policyThickness * 2 + 1),
                     height: canvasBounds.bottom - canvasBounds.top
                 };
             }


### PR DESCRIPTION
Addresses #2253, in certain guide locations, the edge of the policy would be at the wrong place and mouse events would stay with us. 