### PR TITLE
Implement clear guides menu item and action

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -313,6 +313,36 @@ define(function (require, exports) {
     setGuide.transfers = [resetGuidePolicies, deleteGuide];
 
     /**
+     * Clears all the guides in the given document
+     *
+     * @param {{id: number}} document Document model or an object containing document ID
+     * @return {Promise}
+     */
+    var clearGuides = function (document) {
+        if (document === undefined) {
+            var appStore = this.flux.store("application");
+
+            document = appStore.getCurrentDocument();
+        }
+
+        var payload = {
+                documentID: document.id
+            },
+            clearObj = documentLib.clearGuides(documentLib.referenceBy.id(document.id)),
+            dispatchPromise = this.dispatchAsync(events.document.history.nonOptimistic.GUIDES_CLEARED, payload),
+            clearPromise = descriptor.playObject(clearObj);
+
+        return Promise.join(dispatchPromise, clearPromise)
+            .bind(this)
+            .then(function () {
+                return this.transfer(resetGuidePolicies);
+            });
+    };
+    clearGuides.reads = [];
+    clearGuides.writes = [locks.JS_DOC];
+    clearGuides.transfers = [resetGuidePolicies];
+
+    /**
      * Re-gets the guides of the given document and rebuilds the models
      *
      * @param {Document=} document Default is active document
@@ -416,6 +446,7 @@ define(function (require, exports) {
     exports.deleteGuide = deleteGuide;
     exports.resetGuidePolicies = resetGuidePolicies;
     exports.queryCurrentGuides = queryCurrentGuides;
+    exports.clearGuides = clearGuides;
 
     exports.beforeStartup = beforeStartup;
     exports.onReset = onReset;

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -315,7 +315,7 @@ define(function (require, exports) {
     /**
      * Clears all the guides in the given document
      *
-     * @param {{id: number}} document Document model or an object containing document ID
+     * @param {Document=} document Document model
      * @return {Promise}
      */
     var clearGuides = function (document) {
@@ -339,7 +339,7 @@ define(function (require, exports) {
             });
     };
     clearGuides.reads = [];
-    clearGuides.writes = [locks.JS_DOC];
+    clearGuides.writes = [locks.JS_DOC, locks.PS_DOC];
     clearGuides.transfers = [resetGuidePolicies];
 
     /**

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -70,6 +70,7 @@ define(function (require, exports, module) {
                     COMBINE_SHAPES: "combineShapes",
                     DELETE_LAYERS: "deleteLayersNonOptimistic", // eg: ps deletes the entire layer after last path del,
                     GUIDE_SET: "guideSet",
+                    GUIDES_CLEARED: "guidesCleared",
                     GUIDE_DELETED: "guideDeleted"
                 },
                 amendment: {

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -99,7 +99,8 @@ define(function (require, exports, module) {
                 events.document.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
                 events.document.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
                 events.document.history.nonOptimistic.GUIDE_SET, this._handleGuideSet,
-                events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted
+                events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted,
+                events.document.history.nonOptimistic.GUIDES_CLEARED, this._handleGuidesCleared
             );
 
             this._handleReset();
@@ -1092,6 +1093,21 @@ define(function (require, exports, module) {
                 document = this._openDocuments[documentID];
 
             var nextDocument = document.deleteIn(["guides", index]);
+
+            this.setDocument(nextDocument, true);
+        },
+
+        /**
+         * Clears all the guides
+         *
+         * @private
+         * @param {{documentID: number}} payload
+         */
+        _handleGuidesCleared: function (payload) {
+            var documentID = payload.documentID,
+                document = this._openDocuments[documentID];
+
+            var nextDocument = document.set("guides", Immutable.List());
 
             this.setDocument(nextDocument, true);
         }

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -66,6 +66,7 @@ define(function (require, exports, module) {
                 events.document.GUIDES_VISIBILITY_CHANGED, this._updateMenuItems,
                 events.document.history.nonOptimistic.GUIDE_SET, this._updateMenuItems,
                 events.document.history.nonOptimistic.GUIDE_DELETED, this._updateMenuItems,
+                events.document.history.nonOptimistic.GUIDES_CLEARED, this._updateMenuItems,
                 events.document.RESET_LAYERS, this._updateMenuItems,
                 events.document.RESET_LAYERS_BY_INDEX, this._updateMenuItems,
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._updateMenuItems,

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -193,7 +193,8 @@
         "TOGGLE_EXTRAS": "Show | Hide Extras",
         "TOGGLE_RULERS": "Show | Hide Rulers",
         "TOGGLE_SMART_GUIDES": "Show Smart Guides",
-        "TOGGLE_GUIDES": "Show Guides"
+        "TOGGLE_GUIDES": "Show Guides",
+        "CLEAR_GUIDES": "Clear Guides"
     },
     "WINDOW": {
         "$MENU": "Window",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -370,6 +370,10 @@
         "TOGGLE_SMART_GUIDES": {
             "$action": "documents.toggleSmartGuidesVisibility",
             "$enable-rule": "supported-document"
+        },
+        "CLEAR_GUIDES": {
+            "$action": "guides.clearGuides",
+            "$enable-rule": "supported-document"
         }
     },
     "WINDOW": {

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -561,6 +561,9 @@
                             "shift": true
                         }
                     }
+                },
+                {
+                    "id": "CLEAR_GUIDES"
                 }
             ]
         },

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -563,6 +563,9 @@
                     }
                 },
                 {
+                    "separator": true
+                },
+                {
                     "id": "CLEAR_GUIDES"
                 }
             ]

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -524,6 +524,9 @@
                             "shift": true
                         }
                     }
+                },
+                {
+                    "id": "CLEAR_GUIDES"
                 }
             ]
         },

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -526,6 +526,9 @@
                     }
                 },
                 {
+                    "separator": true
+                },
+                {
                     "id": "CLEAR_GUIDES"
                 }
             ]


### PR DESCRIPTION
Requires https://github.com/adobe-photoshop/spaces-adapter/pull/145

Adds View>Clear Guides button that clears out all guides in current document.