### PR TITLE
Don't reposition newly selected documents

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -54,7 +54,7 @@ define(function (require, exports) {
     /**
      * Execute a native Photoshop menu command.
      * 
-     * @param {{commandID: number, waitForCompletion: boolean?}} payload
+     * @param {{commandID: number, waitForCompletion: boolean=}} payload
      * @return {Promise}
      */
     var native = function (payload) {

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -348,18 +348,25 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
+        var selection;
         switch (payload.on) {
-            case "selection":
-                targetBounds = currentDoc.layers.selectedAreaBounds;
-                if (!targetBounds || targetBounds.empty) {
-                    targetBounds = currentDoc.bounds;
-                }
-                break;
-            case "document":
+        case "selection":
+            selection = true;
+            break;
+        case "document":
+            selection = false;
+            break;
+        default:
+            selection = !currentDoc.layers.selected.isEmpty();
+        }
+
+        if (selection) {
+            targetBounds = currentDoc.layers.selectedAreaBounds;
+            if (!targetBounds || targetBounds.empty) {
                 targetBounds = currentDoc.visibleBounds;
-                break;
-            default:
-                throw new Error("Unexpected 'on' value");
+            }
+        } else {
+            targetBounds = currentDoc.visibleBounds;
         }
 
         return this.transfer(centerBounds, targetBounds, payload.zoomInto);

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -30,6 +30,8 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         Immutable = require("immutable"),
         classnames = require("classnames");
+
+    var os = require("adapter/os");
     
     var DocumentHeaderTab = require("jsx!js/jsx/DocumentHeaderTab");
 
@@ -55,6 +57,26 @@ define(function (require, exports, module) {
                 documentIDs: documentIDs,
                 count: count
             };
+        },
+
+        /**
+         * Update the sizes of the panels.
+         *
+         * @private
+         */
+        _updatePanelSizes: function () {
+            var node = React.findDOMNode(this.refs.tabContainer),
+                headerHeight;
+
+            if (node) {
+                headerHeight = node.getBoundingClientRect().height;
+            } else {
+                headerHeight = 0;
+            }
+
+            this.getFlux().actions.ui.updatePanelSizes({
+                headerHeight: headerHeight
+            });
         },
 
         /** @ignore */
@@ -85,11 +107,15 @@ define(function (require, exports, module) {
             this.setState({
                 headerWidth: React.findDOMNode(this).clientWidth
             });
+
+            os.addListener("displayConfigurationChanged", this._updatePanelSizes);
+            this._updatePanelSizes();
             
             window.addEventListener("resize", this._handleWindowResize);
         },
         
         componentWillUnmount: function () {
+            os.removeListener("displayConfigurationChanged", this._updatePanelSizes);
             window.removeEventListener("resize", this._handleWindowResize);
         },
 

--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React),
+        classnames = require("classnames");
+
+    var os = require("adapter/os");
+
+    var Button = require("jsx!js/jsx/shared/Button"),
+        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
+        menu = require("i18n!nls/menu");
+
+    var PanelSet = React.createClass({
+        mixins: [FluxMixin],
+        
+        /**
+         * Update the sizes of the panels.
+         *
+         * @private
+         */
+        _updatePanelSizes: function () {
+            var node = React.findDOMNode(this),
+                iconBarWidth;
+
+            if (node) {
+                iconBarWidth = node.getBoundingClientRect().width;
+            } else {
+                iconBarWidth = 0;
+            }
+
+            this.getFlux().actions.ui.updatePanelSizes({
+                iconBarWidth: iconBarWidth
+            });
+        },
+
+        componentDidMount: function () {
+            os.addListener("displayConfigurationChanged", this._updatePanelSizes);
+            this._updatePanelSizes();
+        },
+
+        componentWillUnmount: function () {
+            os.removeListener("displayConfigurationChanged", this._updatePanelSizes);
+        },
+
+        render: function () {
+            var panelTabBarClassNames = classnames({
+                "panel__tab-bar": true,
+                "panel__tab-bar__visible": true
+            });
+
+            return (
+                <div className={panelTabBarClassNames}>
+                    <Button
+                        className="toolbar__backToPs"
+                        title={menu.WINDOW.RETURN_TO_STANDARD}
+                        onClick={this._handleBackToPSClick}>
+                        <SVGIcon
+                            viewbox="0 0 18 16"
+                            CSSID="workspace" />
+                    </Button>
+                    {this.props.children}
+                </div>
+            );
+        },
+            
+        /**
+         * Close Design Space
+         *
+         * @private
+         */
+        _handleBackToPSClick: function () {
+            this.getFlux().actions.menu.native({ commandID: 5999 });
+        }
+    });
+
+    module.exports = PanelSet;
+});

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -24,8 +24,6 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var os = require("adapter/os");
-
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
@@ -126,23 +124,6 @@ define(function (require, exports, module) {
             });
         },
 
-        /**
-         * Update the sizes of all the panels, including the toolbar.
-         *
-         * @private
-         */
-        _updatePanelSizes: function () {
-            if (this.state.active) {
-                var payload = {
-                    panelWidth: React.findDOMNode(this.refs.panelSet).clientWidth,
-                    headerHeight: React.findDOMNode(this.refs.docHeader).clientHeight,
-                    toolbarWidth: this.refs.toolbar.getToolbarWidth()
-                };
-
-                this.getFlux().actions.ui.updatePanelSizes(payload);
-            }
-        },
-
         componentWillMount: function () {
             window.document.body.addEventListener("keydown", this._suppressBodyKeydown, true);
 
@@ -152,21 +133,12 @@ define(function (require, exports, module) {
             this.props.controller.on("unlock", this._handleControllerUnlock);
         },
 
-        componentDidMount: function () {
-            os.addListener("displayConfigurationChanged", this._updatePanelSizes);
-        },
-
         componentWillUnmount: function () {
             window.document.body.removeEventListener("keydown", this._suppressBodyKeydown);
-            os.removeListener("displayConfigurationChanged", this._updatePanelSizes);
 
             this.props.controller.off("ready", this._handleControllerReady);
             this.props.controller.off("lock", this._handleControllerLock);
             this.props.controller.off("unlock", this._handleControllerUnlock);
-        },
-
-        componentDidUpdate: function () {
-            this._updatePanelSizes();
         },
 
         render: function () {

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -111,8 +111,10 @@ define(function (require, exports, module) {
                     flux.actions.tools.select(defaultTool);
                 }
             }
+        },
 
-            if (this.state.pinned !== nextState.pinned) {
+        componentDidUpdate: function (prevProps, prevState) {
+            if (prevState.pinned !== this.state.pinned) {
                 this._updateToolbarWidth();
             }
         },
@@ -228,7 +230,7 @@ define(function (require, exports, module) {
             }
 
             var toolbarNode = React.findDOMNode(this);
-            return toolbarNode ? toolbarNode.clientWidth : 0;
+            return toolbarNode ? toolbarNode.getBoundingClientRect().width : 0;
         },
 
         /**

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -69,6 +69,11 @@ define(function (require, exports, module) {
         
         componentDidMount: function () {
             this._drawDebounced();
+            window.addEventListener("resize", this._drawDebounced);
+        },
+
+        componentWillUnmount: function () {
+            window.removeEventListener("resize", this._drawDebounced);
         },
 
         componentDidUpdate: function () {

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -196,7 +196,9 @@ define(function (require, exports, module) {
             var documentID = payload.documentID;
 
             delete this._openDocuments[documentID];
-            this.emit("change");
+            
+            // Don't emit a change event here because the application store is
+            // what should be used to monitor the set of currently open documents.
         },
 
         /**

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -119,15 +119,7 @@ define(function (require, exports, module) {
          * @type {number}
          */
         _toolbarWidth: null,
-        
-        /**
-         * A set of unique document IDs that are centered after panel resized. If a document's id is not in the set,
-         * it will be centered when it is selected.
-         *
-         * @private
-         * @type {Set.<number>}
-         */
-        _centeredDocumentIDs: null,
+    
 
         initialize: function () {
             this.bindActions(
@@ -139,9 +131,7 @@ define(function (require, exports, module) {
                 events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
                 events.document.RESET_LAYERS, this._handleLayersUpdated,
                 events.document.RESET_BOUNDS, this._handleLayersUpdated,
-                events.document.history.nonOptimistic.RESET_BOUNDS, this._handleLayersUpdated,
-                events.document.SELECT_DOCUMENT, this._handleSelectDocument,
-                events.document.CLOSE_DOCUMENT, this._handleCloseDocument
+                events.document.history.nonOptimistic.RESET_BOUNDS, this._handleLayersUpdated
             );
 
             this._handleReset();
@@ -161,7 +151,6 @@ define(function (require, exports, module) {
             this._centerOffsets = null;
             this._transformMatrix = null;
             this._inverseTransformMatrix = null;
-            this._centeredDocumentIDs = new Set();
 
             this._panelWidth = 0;
             this._headerHeight = 0;
@@ -431,44 +420,7 @@ define(function (require, exports, module) {
             }
 
             if (this._recalculateCenterOffset()) {
-                this._centerCurrentDocumentOnce();
                 this.emit("change");
-            }
-        },
-        
-        /**
-         * Center the selected document if panel-resize event occurse. 
-         * 
-         * @private
-         */
-        _handleSelectDocument: function () {
-            this.waitFor(["application"], function () {
-                this._centerCurrentDocumentOnce();
-            });
-        },
-        
-        /**
-         * Handle document close by removing its ID from centered documents list.
-         * 
-         * @private
-         * @param {{documentID: number}} payload
-         */
-        _handleCloseDocument: function (payload) {
-            this._centeredDocumentIDs.delete(payload.documentID);
-        },
-        
-        /**
-         * Center the selected document once.
-         *
-         * @private
-         */
-        _centerCurrentDocumentOnce: function () {
-            var applicationStore = this.flux.store("application"),
-                currentDocId = applicationStore.getCurrentDocumentID();
-            
-            if (currentDocId && !this._centeredDocumentIDs.has(currentDocId)) {
-                this._centeredDocumentIDs.add(currentDocId);
-                this.flux.actions.ui.centerOn({ on: "document", zoomInto: true, preserveFocus: true });
             }
         },
 

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -24,12 +24,29 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var Fluxxor = require("fluxxor"),
-        _ = require("lodash");
+    var Fluxxor = require("fluxxor");
     
     var events = require("../events"),
         log = require("js/util/log"),
         math = require("js/util/math");
+
+    /**
+     * Panel/column identifiers.
+     *
+     * @const
+     * @type {object}
+     */
+    var UI_COMPONENTS = Object.freeze({
+        LAYERS_LIBRARY_COL: "layersLibrariesVisible",
+        PROPERTIES_COL: "propertiesVisible",
+        TRANSFORM_PANEL: "transformVisible",
+        STYLES_PANEL: "stylesVisible",
+        APPEARANCE_PANEL: "appearanceVisible",
+        EFFECTS_PANEL: "effectsVisible",
+        EXPORT_PANEL: "exportVisible",
+        LAYERS_PANEL: "layersVisible",
+        LIBRARIES_PANEL: "libraryVisible"
+    });
 
     var UIStore = Fluxxor.createStore({
 
@@ -56,13 +73,6 @@ define(function (require, exports, module) {
          * @type {Number}
          */
         _zoom: null,
-
-        /**
-         * Center offsets to be applied to zoom calculations
-         *
-         * @type {{top: number, left: number, bottom: number, right: number}}
-         */
-        _centerOffsets: null,
 
         /**
          * Flag to tell whether Scrim should draw any of the SVG overlays or not
@@ -103,6 +113,14 @@ define(function (require, exports, module) {
          * @type {number}
          */
         _panelWidth: null,
+
+        /**
+         * Icon bar width
+         *
+         * @private
+         * @type {number}
+         */
+        _iconBarWidth: null,
         
         /**
          * Document header height
@@ -119,7 +137,14 @@ define(function (require, exports, module) {
          * @type {number}
          */
         _toolbarWidth: null,
-    
+
+        /**
+         * Constants used to refer to different panels/columns.
+         * 
+         * @const
+         * @type {object}
+         */
+        components: UI_COMPONENTS,
 
         initialize: function () {
             this.bindActions(
@@ -148,11 +173,12 @@ define(function (require, exports, module) {
             this._marqueeEnabled = false;
             this._marqueeStart = null;
             this._zoom = null;
-            this._centerOffsets = null;
             this._transformMatrix = null;
             this._inverseTransformMatrix = null;
 
             this._panelWidth = 0;
+            this._columnCount = 0;
+            this._iconBarWidth = 0;
             this._headerHeight = 0;
             this._toolbarWidth = 0;
         },
@@ -163,7 +189,7 @@ define(function (require, exports, module) {
                 transformMatrix: this._transformMatrix,
                 inverseTransformMatrix: this._inverseTransformMatrix,
                 zoomFactor: this._zoom,
-                centerOffsets: this._centerOffsets,
+                centerOffsets: this.getCenterOffsets(),
                 overlaysEnabled: this._overlaysEnabled,
                 marqueeEnabled: this._marqueeEnabled,
                 marqueeStart: this._marqueeStart
@@ -247,19 +273,44 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Calculate the overlay offsets, optionally taking into account a
+         * (future) number of open columns.
+         *
+         * @return {{top: number, right: number, bottom: number, left: number}}
+         */
+        getCenterOffsets: function (columns) {
+            var right = this._iconBarWidth;
+
+            if (columns === undefined || columns === this._columnCount) {
+                right += this._panelWidth;
+            } else if (columns > 0) {
+                if (columns === 1 && this._columnCount === 2) {
+                    right += (this._panelWidth / 2);
+                } else if (columns === 2 && this._columnCount === 1) {
+                    right += (this._panelWidth * 2);
+                } else {
+                    log.warn("Unable to infer enter offsets for " + columns +
+                        " columns from " + this._columnCount);
+                }
+            }
+
+            return {
+                top: this._headerHeight,
+                right: right,
+                left: this._toolbarWidth,
+                bottom: 0
+            };
+        },
+
+        /**
          * Get the current cloaking rectangle, which omits the static UI.
          *
-         * @private
          * @return {?{top: number, right: number, left: number, bottom: number}}
          */
         getCloakRect: function () {
-            var centerOffsets = this._centerOffsets,
+            var centerOffsets = this.getCenterOffsets(),
                 windowWidth = window.document.body.clientWidth,
                 windowHeight = window.document.body.clientHeight;
-
-            if (!centerOffsets) {
-                return null;
-            }
             
             return {
                 left: centerOffsets.left,
@@ -377,49 +428,39 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Recalculates center offset given all the HTML panel sizes. 
-         *
-         * @private
-         * @return {boolean} true if the offset is updated
-         */
-        _recalculateCenterOffset: function () {
-            var nextCenterOffsets = {
-                top: this._headerHeight,
-                right: this._panelWidth,
-                left: this._toolbarWidth,
-                bottom: 0
-            };
-            
-            if (_.isEqual(this._centerOffsets, nextCenterOffsets)) {
-                return false;
-            }
-            
-            this._centerOffsets = nextCenterOffsets;
-            return true;
-            
-            // We don't emit offset change because we don't react to it
-        },
-
-        /**
          * Updates the center offsets when they change.
          *
          * @private
          * @param {{panelWidth: number=, headerHeight: number=, toolbarWidth: number=}} payload
          */
         _handlePanelResize: function (payload) {
-            if (payload.hasOwnProperty("panelWidth")) {
+            var changed;
+            if (payload.hasOwnProperty("panelWidth") && payload.panelWidth !== this._panelWidth) {
                 this._panelWidth = payload.panelWidth;
+                changed = true;
             }
 
-            if (payload.hasOwnProperty("headerHeight")) {
+            if (payload.hasOwnProperty("columnCount") && payload.columnCount !== this._columnCount) {
+                this._columnCount = payload.columnCount;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("iconBarWidth") && payload.iconBarWidth !== this._iconBarWidth) {
+                this._iconBarWidth = payload.iconBarWidth;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("headerHeight") && payload.headerHeight !== this._headerHeight) {
                 this._headerHeight = payload.headerHeight;
+                changed = true;
             }
 
-            if (payload.hasOwnProperty("toolbarWidth")) {
+            if (payload.hasOwnProperty("toolbarWidth") && payload.toolbarWidth !== this._toolbarWidth) {
                 this._toolbarWidth = payload.toolbarWidth;
+                changed = true;
             }
 
-            if (this._recalculateCenterOffset()) {
+            if (changed) {
                 this.emit("change");
             }
         },

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -348,20 +348,18 @@
         "ZOOM_TO_SELECTION": {
             "$action": "ui.centerOn",
             "$payload": {
-                "on": "selection",
                 "zoomInto": true,
                 "preserveFocus": true
             },
-            "$enable-rule": "layer-selected"
+            "$enable-rule": "have-document"
         },
         "CENTER_SELECTION": {
             "$action": "ui.centerOn",
             "$payload": {
-                "on": "selection",
                 "zoomInto": false,
                 "preserveFocus": true
             },
-            "$enable-rule": "layer-selected"
+            "$enable-rule": "have-document"
         },
         "TOGGLE_GUIDES": {
             "$action": "documents.toggleGuidesVisibility",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -44,20 +44,14 @@
             "$enable-rule": "always-except-modal"
         },
         "NEW_EXTENDED": {
-            "$action": "menu.native",
-            "$payload": {
-                "commandID": 10
-            },
+            "$action": "documents.createNewExtended",
             "$enable-rule": "always-except-modal"
         },
         "NEW_FROM_TEMPLATE": {
             "$enable-rule": "always-except-modal"
         },
         "OPEN": {
-            "$action": "menu.native",
-            "$payload": {
-                "commandID": 20
-            },
+            "$action": "documents.open",
             "$enable-rule": "always-except-modal"
         },
         "CLOSE": {

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -52,6 +52,7 @@
 .panel-set__container {
     height: 100%;
     max-height: 100%;
+    display: flex;
 }
 
 .panel__tab-bar {
@@ -61,8 +62,7 @@
     display: none;
 }
 
-.panel__visible + .panel__tab-bar,
-.panel__visible + .panel + .panel__tab-bar {
+.panel__tab-bar {
     width: @toolbar-button-size + 0.2rem;
     border-left: 0.2rem solid @bg-border;
 }


### PR DESCRIPTION
1. Do not manually reposition documents on first selection. Instead, either leave the documents where they already are, or let Photoshop position the canvas using the overlay offsets.
2. Enable Zoom to Selection and Center Selection for the document when no layers are selected.

Addresses #1999 and #1081.

Note that a document opened in Design Space when there are currently no open documents will be positioned incorrectly because the panel bounds aren't currently updated until _after_ the first document is open. I intend to address that in this PR as well, but it doesn't work yet. So, I'm putting this up for review/testing first (by @placegraphichere) to make sure that, besides the first-doc behavior, this is an improvement. 