### PR TITLE
React to Nudge, and fix marquee

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -697,7 +697,7 @@ define(function (require, exports) {
      * Otherwise will add/transfer selection to layers
      *
      * @param {Document} doc Owner document
-     * @param {Array.<number>} ids Layer IDs
+     * @param {?Array.<number>} ids Layer IDs
      * @param {boolean} add Flag to add to or replace selection
      * @return {Promise}
      */

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -703,6 +703,10 @@ define(function (require, exports) {
      */
     var marqueeSelect = function (doc, ids, add) {
         this.dispatch(events.ui.SUPERSELECT_MARQUEE, { enabled: false });
+
+        if (!ids) {
+            return Promise.resolve();
+        }
         
         var layers = Immutable.List(ids.map(doc.layers.byID.bind(doc.layers))),
             modifier = add ? "add" : "select";

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1129,6 +1129,7 @@ define(function (require, exports) {
 
         descriptor.addListener("transform", _layerTransformHandler);
         descriptor.addListener("move", _layerTransformHandler);
+        descriptor.addListener("nudge", _layerTransformHandler);
         descriptor.addListener("editArtboardEvent", _artboardTransformHandler);
         return Promise.resolve();
     };
@@ -1141,6 +1142,7 @@ define(function (require, exports) {
     var onReset = function () {
         descriptor.removeListener("transform", _layerTransformHandler);
         descriptor.removeListener("move", _layerTransformHandler);
+        descriptor.removeListener("nudge", _layerTransformHandler);
         descriptor.removeListener("editArtboardEvent", _artboardTransformHandler);
 
         return Promise.resolve();

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -992,91 +992,6 @@ define(function (require, exports) {
     rotateLayersInCurrentDocument.transfers = [rotate];
 
     /**
-     * Nudges the given layers in the given direction
-     *
-     * @param {string} direction Direction of nudge
-     * @param {boolean} bigStep Flag to indicate bigger nudge
-     *
-     * @return {Promise}
-     */
-    var nudgeLayers = function (direction, bigStep) {
-        // Different from other actions, nudge always makes sure to get the latest document model
-        // Since we rely on the bounds information from the model to compute new positions
-        // Otherwise, superselectTool.onKeyDown's document model and the current document model
-        // can fall out of sync and produce false results, breaking parity
-        var document = this.flux.store("application").getCurrentDocument(),
-            layerSpec = document.layers.selected;
-
-        if (layerSpec.isEmpty()) {
-            return Promise.resolve();
-        }
-
-        var hasLocked = layerSpec.some(function (layer) {
-            return layer.locked;
-        });
-
-        if (hasLocked) {
-            return Promise.resolve();
-        }
-
-        layerSpec = layerSpec.filterNot(function (layer) {
-            return layer.kind === layer.layerKinds.GROUPEND;
-        });
-
-        var options = {
-                historyStateInfo: {
-                    name: strings.ACTIONS.NUDGE_LAYERS,
-                    target: documentLib.referenceBy.id(document.id)
-                }
-            },
-            payload = {
-                documentID: document.id,
-                positions: []
-            },
-            deltaX = 0,
-            deltaY = 0,
-            bigNudge = 10,
-            nudge = 1;
-
-        switch (direction) {
-            case "up":
-                deltaY = bigStep ? -bigNudge : -nudge;
-                break;
-            case "down":
-                deltaY = bigStep ? bigNudge : nudge;
-                break;
-            case "left":
-                deltaX = bigStep ? -bigNudge : -nudge;
-                break;
-            case "right":
-                deltaX = bigStep ? bigNudge : nudge;
-                break;
-        }
-
-        var translateLayerActions = layerSpec.reduce(function (actions, layer) {
-            var currentBounds = document.layers.childBounds(layer),
-                position = {
-                    x: currentBounds.left + deltaX,
-                    y: currentBounds.top + deltaY
-                },
-                layerActions = _getMoveLayerActions.call(this, document, layer, position, payload.positions);
-
-            return actions.concat(layerActions);
-        }, Immutable.List(), this);
-
-        var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.REPOSITION_LAYERS, payload)
-                .bind(this).then(function () {
-                    this.transfer(toolActions.resetBorderPolicies);
-                }),
-            positionPromise = layerActionsUtil.playLayerActions(document, translateLayerActions, true, options);
-        
-        return Promise.join(positionPromise, dispatchPromise);
-    };
-    nudgeLayers.reads = [locks.JS_APP];
-    nudgeLayers.writes = [locks.PS_DOC, locks.JS_DOC];
-    nudgeLayers.transfers = [toolActions.resetBorderPolicies];
-
-    /**
      * Transform event handler initialized in beforeStartup
      *
      * @private
@@ -1172,5 +1087,4 @@ define(function (require, exports) {
     exports.setRadius = setRadius;
     exports.rotate = rotate;
     exports.rotateLayersInCurrentDocument = rotateLayersInCurrentDocument;
-    exports.nudgeLayers = nudgeLayers;
 });

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -49,7 +49,6 @@ define(function (require, exports, module) {
                     BLEND_MODE_CHANGED: "blendModeChanged",
                     REORDER_LAYERS: "reorderLayers",
                     REPOSITION_LAYERS: "repositionLayers",
-                    NUDGE_LAYERS: "nudgeLayers",
                     RESIZE_LAYERS: "resizeLayers",
                     SET_LAYERS_PROPORTIONAL: "setLayersProportional",
                     STROKE_COLOR_CHANGED: "strokeColorChanged",

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -386,11 +386,8 @@ define(function (require, exports, module) {
 
             this._currentMouseDown = false;
 
-            if (this._marqueeRect) {
-                var superselect = this.getFlux().actions.superselect;
-                superselect.marqueeSelect(this.state.document, this._marqueeResult, event.shiftKey);
-                this._marqueeRect = null;
-            }
+            this.getFlux().actions.superselect.marqueeSelect(this.state.document, this._marqueeResult, event.shiftKey);
+            this._marqueeRect = null;
         },
 
         /**

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -24,7 +24,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var _ = require("lodash");
+    var _ = require("lodash"),
+        Promise = require("bluebird");
 
     var util = require("adapter/util"),
         descriptor = require("adapter/ps/descriptor"),
@@ -35,6 +36,7 @@ define(function (require, exports, module) {
     var Tool = require("js/models/tool"),
         VectorTool = require("./superselect/vector"),
         TypeTool = require("./superselect/type"),
+        events = require("js/events"),
         system = require("js/util/system"),
         shortcuts = require("js/util/shortcuts"),
         SuperselectOverlay = require("jsx!js/jsx/tools/SuperselectOverlay"),
@@ -68,10 +70,14 @@ define(function (require, exports, module) {
             };
 
             return descriptor.playObject(toolLib.setToolOptions("moveTool", toolOptions))
+                .bind(this)
                 .then(function () {
-                    UI.setPointerPropagationMode({
-                        defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
-                    });
+                    var propMode = UI.setPointerPropagationMode({
+                            defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
+                        }),
+                        marquee = this.dispatchAsync(events.ui.SUPERSELECT_MARQUEE, { enabled: false });
+
+                    return Promise.join(propMode, marquee);
                 });
         };
 

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -90,13 +90,13 @@ define(function (require, exports, module) {
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.TAB),
             enterKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER),
-            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
-            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
-            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT),
-            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT);
 
         this.keyboardPolicyList = [
@@ -237,8 +237,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        var detail = event.detail,
-            direction = "";
+        var detail = event.detail;
 
         switch (detail.keyCode) {
         case OS.eventKeyCode.ESCAPE: // Escape
@@ -252,23 +251,6 @@ define(function (require, exports, module) {
         case OS.eventKeyCode.ENTER: // Enter
             flux.actions.superselect.diveIn(currentDocument);
             break;
-        case OS.eventKeyCode.ARROW_UP:
-            direction = "up";
-            break;
-        case OS.eventKeyCode.ARROW_DOWN:
-            direction = "down";
-            break;
-        case OS.eventKeyCode.ARROW_LEFT:
-            direction = "left";
-            break;
-        case OS.eventKeyCode.ARROW_RIGHT:
-            direction = "right";
-            break;
-        }
-
-        if (direction !== "") {
-            var bigStep = detail.modifiers.shift;
-            flux.actions.transform.nudgeLayersThrottled(direction, bigStep);
         }
 
         if (detail.keyChar === " ") {


### PR DESCRIPTION
f9a3db3 addresses #2150, and it works. However, PS doesn't always send us ALL the nudge events, so if you want to test it, please download latest Jenkins of pg-dev to get ALL the nudge events.

40c6003 addresses #2301, problem was, I was only finishing marquee select if there was a rectangle being drawn, so for small enough distances / fast mouse events / action not finishing on time, the marquee flag would remain up, and overlays would be broken. Now it's more stable, and we reset the flag on tool select as well (so user can't switch tools while marquee selecting to leave the flag up, darn user!)