### PR TITLE
Toggle overlay cleanup

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -633,8 +633,6 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
-        this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
-
         return this.transfer(selectDocument, nextDocument);
     };
     selectNextDocument.reads = [locks.JS_APP, locks.JS_DOC];
@@ -654,8 +652,6 @@ define(function (require, exports) {
         if (!previousDocument) {
             return Promise.resolve();
         }
-
-        this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
 
         return this.transfer(selectDocument, previousDocument);
     };

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -616,8 +616,6 @@ define(function (require, exports) {
             copyDrag = modifiers.option;
 
         if (panning) {
-            this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
-                        
             var dragEvent = {
                 eventKind: eventKind,
                 location: coordinates,
@@ -672,8 +670,6 @@ define(function (require, exports) {
                                 descriptor.addListener("moveToArtboard", _moveToArtboardListener);
                             }
 
-                            this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
-                            
                             var dragEvent = {
                                 eventKind: eventKind,
                                 location: coordinates,

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1104,14 +1104,13 @@ define(function (require, exports) {
         }, this);
 
         _layerTransformHandler = synchronization.debounce(function (event) {
-            // If it was a simple click/didn't move anything, there is no need to update bounds,
-            // just redraw the overlay
-            if (event.trackerEndedWithoutBreakingHysteresis) {
-                return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-            }
-
             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
-
+            
+            // If it was a simple click/didn't move anything, there is no need to update bounds
+            if (event.trackerEndedWithoutBreakingHysteresis) {
+                return Promise.resolve();
+            }
+            
             var appStore = this.flux.store("application"),
                 currentDoc = appStore.getCurrentDocument(),
                 textLayers = currentDoc.layers.allSelected.filter(function (layer) {

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -129,11 +129,7 @@ define(function (require, exports) {
 
         var setFacePlayObject = textLayerLib.setPostScript(layerRefs, postscript),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
-            setFacePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions);
-                }),
+            setFacePromise = locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions),
             updatePromise = this.transfer(updatePostScript, document, layers, postscript, family, style);
 
         return Promise.join(updatePromise, setFacePromise).bind(this).then(function () {
@@ -189,11 +185,7 @@ define(function (require, exports) {
 
         var setFacePlayObject = textLayerLib.setFace(layerRefs, family, style),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
-            setFacePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions);
-                }),
+            setFacePromise = locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions),
             updatePromise = this.transfer(updateFace, document, layers, family, style);
 
         return Promise.join(updatePromise, setFacePromise).bind(this).then(function () {
@@ -334,11 +326,7 @@ define(function (require, exports) {
 
         var setSizePlayObject = textLayerLib.setSize(layerRefs, size, "px"),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_SIZE, modal),
-            setSizePromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setSizePlayObject, typeOptions);
-                }),
+            setSizePromise = locking.playWithLockOverride(document, layers, setSizePlayObject, typeOptions),
             updatePromise = this.transfer(updateSize, document, layers, size);
 
         return Promise.join(updatePromise, setSizePromise).bind(this).then(function () {
@@ -391,11 +379,7 @@ define(function (require, exports) {
 
         var setTrackingPlayObject = textLayerLib.setTracking(layerRefs, psTracking),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_TRACKING, modal),
-            setTrackingPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setTrackingPlayObject, typeOptions);
-                }),
+            setTrackingPromise = locking.playWithLockOverride(document, layers, setTrackingPlayObject, typeOptions),
             updatePromise = this.transfer(updateTracking, document, layers, tracking);
 
         return Promise.join(updatePromise, setTrackingPromise).bind(this).then(function () {
@@ -452,11 +436,7 @@ define(function (require, exports) {
 
         var setLeadingPlayObject = textLayerLib.setLeading(layerRefs, autoLeading, leading, "px"),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_LEADING, modal),
-            setLeadingPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setLeadingPlayObject, typeOptions);
-                }),
+            setLeadingPromise = locking.playWithLockOverride(document, layers, setLeadingPlayObject, typeOptions),
             updatePromise = this.transfer(updateLeading, document, layers, leading);
 
         return Promise.join(updatePromise, setLeadingPromise).bind(this).then(function () {
@@ -510,11 +490,7 @@ define(function (require, exports) {
         var setAlignmentPlayObject = textLayerLib.setAlignment(layerRefs, alignment),
             typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT,
                 modal, false, options),
-            setAlignmentPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
-                .bind(this)
-                .then(function () {
-                    locking.playWithLockOverride(document, layers, setAlignmentPlayObject, typeOptions);
-                }),
+            setAlignmentPromise = locking.playWithLockOverride(document, layers, setAlignmentPlayObject, typeOptions),
             transferPromise = this.transfer(updateAlignment, document, layers, alignment);
 
         return Promise.join(transferPromise, setAlignmentPromise).bind(this).then(function () {

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -468,7 +468,6 @@ define(function (require, exports) {
 
         // Handles spacebar + drag, scroll and window resize events
         _scrollHandler = function (event) {
-            this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
             setTransformDebounced(event);
         }.bind(this);
         descriptor.addListener("scroll", _scrollHandler);


### PR DESCRIPTION
Back in #1960, when we had on canvas transform, we had to toggle the overlays for a lot of actions ourselves. But with the invention of cloaking technology, and us drawing transform through Photoshop, most of those toggles became obsolete...

Simple code clean up, removed it where it didn't make a difference.