### PR TITLE
jsdoc: fix existing jsdoc and make jscs checks existence of jsdoc on functions

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -131,10 +131,39 @@
         "self"
     ],
     "validateIndentation": 4,
-    "validateJSDoc": {
+    "jsDoc": {
+        "checkAnnotations": {
+            "preset": "closurecompiler", 
+            "extra": {
+                "callback": true
+            }
+        },
         "checkParamNames": true,
         "requireParamTypes": true,
-        "checkRedundantParams": true
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "enforceExistence": "exceptExports",
+        "enforceExistenceExcept": [
+            "get",
+            "setup",
+            "value",
+            "beforeStartup",
+            "initialize",
+            "render",
+            "getState",
+            "getInitialState",
+            "getDefaultProps",
+            "getStateFromFlux",
+            "componentWillReceiveProps",
+            "componentWillMount",
+            "componentWillUnmount",
+            "componentDidMount",
+            "shouldComponentUpdate",
+            "componentWillUpdate",
+            "componentDidUpdate"
+        ]
     },
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,8 @@
 
 module.exports = function (grunt) {
     "use strict";
-
+    
+    /** @ignore */
     var getRequireOptions = function (locale) {
         return {
             options: {
@@ -65,9 +66,26 @@ module.exports = function (grunt) {
             ]
         },
         jscs: {
-            src: "<%= jshint.all %>",
-            options: {
-                config: ".jscsrc"
+            main: {
+                src: [
+                    "*.js",
+                    "*.json",
+                    "src/**/*.js",
+                    "src/**/*.jsx"
+                ],
+                options: {
+                    config: ".jscsrc"
+                }
+            },
+            secondary: {
+                src: [
+                    "test/**/*.js",
+                    "test/**/*.jsx"
+                ],
+                options: {
+                    config: ".jscsrc",
+                    jsDoc: false
+                }
             }
         },
         jsdoc: {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-requirejs": "^0.4.4",
-    "grunt-jscs": "^1.6.0",
-    "grunt-jsdoc": "^0.6.7",
+    "grunt-jscs": "^2.1.0",
+    "grunt-jsdoc": "^0.6.8",
     "grunt-jsonlint": "^1.0.4",
     "grunt-jsxhint": "^0.6.0",
     "grunt-lintspaces": "^0.7.0",
+    "jscs-jsdoc": "shaoshing/jscs-jsdoc#v1.1.0.x",
     "jscs-trailing-whitespace-in-source": "0.0.1",
+    "lodash": "^3.10.1",
     "react-tools": "^0.13.1"
   }
 }

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -56,7 +56,7 @@ define(function (require, exports) {
      * 
      * @private
      * @param {HTMLElement} el
-     * @return boolean
+     * @return {boolean}
      */
     var _isInput = function (el) {
         return el instanceof window.HTMLInputElement;
@@ -67,7 +67,7 @@ define(function (require, exports) {
      * 
      * @private
      * @param {HTMLInputElement} el
-     * @return boolean
+     * @return {boolean}
      */
     var _isTextInput = function (el) {
         switch (el.type) {

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -248,6 +248,7 @@ define(function (require, exports) {
      *
      * @param {{id: number}} document Document model or object containing document ID
      * @param {number} index Index of the guide to be deleted
+     * @param {object} options
      * @param {boolean=} options.sendChanges If true, will call the action descriptor to delete the guide from PS
      *
      * @return {Promise}

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -41,7 +41,8 @@ define(function (require, exports) {
 
     /**
      * Photoshop command ID for "undo"
-     * @const {number}
+     * @type {number}
+     * @const 
      */
     var UNDO_NATIVE_MENU_COMMMAND_ID = 101;
 
@@ -305,7 +306,8 @@ define(function (require, exports) {
     };
     beforeStartup.reads = [];
     beforeStartup.writes = [];
-
+    
+    /** @ignore */
     var onReset = function () {
         descriptor.removeListener("historyState", _historyStateHandler);
 

--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -181,7 +181,6 @@ define(function (require, exports) {
      * @param {boolean} enabled enabled flag
      * @return {Promise}
      */
-
     var setShadowEnabled = function (document, layers, shadowIndex, enabled, type) {
         return _upsertShadowProperties.call(
             this, document, layers, shadowIndex, { enabled: enabled }, 0, type);
@@ -198,7 +197,6 @@ define(function (require, exports) {
      * @param {string} type of Shadow
      * @return {Promise}
      */
-
     var deleteShadow = function (document, layers, shadowIndex, type) {
         var payload = {
             documentID: document.id,

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -183,8 +183,8 @@ define(function (require, exports) {
      *  - Tells Photoshop the location of the content
      *  - Updates the document
      *
-     * @todo Eventually, we'll need this to accept layer(s), library, and be more flexible
-     * @todo Also, we definitely need to get rid of the update document call, but this is 0.1
+     * TODO Eventually, we'll need this to accept layer(s), library, and be more flexible
+     * TODO Also, we definitely need to get rid of the update document call, but this is 0.1
      *
      * @return {Promise}
      */
@@ -291,7 +291,7 @@ define(function (require, exports) {
      *  - Using fontStore.getTypeObjectFromLayer, creates a Design Library acceptable font object
      *  - Updates the rendition representation with the exported thumbnail
      *
-     * @todo Make sure the typeObject is correctly created for everything we're supplying
+     * TODO Make sure the typeObject is correctly created for everything we're supplying
      *
      * @return {Promise}
      */

--- a/src/js/actions/search/documents.js
+++ b/src/js/actions/search/documents.js
@@ -34,7 +34,7 @@ define(function (require, exports) {
      * 
      * @private
      * @return {Immutable.List.<object>}
-    */
+     */
     var _currDocSearchOptions = function () {
         var appStore = this.flux.store("application"),
             docStore = this.flux.store("document"),
@@ -56,7 +56,7 @@ define(function (require, exports) {
      * 
      * @private
      * @return {Immutable.List.<object>}
-    */
+     */
     var _recentDocSearchOptions = function () {
         var appStore = this.flux.store("application"),
             recentFiles = appStore.getRecentFiles(),
@@ -78,7 +78,7 @@ define(function (require, exports) {
      *
      * @private
      * @param {number} idInt ID of document to switch to
-    */
+     */
     var _confirmCurrDocSearch = function (idInt) {
         var selectedDoc = this.flux.store("document").getDocument(idInt);
         if (selectedDoc) {
@@ -91,25 +91,25 @@ define(function (require, exports) {
      *
      * @private
      * @param {number} idInt ID of recent document to switch to
-    */
+     */
     var _confirmRecentDocSearch = function (idInt) {
         var recentFiles = this.flux.store("application").getRecentFiles(),
             fileName = recentFiles.get(idInt);
         this.flux.actions.documents.open(fileName);
     };
 
-    /*
+    /**
      * Find SVG class for documents
      * If this needs to vary based on the item, use category list as parameter 
      * (see getSVGCallback type in search store)
      * 
      * @return {string}
-    */
+     */
     var _getSVGClass = function () {
         return "document";
     };
 
-    /*
+    /**
      * Register current document info for search
      */
     var registerCurrentDocumentSearch = function () {
@@ -126,7 +126,7 @@ define(function (require, exports) {
         this.dispatch(events.search.REGISTER_SEARCH_PROVIDER, currentDocPayload);
     };
     
-    /*
+    /**
      * Register recent document info for search
      */
     var registerRecentDocumentSearch = function () {

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -99,13 +99,13 @@ define(function (require, exports) {
         }, Immutable.List());
     };
 
-    /*
+    /**
      * Find SVG class for library item based on what type of asset it is
      *
      * @private
      * @param {Array.<string>} categories 
      * @return {string}
-    */
+     */
     var _getSVGClass = function (categories) {
         var type = categories[categories.length - 1],
             // map from item categories to svg icon class name
@@ -123,7 +123,7 @@ define(function (require, exports) {
      *
      * @private
      * @param {string} id ID of layer to select
-    */
+     */
     var _confirmSearch = function (id) {
         var elementInfo = _idMap[id],
             appStore = this.flux.store("application"),

--- a/src/js/actions/search/menucommands.js
+++ b/src/js/actions/search/menucommands.js
@@ -164,7 +164,7 @@ define(function (require, exports) {
         menuActions._playMenuCommand.call(this, id);
     };
 
-    /*
+    /**
      * Find SVG class for menu commands
      * If this needs to vary based on the item, use category list as parameter 
      * (see getSVGCallback type in search store)
@@ -175,7 +175,7 @@ define(function (require, exports) {
         return "menu-commands";
     };
     
-    /*
+    /**
      * Register recent document info for search
      */
     var registerMenuCommandSearch = function () {

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -80,7 +80,7 @@ define(function (require, exports) {
      * @param {object} strokeProperties a pseudo stroke object containing only new props
      * @param {string} eventName name of the event to emit afterwards
      * @param {boolean=} coalesce optionally include this in the payload to drive history coalescing
-     * @return Promise
+     * @return {Promise}
      */
     var _strokeChangeDispatch = function (document, layers, strokeProperties, eventName, coalesce) {
         var payload = {
@@ -102,7 +102,7 @@ define(function (require, exports) {
      * @param {object} fillProperties a pseudo fill object containing only new props
      * @param {string} eventName name of the event to emit afterwards
      * @param {boolean=} coalesce optionally include this in the payload to drive history coalescing
-     * @return Promise
+     * @return {Promise}
      */
     var _fillChangeDispatch = function (document, layers, fillProperties, eventName, coalesce) {
         // TODO layers param needs to be made fa real
@@ -165,6 +165,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {Stroke} stroke Stroke properties to apply
+     * @param {object} options
      * @param {boolean=} options.enabled Default true
      * @return {Promise}
      */
@@ -225,6 +226,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {Color} color color of the strokes, since photoshop does not provide a way to simply enable a stroke
+     * @param {object} options
      * @param {boolean=} options.enabled
      * @return {Promise}
      */
@@ -246,7 +248,8 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {Color} color
-     * @param {boolean=} option.enabled optional enabled flag, default=true.
+     * @param {object} options
+     * @param {boolean=} options.enabled optional enabled flag, default=true.
      *                                  If supplied, causes a resetBounds afterwards
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @param {boolean=} options.ignoreAlpha Whether to ignore the alpha value of the
@@ -359,6 +362,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {number} opacity opacity as a percentage [0,100]
+     * @param {object} options
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */
@@ -443,6 +447,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {Color} color
+     * @param {object} options
      * @param {boolean=} options.enabled
      * @return {Promise}
      */
@@ -463,6 +468,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers list of layers being updating
      * @param {Color} color
+     * @param {object} options
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @param {boolean=} options.enabled optional enabled flag, default=true
      * @param {boolean=} options.ignoreAlpha Whether to ignore the alpha value of the
@@ -512,6 +518,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.List.<Layer>} layers
      * @param {number} opacity Opacity percentage [0,100]
+     * @param {object} options
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @return {Promise}
      */

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -215,6 +215,7 @@ define(function (require, exports) {
      * @param {Immutable.Iterable.<Layers>} layers
      * @param {Color} color
      * @param {boolean} modal is the app in a modal state, which effects history
+     * @param {object} options
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @param {boolean=} options.ignoreAlpha
      * @return {Promise}
@@ -252,6 +253,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Immutable.Iterable.<Layers>} layers
      * @param {Color} color
+     * @param {object} options
      * @param {boolean=} options.coalesce Whether to coalesce this operation's history state
      * @param {boolean=} options.ignoreAlpha Whether to ignore the alpha value of the
      *  given color and only update the opaque color value.

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      * @private
      * @param {string} moduleName1
      * @param {string} moduleName2
-     * @return number
+     * @return {number}
      */
     var _actionModuleComparator = function (moduleName1, moduleName2) {
         var module1 = actionIndex[moduleName1],

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
             };
         },
 
+        /** @ignore */
         _updateTabContainerScroll: function () {
             var currentTab = window.document.querySelector(".document-title__current");
             if (currentTab) {
@@ -96,7 +97,7 @@ define(function (require, exports, module) {
             this._updateTabContainerScroll();
         },
 
-        /*
+        /**
          * Update the state with the size of the header element on resize
          */
         _handleWindowResize: function () {
@@ -105,6 +106,7 @@ define(function (require, exports, module) {
             });
         },
         
+        /** @ignore */
         _handleTabClick: function (documentID) {
             var selectedDoc = this.getFlux().store("document").getDocument(documentID);
             if (selectedDoc) {

--- a/src/js/jsx/Help.jsx
+++ b/src/js/jsx/Help.jsx
@@ -36,14 +36,16 @@ define(function (require, exports, module) {
     /**
      * Unique identifier for the First Launch Dialog
      *
-     * @const {String}
+     * @const 
+     * @type {string}
      */
     var FIRST_LAUNCH_DIALOG_ID = "first-launch-dialog";
     
     /**
      * Unique identifier for the Keyboard Shortcut Dialog
      *
-     * @const {String}
+     * @const
+     * @type {string}
      */
     var KEYBOARD_SHORTCUT_DIALOG_ID = "keyboard-shortcut-dialog";
         

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -136,6 +136,7 @@ define(function (require, exports, module) {
                 !Immutable.is(this.state.activeDocument, nextState.activeDocument);
         },
 
+        /** @ignore */
         _handleColumnVisibilityToggle: function (columnName) {
             var nextState = {};
             nextState[columnName] = !this.state[columnName];
@@ -144,6 +145,7 @@ define(function (require, exports, module) {
             this.setState(nextState);
         },
         
+        /** @ignore */
         _handlePanelVisibilityToggle: function (panelName) {
             // NOTE: We may want remove this if we come up with a better unsupported state for panels
             if (this.state.document && this.state.document.unsupported) {

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -260,7 +260,11 @@ define(function (require, exports, module) {
             );
         },
         
-        // Stringifies CanvasToWindow transformation for all SVG coordinates
+        /** 
+         * Stringifies CanvasToWindow transformation for all SVG coordinates
+         * 
+         * @ignore
+         */
         _getTransformString: function (transformMatrix) {
             if (!transformMatrix) {
                 return "";

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -35,7 +35,8 @@ define(function (require, exports, module) {
     /**
      * Unique identifier for the Search Dialog
      *
-     * @const {string}
+     * @const
+     * @type {string}
      */
     var SEARCH_BAR_DIALOG_ID = "search-bar-dialog";
 

--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -52,6 +52,7 @@ define(function (require, exports, module) {
     var _keyboardPolicy = null;
 
     module.exports = {
+        /** @ignore */
         acquireFocus: function () {
             this.getFlux().actions.policy.addKeyboardPolicies(keyboardPolicyList)
                 .then(function (policy) {
@@ -64,6 +65,7 @@ define(function (require, exports, module) {
                 log.error("Failed to acquire keyboard focus:", message);
             });
         },
+        /** @ignore */
         releaseFocus: function () {
             if (_keyboardPolicy) {
                 this.getFlux().actions.policy.removeKeyboardPolicies(_keyboardPolicy);

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -39,7 +39,8 @@ define(function (require, exports, module) {
     /**
      * The ID of the option display when there are no other valid results
      *
-     * @const {string}
+     * @const
+     * @type {string}
      */
     var PLACEHOLDER_ID = "NO_OPTIONS-placeholder";
 
@@ -335,6 +336,7 @@ define(function (require, exports, module) {
             return optionList;
         },
 
+        /** @ignore */
         _handleDialogClick: function (event) {
             this.refs.datalist.removeAutofillSuggestion();
             event.stopPropagation();
@@ -360,6 +362,7 @@ define(function (require, exports, module) {
             }
         },
 
+        /** @ignore */
         _handleKeyDown: function (event) {
             switch (event.key) {
                 case "Return":
@@ -384,6 +387,7 @@ define(function (require, exports, module) {
             }
         },
 
+        /** @ignore */
         _clearInput: function () {
             this._updateFilter(null);
             this._updateDatalistInput(null);

--- a/src/js/jsx/sections/layers/DummyLayerFace.jsx
+++ b/src/js/jsx/sections/layers/DummyLayerFace.jsx
@@ -61,9 +61,11 @@ define(function (require, exports, module) {
 
     // Create a Droppable from a Draggable from a DummyLayerFace.
     var draggedVersion = Draggable.createWithComponent(DummyLayerFace, "y"),
+        /** @ignore */
         isEqual = function (layerA, layerB) {
             return layerA.key === layerB.key;
         },
+        /** @ignore */
         droppableSettings = function (props) {
             return {
                 zone: props.zone,

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -382,9 +382,11 @@ define(function (require, exports, module) {
 
     // Create a Droppable from a Draggable from a LayerFace.
     var draggedVersion = Draggable.createWithComponent(LayerFace, "y"),
+        /** @ignore */
         isEqual = function (layerA, layerB) {
             return layerA.key === layerB.key;
         },
+        /** @ignore */
         droppableSettings = function (props) {
             return {
                 zone: props.zone,

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -309,7 +309,7 @@ define(function (require, exports, module) {
          * @param {{DOMElement: node, target: Layer}} dropInfo
          * @param {Immutable.List.<Layer>} draggedLayers Currently dragged layers
          * @param {{x: number, y: number}} point Point where drop event would occur
-         * @return {boolean} Whether the aforementioned drop may occur
+         * @return {{compatible: boolean, valid: compatiable}} Whether the aforementioned drop may occur
          */
         _validDropTarget: function (dropInfo, draggedLayers, point) {
             var dropNode = dropInfo.node,

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -80,19 +80,17 @@ define(function (require, exports, module) {
             return true;
         },
 
-        _handleRefresh: function () {
-            this.getFlux().actions.libraries.beforeStartup();
-            this.getFlux().actions.libraries.afterStartup();
-        },
-
+        /** @ignore */
         _handleLibraryChange: function (libraryID) {
             this.getFlux().actions.libraries.selectLibrary(libraryID);
         },
 
+        /** @ignore */
         _handleLibraryAdd: function () {
             this.getFlux().actions.libraries.createLibrary("New Library");
         },
 
+        /** @ignore */
         _handleLibraryRemove: function () {
             this.getFlux().actions.libraries.removeCurrentLibrary();
         },

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -163,6 +163,7 @@ define(function (require, exports, module) {
             });
         },
 
+        /** @ignore */
         _getLibraryItems: function () {
             if (!this.props.library) {
                 return null;

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -169,7 +169,6 @@ define(function (require, exports, module) {
         
         /**
          * Sync all libraries.
-         * @return {Promise}
          */
         _handleSyncLibraries: function () {
             this.getFlux().actions.libraries.syncLibraries();

--- a/src/js/jsx/sections/libraries/assets/Color.jsx
+++ b/src/js/jsx/sections/libraries/assets/Color.jsx
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
         },
 
         // Grabbed from CC-libraries-panel
+        /** @ignore */
         _getStringColorValue: function (color) {
             var result;
             if (color) {

--- a/src/js/jsx/sections/nodoc/RecentFiles.jsx
+++ b/src/js/jsx/sections/nodoc/RecentFiles.jsx
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
     /**
      * Maximum number of recent files to display
      *
-     * @const {Number}
+     * @const
+     * @type {number}
      */
     var MAX_RECENT_FILES = 10;
 

--- a/src/js/jsx/sections/style/Shadow.jsx
+++ b/src/js/jsx/sections/style/Shadow.jsx
@@ -243,6 +243,7 @@ define(function (require, exports) {
             };
         },
 
+        /** @ignore */
         _stringHelper: function (dropString, innerString) {
             if (this.props.type === "dropShadow") {
                 return dropString;

--- a/src/js/jsx/sections/transform/Rotate.jsx
+++ b/src/js/jsx/sections/transform/Rotate.jsx
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
             this._lastAngle = 0;
         },
 
-        /*
+        /**
          * Force a re-render on undo/redo.
          *
          * @private

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -47,7 +47,8 @@ define(function (require, exports, module) {
     /**
      * Keys on which to dismiss the color picker dialog 
      * 
-     * @const {Array.<key: {string}, modifiers: {object}>} 
+     * @const
+     * @type {Array.<key: {string}, modifiers: {object}>} 
      */
     var DISSMISS_ON_KEYS = [
         { key: os.eventKeyCode.ESCAPE, modifiers: null },
@@ -105,6 +106,7 @@ define(function (require, exports, module) {
             }
         },
 
+        /** @ignore */
         _getID: function () {
             return "colorpicker-" + this.props.id;
         },
@@ -325,7 +327,7 @@ define(function (require, exports, module) {
             }
         },
 
-        /*
+        /**
          * Force the color picker to update on history state changes.
          *
          * @private

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -547,6 +547,7 @@ define(function (require, exports, module) {
             };
         },
 
+        /** @ignore */
         setColor: function (color, quiet) {
             var hsva = this._getHSVA(color);
             this._update(hsva, quiet);
@@ -566,7 +567,7 @@ define(function (require, exports, module) {
          * Get the luminosity of the current color.
          * 
          * @private
-         * return {number} The luminosity in [0,1].
+         * @return {number} The luminosity in [0,1].
          */
         _getLuminosity: function () {
             var brightness = tinycolor(this.state.color.toJS())

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -341,6 +341,7 @@ define(function (require, exports, module) {
             }
         },
 
+        /** @ignore */
         _handleSelectClose: function (event, action) {
             if (this.props.autoSelect) {
                 this._handleSelectClick(event, action);

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -38,7 +38,8 @@ define(function (require, exports, module) {
     /**
      * Valid methods of positioning the dialog
      * 
-     * @const {{string: string}}
+     * @const
+     * @type {{string: string}}
      */
     var POSITION_METHODS = {
         CENTER: "center",
@@ -318,6 +319,7 @@ define(function (require, exports, module) {
             this.getFlux().store("dialog").deregisterDialog(this.props.id);
         },
 
+        /** @ignore */
         isOpen: function () {
             return this.state.open;
         }

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -126,7 +126,7 @@ define(function (require, exports, module) {
          * Parses the input string to a valid number
          *
          * @param {string} rawValue value of the input field
-         * @return {number} Value of the input field as a number or null if invalid
+         * @return {?number} Value of the input field as a number or null if invalid
          */
         _extractValue: function (rawValue) {
             if (this.props.special && rawValue === this.props.special) {
@@ -152,7 +152,7 @@ define(function (require, exports, module) {
             }
         },
         
-        /*
+        /**
          * Formats the number value into a string
          *
          * @param {?number|Immutable.Iterable.<number>} value Value of the input

--- a/src/js/jsx/shared/ToggleButton.jsx
+++ b/src/js/jsx/shared/ToggleButton.jsx
@@ -89,6 +89,7 @@ define(function (require, exports, module) {
             );
         },
 
+        /** @ignore */
         handleClick: function (newSelected, event) {
             if (this.props.onClick) {
                 this.props.onClick(event, newSelected);

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -136,7 +136,9 @@ define(function (require, exports, module) {
             this.drawGuideEdges();
         },
 
-        // Draws the guide edge areas
+        /**
+         * Draws the guide edge areas
+         */
         drawGuideEdges: function () {
             var uiStore = this.getFlux().store("ui"),
                 canvasBounds = uiStore.getCloakRect();

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -260,8 +260,6 @@ define(function (require, exports, module) {
 
         /**
          * Draws sampler HUD if there is one available from the store
-         *
-         * @return {[type]} [description]
          */
         drawSamplerHUD: function () {
             if (!this.state.sampleTypes || !this.state.samplePoint) {

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
      * @param {object?} descriptor.pathBounds If available, will be parsed as shape layer
      * @param {object?} descriptor.boundsNoEffects Bounds object available for all layers
      *
-     * @return {{top: number, left: number, bottom: number, right: number}}
+     * @return {?{top: number, left: number, bottom: number, right: number}}
      */
     Bounds.parseLayerDescriptor = function (descriptor) {
         var boundsObject;
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
      *
      * @param {Bounds} boundsOne
      * @param {Bounds} boundsTwo
-     * @return {Bounds} Intersection of boundsOne and boundsTwo
+     * @return {?Bounds} Intersection of boundsOne and boundsTwo
      */
     Bounds.intersection = function (boundsOne, boundsTwo) {
         if (!boundsOne || !boundsTwo) {

--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -86,8 +86,8 @@ define(function (require, exports, module) {
      * @param {object} baseParentStyle
      * @return {CharacterStyle}
      */
-    CharacterStyle.fromCharacterStyleDescriptor =
-        function (documentDescriptor, layerDescriptor, characterStyleDescriptor, baseParentStyle) {
+    CharacterStyle.fromCharacterStyleDescriptor = function (documentDescriptor,
+        layerDescriptor, characterStyleDescriptor, baseParentStyle) {
         var model = {},
             resolution = typeof documentDescriptor === "number" ?
                 documentDescriptor :

--- a/src/js/models/eventpolicy.js
+++ b/src/js/models/eventpolicy.js
@@ -31,7 +31,7 @@ define(function (require, exports) {
      * @constructor
      * @param {!number} action
      * @param {!number} eventKind
-     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}}=} modifiers
+     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}=} modifiers
      */
     var BaseEventPolicy = function (action, eventKind, modifiers) {
         this.action = action;
@@ -77,7 +77,7 @@ define(function (require, exports) {
      * @constructor
      * @param {!number} action
      * @param {!number} event
-     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}}=} modifiers
+     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}=} modifiers
      * @param {number=|string=} key
      */
     var KeyboardEventPolicy = function (action, event, modifiers, key) {
@@ -105,7 +105,7 @@ define(function (require, exports) {
      * @constructor
      * @param {!number} action
      * @param {!number} event
-     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}}=} modifiers
+     * @param {{shift: boolean, control: boolean, alt: boolean, command: boolean}=} modifiers
      * @param {{x: number, y: number, width: number, height: number}=} area
      */
     var PointerEventPolicy = function (action, event, modifiers, area) {

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -319,7 +319,7 @@ define(function (require, exports, module) {
      * Static method to generate the appropriate LayerEffect based on a provided type
      *
      * @param {string} layerEffectType
-     * @return {LayerEffect}  instance of a layer effect such as a Shadow
+     * @return {Shadow}  instance of a layer effect such as a Shadow
      */
     Layer.newLayerEffectByType = function (layerEffectType) {
         if (layerEffectType === "dropShadow" || layerEffectType === "innerShadow") {

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -854,7 +854,7 @@ define(function (require, exports, module) {
                 } else if (layerIndex < nextIndex.size) {
                     nextIndex = nextIndex.delete(replaceIndex).splice(layerIndex, 0, layerID);
                 } else {
-                    throw new Error ("Replacing a layer but the new layer's index seems out of bounds");
+                    throw new Error("Replacing a layer but the new layer's index seems out of bounds");
                 }
             } else {
                 nextIndex = nextIndex.splice(layerIndex, 0, layerID);

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -274,7 +274,7 @@ define(function (require, exports, module) {
     /**
      * Incorporates artboard templates into the menu and menu actions
      * 
-     * @privates
+     * @private
      * @param {object} menus
      * @param {object} actions
      * @param {Array.<object>} templates

--- a/src/js/models/paragraphstyle.js
+++ b/src/js/models/paragraphstyle.js
@@ -56,8 +56,8 @@ define(function (require, exports, module) {
      * @param {object} paragraphStyleDescriptor
      * @return {ParagraphStyle}
      */
-    ParagraphStyle.fromParagraphStyleDescriptor =
-        function (documentDescriptor, layerDescriptor, paragraphStyleDescriptor) {
+    ParagraphStyle.fromParagraphStyleDescriptor = function (documentDescriptor,
+        layerDescriptor, paragraphStyleDescriptor) {
         var model = {},
             paragraphStyle = paragraphStyleDescriptor.paragraphStyle;
 

--- a/src/js/models/radii.js
+++ b/src/js/models/radii.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
      * Construct a Radii object from the given Photoshop layer descriptor.
      *
      * @param {object} descriptor
-     * @return {Radii}
+     * @return {?Radii}
      */
     Radii.fromLayerDescriptor = function (descriptor) {
         if (!descriptor.keyOriginType || descriptor.keyOriginType.length === 0) {

--- a/src/js/models/shadow.js
+++ b/src/js/models/shadow.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
      * @param {number} x x coordinate in pixels
      * @param {number} y y coordinate in pixels
      *
-     * @return {{distance: number, angle: number}} object containing distance in pixels and angle in degrees
+     * @return {?{distance: number, angle: number}} object containing distance in pixels and angle in degrees
      */
     var _calculatePolarCoords = function (x, y) {
         if (!_.isNumber(x) || !_.isNumber(y)) {

--- a/src/js/stores/application.js
+++ b/src/js/stores/application.js
@@ -212,6 +212,7 @@ define(function (require, exports, module) {
             return this._getNextPrevDocument(false);
         },
         
+        /** @ignore */
         setHostVersion: function (payload) {
             var parts = [
                 payload.versionMajor,

--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
          * consistent type.
          *
          * @private
-         * @return {string}
+         * @return {?string}
          */
         _getCurrentSelectionType: function () {
             var applicationStore = this.flux.store("application"),

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
          * Remove a single document model for the given document ID
          *
          * @private
-         * @param {{documentID: number} payload
+         * @param {{documentID: number}} payload
          */
         _closeDocument: function (payload) {
             var documentID = payload.documentID;
@@ -290,7 +290,7 @@ define(function (require, exports, module) {
          * Reset the given layer models.
          *
          * @private
-         * @param {{documentID: number, layers: Immutable.Iterable.<{layerID: number, descriptor: object}>} payload
+         * @param {{documentID: number, layers: Immutable.Iterable.<{layerID: number, descriptor: object}>}} payload
          */
         _handleLayerReset: function (payload) {
             var documentID = payload.documentID,
@@ -306,7 +306,7 @@ define(function (require, exports, module) {
          * Reset the given layer bounds models.
          *
          * @private
-         * @param {{documentID: number, layers: Immutable.Iterable.<{layerID: number, descriptor: object}>} payload
+         * @param {{documentID: number, layers: Immutable.Iterable.<{layerID: number, descriptor: object}>}} payload
          */
         _handleBoundsReset: function (payload) {
             var documentID = payload.documentID,
@@ -660,7 +660,7 @@ define(function (require, exports, module) {
          * Update the proportional flag of affected layers
          *
          * @private
-         * @param {{documentID: number, layerIDs: Array.<number>, propotional: bool} payload
+         * @param {{documentID: number, layerIDs: Array.<number>, propotional: bool}} payload
          */
         _handleSetLayersProportional: function (payload) {
             var documentID = payload.documentID,
@@ -1044,7 +1044,7 @@ define(function (require, exports, module) {
          * Updates a guide with new information, or creates a new guide
          * 
          * @private
-         * @param {{documentID: number, index: number, guide: object} payload
+         * @param {{documentID: number, index: number, guide: object}} payload
          */
         _handleGuideSet: function (payload) {
             var documentID = payload.documentID,

--- a/src/js/stores/example-one.js
+++ b/src/js/stores/example-one.js
@@ -36,15 +36,21 @@ define(function (require, exports, module) {
                 events.example.SYNC_ACTION, this.setCounter
             );
         },
+
         getState: function () {
             return {
                 time: this.elapsedTime
             };
         },
+        
+        /** @ignore */
         start: function () {
             this.elapsedTime = null;
             this.startTime = new Date().getTime();
         },
+
+        
+        /** @ignore */
         success: function () {
             var stopTime = new Date().getTime();
 
@@ -52,6 +58,8 @@ define(function (require, exports, module) {
             this.startTime = null;
             this.emit("change");
         },
+        
+        /** @ignore */
         fail: function () {
             this.elapsedTime = null;
             this.startTime = null;
@@ -59,6 +67,8 @@ define(function (require, exports, module) {
         },
         startTime: null,
         elapsedTime: null,
+        
+        /** @ignore */
         setCounter: function (payload) {
             var counter = payload.count;
             this.counter = counter;

--- a/src/js/stores/example-two.js
+++ b/src/js/stores/example-two.js
@@ -39,6 +39,8 @@ define(function (require, exports, module) {
             };
         },
         counter: null,
+        
+        /** @ignore */
         setCounter: function () {
             this.waitFor(["example-one"], function (exampleOneStore) {
                 var counter = exampleOneStore.counter;

--- a/src/js/stores/export.js
+++ b/src/js/stores/export.js
@@ -131,7 +131,7 @@ define(function (require, exports, module) {
                 layerIDs = Array.isArray(payload.layerIDs) ? payload.layerIDs : [payload.layerIDs];
 
             if (!documentID) {
-                throw new Error ("Can not update an asset without a valid documentID (%s)", documentID);
+                throw new Error("Can not update an asset without a valid documentID (%s)", documentID);
             }
 
             var curDocumentExports = this.getDocumentExports(documentID) || new DocumentExports(),

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
          * ensures that a document object with an ID exists in state
          *
          * @param {number} documentID
-         * @return {number}
+         * @return {?number}
          */
         lastSavedStateIndex: function (documentID) {
             var savedHistoryIndex = this._saved.get(documentID);
@@ -341,14 +341,14 @@ define(function (require, exports, module) {
             return this._handleHistoryFromPhotoshop(historyPayload);
         },
 
-        /*
-        * Helper function to mine the documentID from the unstructured payload
-        * hope to structure this better in the future
-        *
-        * @private
-        * @param {object}
-        * @return {number}
-        */
+        /**
+         * Helper function to mine the documentID from the unstructured payload
+         * hope to structure this better in the future
+         *
+         * @private
+         * @param {object} payload
+         * @return {number}
+         */
         _getDocumentID: function (payload) {
             if (payload.hasOwnProperty("documentID")) {
                 return payload.documentID;
@@ -427,7 +427,7 @@ define(function (require, exports, module) {
                 newState = new HistoryState({ document: lastSavedDocument });
 
             if (!lastSavedDocument) {
-                throw new Error ("Could not revert using cached history because document model not found");
+                throw new Error("Could not revert using cached history because document model not found");
             }
 
             // push a new history on top of current

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -95,6 +95,7 @@ define(function (require, exports, module) {
             this._isSyncing = false;
         },
 
+        /** @ignore */
         _handleLibrariesUnloaded: function () {
             this._handleReset();
 
@@ -308,10 +309,12 @@ define(function (require, exports, module) {
             return this._libraries.get(this._selectedLibraryID);
         },
 
+        /** @ignore */
         getConnectionStatus: function () {
             return this._serviceConnected;
         },
         
+        /** @ignore */
         isSyncing: function () {
             return this._isSyncing;
         }

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -307,7 +307,7 @@ define(function (require, exports, module) {
             return Immutable.List();
         },
 
-        /*
+        /**
          * Find SVG for item with specified categories 
          * 
          * @param {Array.<string>} categories

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -168,7 +168,8 @@ define(function (require, exports, module) {
             this._headerHeight = 0;
             this._toolbarWidth = 0;
         },
-
+        
+        /** @ignore */
         getState: function () {
             return {
                 transformMatrix: this._transformMatrix,
@@ -180,11 +181,13 @@ define(function (require, exports, module) {
                 marqueeStart: this._marqueeStart
             };
         },
-
+        
+        /** @ignore */
         zoomWindowToCanvas: function (x) {
             return x * this._zoom;
         },
 
+        /** @ignore */
         zoomCanvasToWindow: function (x) {
             return x / this._zoom;
         },
@@ -259,7 +262,7 @@ define(function (require, exports, module) {
          * Get the current cloaking rectangle, which omits the static UI.
          *
          * @private
-         * @return {{top: number, right: number, left: number, bottom: number}}
+         * @return {?{top: number, right: number, left: number, bottom: number}}
          */
         getCloakRect: function () {
             var centerOffsets = this._centerOffsets,

--- a/src/js/tools/ellipse.js
+++ b/src/js/tools/ellipse.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
     var EllipseTool = function () {
         var resetPromise = descriptor.playObject(toolLib.resetShapeTool()),
             firstLaunch = true;
-
+            
+        /** @ignore */
         var selectHandler = function () {
             var defaultPromise;
 

--- a/src/js/tools/sampler.js
+++ b/src/js/tools/sampler.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
     var _currentMouseX,
         _currentMouseY;
 
+    /** @ignore */
     var _mouseMoveHandler = function (event) {
         _currentMouseX = event.location[0];
         _currentMouseY = event.location[1];
@@ -86,6 +87,7 @@ define(function (require, exports, module) {
     };
     util.inherits(SamplerTool, Tool);
 
+    /** @ignore */
     SamplerTool.prototype.onClick = function (event) {
         var flux = this.getFlux(),
             applicationStore = flux.store("application"),

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -199,6 +199,7 @@ define(function (require, exports, module) {
         _spaceKeyDown = false;
     };
 
+    /** @ignore */
     SuperSelectTool.prototype.onClick = function (event) {
         // Prevents clicks from reaching the window and dismissing onWindowClick dialogs
         event.stopPropagation();
@@ -224,7 +225,7 @@ define(function (require, exports, module) {
     /**
      * Handler for keydown events, installed when the tool is active.
      *
-     * @todo  Fix this after keyboard policies are more in place
+     * TODO Fix this after keyboard policies are more in place
      * @param {CustomEvent} event
      */
     SuperSelectTool.prototype.onKeyDown = function (event) {

--- a/src/js/util/layeractions.js
+++ b/src/js/util/layeractions.js
@@ -54,7 +54,7 @@ define(function (require, exports) {
             // discard the -1 values, those are related to selection actions
             if (destinationIndex >= 0) {
                 if (!layerActions.has(destinationIndex)) {
-                    throw new Error ("Could not find index " + destinationIndex + " in layerActions");
+                    throw new Error("Could not find index " + destinationIndex + " in layerActions");
                 }
                 var layerAction = layerActions.get(destinationIndex);
                 if (_.isArray(layerAction.playObject)) {

--- a/src/js/util/math.js
+++ b/src/js/util/math.js
@@ -67,7 +67,7 @@ define(function (require, exports) {
     * Convert a pixel dimension to a number.
     *
     * @param {string} pixelDimension
-    * @return {number}
+    * @return {?number}
     */
     var pixelDimensionToNumber = function (pixelDimension) {
         if (pixelDimension.substr(-2) === "px") {

--- a/src/js/util/object.js
+++ b/src/js/util/object.js
@@ -127,7 +127,7 @@ define(function (require, exports) {
      * Memoize a lookup function.
      * 
      * @param {function()} lookup Un-memoized lookup function.
-     * @return {function()} Memoized lookup function.
+     * @return {{ value: function }} Memoized lookup function.
      */
     var cachedLookupSpec = function (lookup) {
         var privateCacheName = window.Symbol();

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -58,7 +58,7 @@ define(function (require, exports) {
      *
      * @private
      * @param {Array.<string>} categories
-     * @return {string}
+     * @return {?string}
     */
     var getSVGClassFromLayerCategories = function (categories) {
         if (categories.length === 0) {

--- a/test/spec/util/spaces-mock.js
+++ b/test/spec/util/spaces-mock.js
@@ -42,15 +42,15 @@ define(function (require, exports, module) {
 
     /**
      * @private
-     * @type {Array.<{test: function (object): boolean,
-     *  response: {err: ?object, result: object=} | function(object): {err: ?object, result: object=}>}
+     * @type {Array.<object>|function} Array.<{test: function (object): boolean, 
+     * response: {err: ?object, result: object=} or function(object): {err: ?object, result: object=}>
      */
     SpacesMock.prototype._getMocks = null;
 
     /**
      * @private
-     * @type {Array.<{test: function (string, object): boolean,
-     *  response: {err: ?object, result: object=} | function(object): {err: ?object, result: object=}>}
+     * @type {Array.<object>|function} Array.<{test: function (string, object): boolean, 
+     * response: {err: ?object, result: object=} or function(object): {err: ?object, result: object=}>
      */
     SpacesMock.prototype._playMocks = null;
 


### PR DESCRIPTION
**require `npm install`**

This PR fixed the existing jsdoc, to allow us enable the "enforceExistence" option

* corrected wrong jsdoc format
* added @ignore tag to those functions without jsdoc

"enforceExistence" option will not check:

* function(s) within documented function.
* fluxxor and react lifecycle functions (listed in the "enforceExistenceExcept" options).
* functions defined in test files.