### PR TITLE
CC Libraries - support open-for-edit for graphic assets.

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -676,6 +676,40 @@ define(function (require, exports) {
     exportDocumentAssets.reads = [locks.JS_DOC, locks.JS_EXPORT];
     exportDocumentAssets.writes = [locks.GENERATOR];
     exportDocumentAssets.transfers = [promptForFolder, updateExportAsset];
+    
+    /**
+     * Copy file from one location to another.
+     *
+     * @param {string} sourcePath
+     * @param {string} targetPath
+     * @return {Promise} 
+     */
+    var copyFile = function (sourcePath, targetPath) {
+        if (!_exportService || !_exportService.ready()) {
+            return _setServiceAvailable.call(this, false);
+        }
+
+        return _exportService.copyFile(sourcePath, targetPath);
+    };
+    copyFile.reads = [];
+    copyFile.writes = [locks.GENERATOR];
+    
+    /**
+     * Remove files at specific locations.
+     *
+     * @param {Array.<string>} filePaths
+     * @return {Promise}
+     */
+    var removeFiles = function (filePaths) {
+        if (!_exportService || !_exportService.ready()) {
+            return _setServiceAvailable.call(this, false);
+        }
+
+        return _exportService.removeFiles(filePaths);
+    };
+    removeFiles.reads = [];
+    removeFiles.writes = [locks.GENERATOR];
+>>>>>>> Add export actions for libraries: copyFile & removeFiles.
 
     /**
      * After start up, ensure that generator is enabled, and then initialize the export service
@@ -796,5 +830,9 @@ define(function (require, exports) {
     exports.exportLayerAssets = exportLayerAssets;
     exports.exportDocumentAssets = exportDocumentAssets;
     exports.afterStartup = afterStartup;
+    
+    exports.copyFile = copyFile;
+    exports.removeFiles = removeFiles;
+
     exports.onReset = onReset;
 });

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -695,21 +695,20 @@ define(function (require, exports) {
     copyFile.writes = [locks.GENERATOR];
     
     /**
-     * Remove files at specific locations.
+     * Delete files at specific locations.
      *
      * @param {Array.<string>} filePaths
      * @return {Promise}
      */
-    var removeFiles = function (filePaths) {
+    var deleteFiles = function (filePaths) {
         if (!_exportService || !_exportService.ready()) {
             return _setServiceAvailable.call(this, false);
         }
 
-        return _exportService.removeFiles(filePaths);
+        return _exportService.deleteFiles(filePaths);
     };
-    removeFiles.reads = [];
-    removeFiles.writes = [locks.GENERATOR];
->>>>>>> Add export actions for libraries: copyFile & removeFiles.
+    deleteFiles.reads = [];
+    deleteFiles.writes = [locks.GENERATOR];
 
     /**
      * After start up, ensure that generator is enabled, and then initialize the export service
@@ -832,7 +831,7 @@ define(function (require, exports) {
     exports.afterStartup = afterStartup;
     
     exports.copyFile = copyFile;
-    exports.removeFiles = removeFiles;
+    exports.deleteFiles = deleteFiles;
 
     exports.onReset = onReset;
 });

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -169,11 +169,17 @@ define(function (require, exports, module) {
             ASSET_CREATED: "libraryAssetCreated",
             ASSET_REMOVED: "libraryAssetRemoved",
             ASSET_RENAMED: "libraryAssetRenamed",
+            OPEN_GRAPHIC_FOR_EDIT: "libraryOpenGraphicForEdit",
+            UPDATING_GRAPHIC_CONTENT: "libraryUpdatingGraphicContent",
+            UPDATED_GRAPHIC_CONTENT: "libraryUpdatedGraphicContent",
+            CLOSED_GRAPHIC_DOCUMENT: "libraryClosedGraphicDocument",
+            DELETED_GRAPHIC_TEMP_FILES: "libraryDeletedGraphicTempFiles",
             LIBRARY_CREATED: "libraryCreated",
             LIBRARY_REMOVED: "libraryRemoved",
             LIBRARY_RENAMED: "libraryRenamed",
             LIBRARY_SELECTED: "librarySelected",
-            SYNC_LIBRARIES: "syncLibraries"
+            SYNC_LIBRARIES: "librarySyncLibraries",
+            SYNCING_LIBRARIES: "librarySyncingLibraries"
         },
         search: {
             REGISTER_SEARCH_PROVIDER: "registerSearchProvider"

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
         }
 
         return promise.then(function () {
-            flux.actions.libraries.createElementFromSelectedLayer();
+            flux.actions.libraries.createGraphicFromSelectedLayer();
         });
     };
 

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
          * @private
          */
         addGraphic: function () {
-            this.getFlux().actions.libraries.createElementFromSelectedLayer();
+            this.getFlux().actions.libraries.createGraphicFromSelectedLayer();
         },
 
         /**

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -76,6 +76,15 @@ define(function (require, exports, module) {
                 this.setState({ renditionPath: renditionPath });
             }
         },
+            
+        /**
+         * Open the selected asset in Photoshop for edit.
+         *
+         * @private
+         */
+        _handleOpenForEdit: function () {
+            this.getFlux().actions.libraries.openGraphicForEdit(this.props.element);
+        },
 
         render: function () {
             var element = this.props.element,
@@ -88,9 +97,10 @@ define(function (require, exports, module) {
 
             return (
                 <div className={classNames}
-                     key={element.id}
-                     onMouseDown={this.props.handleDragStart}>
-                    <div className="libraries__asset__preview libraries__asset__preview-graphic">
+                     key={element.id}>
+                    <div className="libraries__asset__preview libraries__asset__preview-graphic"
+                         onMouseDown={this.props.handleDragStart}
+                         onDoubleClick={this._handleOpenForEdit}>
                         <AssetPreviewImage
                             element={this.props.element}
                             onComplete={this._handlePreviewCompleted}/>

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -576,6 +576,24 @@ define(function (require, exports, module) {
             return smartObjectTypes.LOCAL_LINKED;
         }
     };
+    
+    /**
+     * Return true if the layer is a smart object that links to a CC Libiraries element.
+     * 
+     * @return {boolean}
+     */
+    Layer.prototype.isCloudLinkedSmartObject = function () {
+        return this.smartObjectType() === smartObjectTypes.CLOUD_LINKED;
+    };
+    
+    /**
+     * Return the reference of the layer's linked CC Libraries element. 
+     * 
+     * @return {?string}
+     */
+    Layer.prototype.getLibraryElementReference = function () {
+        return this.isCloudLinkedSmartObject() ? this.smartObject.link.elementReference : null;
+    };
 
     module.exports = Layer;
 });

--- a/src/js/stores/preferences.js
+++ b/src/js/stores/preferences.js
@@ -153,6 +153,11 @@ define(function (require, exports, module) {
                 value = payload.value;
 
             try {
+                // Skip if the value remains unchanged, to avoid emitting unnecessary change event.
+                if (this._preferences.get(key) === value) {
+                    return;
+                }
+                
                 var valueJSON = JSON.stringify(value),
                     qualifiedKey = _getQualifiedKey(key);
 

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -165,6 +165,27 @@ define(function (require, exports, module) {
                 return Promise.resolve();
             });
     };
+    
+    /**
+     * Copy file from one location to another.
+     *
+     * @param {string} sourcePath
+     * @param {string} targetPath
+     * @return {Promise} 
+     */
+    ExportService.prototype.copyFile = function (sourcePath, targetPath) {
+        return this._spacesDomain.exec("copyFile", { source: sourcePath, target: targetPath });
+    };
+    
+    /**
+     * Remove files at specific locations.
+     *
+     * @param {Array.<string>} filePaths
+     * @return {Promise}
+     */
+    ExportService.prototype.removeFiles = function (filePaths) {
+        return this._spacesDomain.exec("removeFiles", { filePaths: filePaths });
+    };
 
     /**
      * The preference key of the generator domain, used to find the port number stored in photoshop

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -178,13 +178,13 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Remove files at specific locations.
+     * Delete files at specific locations.
      *
      * @param {Array.<string>} filePaths
      * @return {Promise}
      */
-    ExportService.prototype.removeFiles = function (filePaths) {
-        return this._spacesDomain.exec("removeFiles", { filePaths: filePaths });
+    ExportService.prototype.deleteFiles = function (filePaths) {
+        return this._spacesDomain.exec("deleteFiles", { filePaths: filePaths });
     };
 
     /**


### PR DESCRIPTION
**require changes from the adapter and generator-space plugin, see bottom for setting up generator-space plugin**

This PR implements open-for-edit for graphic assets. You can double click on graphic asset's thumbnail to open the asset for editing. Some notes:

* currently it only supports edit PSD file. The other file types require features that are not supported in DS yet.
* switching back to standard PS will break the upload-after-save feature, but switch from standard PS to DS will maintain the functionality.
* Close document will delete the temp files.

It also fix #1408 Closing Library Linked Smart Object blinks zero-doc state.

![lib-edit](https://cloud.githubusercontent.com/assets/118264/9689208/61c790fa-52e9-11e5-8b61-cbbd98c988fc.gif)

@volfied please review. 
@mcilroyc I made the change to import the file system commands, so could you review this PR?

#### setup the generator-space plugin

```
Run latest PS dev build (> 594)
```
or
```
cd PROJECTS
git clone git@github.com:adobe-photoshop/generator-spaces.git
cd generator-spaces
git checkout shao/filesystem
npm install

cd PS-DEV/Adobe\ Photoshop\ CC\ 2015.app
rm -rf Contents/Required/Plug-Ins/Generator/spaces.generate/
ln -s PROJECTS/generator-spaces Contents/Required/Plug-Ins/Generator/spaces.generate
RESTART PS-DEV
```