### PR TITLE
On no-selection, don't shift zoom center.

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -354,7 +354,7 @@ define(function (require, exports) {
                 }
                 break;
             case "document":
-                targetBounds = currentDoc.bounds;
+                targetBounds = currentDoc.visibleBounds;
                 break;
             default:
                 throw new Error("Unexpected 'on' value");

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -172,5 +172,21 @@ define(function (require, exports, module) {
         return this.set("bounds", this.bounds.updateSize(x, y, proportional));
     };
 
+    Object.defineProperties(Document.prototype, object.cachedGetSpecs({
+        /**
+         * If document has any artboards, it's the union of all top layers bounds
+         * otherwise it's document bounds
+         * 
+         * @type {Bounds}
+         */
+        "visibleBounds": function () {
+            if (this.layers.hasArtboard) {
+                return this.layers.overallBounds;
+            } else {
+                return this.bounds;
+            }
+        }
+    }));
+
     module.exports = Document;
 });

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -296,6 +296,31 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Bounds of all the top layers
+         * @type {Immutable.List.<Bounds>}
+         */
+        "topBounds": function () {
+            return this.top
+                .toSeq()
+                .map(function (layer) {
+                    return this.childBounds(layer);
+                }, this)
+                .filter(function (bounds) {
+                    return bounds && bounds.area > 0;
+                })
+                .toList();
+        },
+
+        /**
+         * Overall bounds of all the layers in the structure
+         *
+         * @return {Bounds}
+         */
+        "overallBounds": function () {
+            return Bounds.union(this.topBounds);
+        },
+
+        /**
          * The set of artboards in the document
          * @type {Immutable.List.<Layer>}
          */

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -341,7 +341,6 @@
             "$action": "ui.zoom",
             "$payload": {
                 "zoom": 1,
-                "pan": true,
                 "preserveFocus": true
             },
             "$enable-rule": "have-document"


### PR DESCRIPTION
If there is no selection during zoom in/out, we keep the center fixed and zoom out/in correctly.

Addresses #661, and possibly couple other zoom bugs that I will add as I see them.
#2206
#2169
#1081
#1709
@iwehrman You sic'ed me on this, you review it :)