### PR TITLE
Update panel sizes when display configuration changes

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -236,6 +236,7 @@ define(function (require, exports) {
      * Parse the panel size information and dispatch the PANELS_RESIZED ui event
      *
      * @private
+     * @param {{toolbarWidth: number=, panelWidth: number=, headerHeight: number=}} sizes
      * @return {Promise}
      */
     var updatePanelSizes = function (sizes) {
@@ -262,19 +263,11 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var updateToolbarWidth = function (toolbarWidth) {
-        return this.dispatchAsync(events.ui.TOOLBAR_PINNED, { toolbarWidth: toolbarWidth })
-            .bind(this)
-            .then(function () {
-                var centerOffsets = this.flux.store("ui").getState().centerOffsets;
-                return adapterUI.setOverlayOffsets(centerOffsets);
-            })
-            .then(function () {
-                this.transfer(setOverlayCloaking);
-            });
+        return this.transfer(updatePanelSizes, { toolbarWidth: toolbarWidth });
     };
     updateToolbarWidth.reads = [];
-    updateToolbarWidth.writes = [locks.JS_UI, locks.PS_APP];
-    updateToolbarWidth.transfers = [setOverlayCloaking];
+    updateToolbarWidth.writes = [];
+    updateToolbarWidth.transfers = [updatePanelSizes];
     updateToolbarWidth.modal = true;
 
     /**

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -122,7 +122,6 @@ define(function (require, exports, module) {
         ui: {
             TRANSFORM_UPDATED: "transformUpdated",
             PANELS_RESIZED: "panelsResized",
-            TOOLBAR_PINNED: "toolbarPinned",
             TOGGLE_OVERLAYS: "toggleOverlays",
             SUPERSELECT_MARQUEE: "superselectMarquee"
         },

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -24,6 +24,8 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var os = require("adapter/os");
+
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
@@ -104,6 +106,8 @@ define(function (require, exports, module) {
 
         /**
          * When the controller is locked, mark the component as inactive.
+         *
+         * @private
          */
         _handleControllerLock: function () {
             this.setState({
@@ -113,11 +117,30 @@ define(function (require, exports, module) {
 
         /**
          * When the controller is unlocked, mark the component as active.
+         *
+         * @private
          */
         _handleControllerUnlock: function () {
             this.setState({
                 active: true
             });
+        },
+
+        /**
+         * Update the sizes of all the panels, including the toolbar.
+         *
+         * @private
+         */
+        _updatePanelSizes: function () {
+            if (this.state.active) {
+                var payload = {
+                    panelWidth: React.findDOMNode(this.refs.panelSet).clientWidth,
+                    headerHeight: React.findDOMNode(this.refs.docHeader).clientHeight,
+                    toolbarWidth: this.refs.toolbar.getToolbarWidth()
+                };
+
+                this.getFlux().actions.ui.updatePanelSizes(payload);
+            }
         },
 
         componentWillMount: function () {
@@ -129,22 +152,21 @@ define(function (require, exports, module) {
             this.props.controller.on("unlock", this._handleControllerUnlock);
         },
 
+        componentDidMount: function () {
+            os.addListener("displayConfigurationChanged", this._updatePanelSizes);
+        },
+
         componentWillUnmount: function () {
             window.document.body.removeEventListener("keydown", this._suppressBodyKeydown);
+            os.removeListener("displayConfigurationChanged", this._updatePanelSizes);
+
             this.props.controller.off("ready", this._handleControllerReady);
             this.props.controller.off("lock", this._handleControllerLock);
             this.props.controller.off("unlock", this._handleControllerUnlock);
         },
 
         componentDidUpdate: function () {
-            if (this.state.active) {
-                var payload = {
-                    panelWidth: React.findDOMNode(this.refs.panelSet).clientWidth,
-                    headerHeight: React.findDOMNode(this.refs.docHeader).clientHeight
-                };
-
-                this.getFlux().actions.ui.updatePanelSizes(payload);
-            }
+            this._updatePanelSizes();
         },
 
         render: function () {
@@ -164,6 +186,7 @@ define(function (require, exports, module) {
                     <Scrim
                         active={this.state.active} />
                     <Toolbar
+                        ref="toolbar"
                         active={this.state.active} />
                     <DocumentHeader
                         ref="docHeader"

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -101,7 +101,9 @@ define(function (require, exports, module) {
 
         componentDidUpdate: function (prevProps, prevState) {
             // NOTE: Special case of going from No Doc state requires update to panel sizes
-            if (!prevState.activeDocument && this.state.activeDocument) {
+            if ((!prevState.activeDocument && this.state.activeDocument) ||
+                prevState[UI.PROPERTIES_COL] !== this.state[UI.PROPERTIES_COL] ||
+                prevState[UI.LAYERS_LIBRARY_COL] !== this.state[UI.LAYERS_LIBRARY_COL]) {
                 var payload = {
                     panelWidth: React.findDOMNode(this.refs.panelSet).clientWidth
                 };

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -134,7 +134,6 @@ define(function (require, exports, module) {
                 events.RESET, this._handleReset,
                 events.ui.TRANSFORM_UPDATED, this._transformUpdated,
                 events.ui.PANELS_RESIZED, this._handlePanelResize,
-                events.ui.TOOLBAR_PINNED, this._handleToolbarPin,
                 events.ui.SUPERSELECT_MARQUEE, this._handleMarqueeStart,
                 events.ui.TOGGLE_OVERLAYS, this._handleOverlayToggle,
                 events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
@@ -416,14 +415,21 @@ define(function (require, exports, module) {
          * Updates the center offsets when they change.
          *
          * @private
-         * @param {{panelWidth: number, headerHeight: number}} payload
+         * @param {{panelWidth: number=, headerHeight: number=, toolbarWidth: number=}} payload
          */
         _handlePanelResize: function (payload) {
-            this._panelWidth = payload.panelWidth;
+            if (payload.hasOwnProperty("panelWidth")) {
+                this._panelWidth = payload.panelWidth;
+            }
+
             if (payload.hasOwnProperty("headerHeight")) {
                 this._headerHeight = payload.headerHeight;
             }
-            
+
+            if (payload.hasOwnProperty("toolbarWidth")) {
+                this._toolbarWidth = payload.toolbarWidth;
+            }
+
             if (this._recalculateCenterOffset()) {
                 this._centerCurrentDocumentOnce();
             }
@@ -463,18 +469,6 @@ define(function (require, exports, module) {
                 this._centeredDocumentIDs.add(currentDocId);
                 this.flux.actions.ui.centerOn({ on: "document", zoomInto: true, preserveFocus: true });
             }
-        },
-
-        /**
-         * Updates the left center offset when toolbar is pinned
-         *
-         * @private
-         * @param {{toolbarWidth: number}} payload
-         */
-        _handleToolbarPin: function (payload) {
-            this._toolbarWidth = payload.toolbarWidth;
-
-            this._recalculateCenterOffset();
         },
 
         /**

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -432,6 +432,7 @@ define(function (require, exports, module) {
 
             if (this._recalculateCenterOffset()) {
                 this._centerCurrentDocumentOnce();
+                this.emit("change");
             }
         },
         


### PR DESCRIPTION
1. Updates panel sizes (and hence the adapter's "overlay offset" state) when the display configuration changes, using the new `displayConfigurationChanged` os event. Addresses #2214.
2. Reduces `updateToolbarWidth` to a helper function that immediately transfers to `updatePanelSizes`. Removes the `TOOLBAR_PINNED` event.
3. Averts an unhandled exception when clicking on the toolbar before any tool is known to be active. Addresses #2156.
4. Correctly updates the toolbar width even when unpinned. Addresses #2265.