### PR TITLE
Get guides in correct order from PS and ask for them on layer moves

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -86,7 +86,6 @@ define(function (require, exports) {
             function (required, optional) {
                 return _.chain(required)
                     .zipWith(optional, _.merge)
-                    .reverse()
                     .value();
             });
     };
@@ -316,10 +315,16 @@ define(function (require, exports) {
     /**
      * Re-gets the guides of the given document and rebuilds the models
      *
-     * @param {Document} document
+     * @param {Document=} document Default is active document
      * @return {Promise}
      */
     var queryCurrentGuides = function (document) {
+        var appStore = this.flux.store("application");
+
+        if (document === undefined) {
+            document = appStore.getCurrentDocument();
+        }
+        
         var docRef = documentLib.referenceBy.id(document.id);
 
         return _getGuidesForDocumentRef(docRef)

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -44,6 +44,7 @@ define(function (require, exports) {
         log = require("js/util/log"),
         events = require("../events"),
         shortcuts = require("./shortcuts"),
+        guides = require("./guides"),
         tools = require("./tools"),
         layerActionsUtil = require("js/util/layeractions"),
         locks = require("js/locks"),
@@ -487,13 +488,17 @@ define(function (require, exports) {
                 } else {
                     this.dispatch(events.document.history.nonOptimistic.RESET_BOUNDS, payload);
                 }
-            }).then(function () {
+            })
+            .then(function () {
+                return this.transfer(guides.queryCurrentGuides);
+            })
+            .then(function () {
                 return this.transfer(tools.resetBorderPolicies);
             });
     };
     resetBounds.reads = [locks.PS_DOC];
     resetBounds.writes = [locks.JS_DOC];
-    resetBounds.transfers = [tools.resetBorderPolicies];
+    resetBounds.transfers = [tools.resetBorderPolicies, guides.queryCurrentGuides];
 
     /** 
      * Transfers to reset bounds, but if there is a failure, quietly fails instead of 


### PR DESCRIPTION
My recent core related guide changes, I introduced a `reverse` call to getGuidesForDocumentRef call... so editing one guide was causing another guide to change.

I also noticed that artboards move their guides with them, but we don't do anything to update the guides. So for now I'm querying all guides on resetBounds calls. In the future this can be done smarter by just asking for that artboards guides if any is moved (I'd like to unblock guides first, and then fix this in a separate issue)

Addresses new gripes in #2144