### PR TITLE
Export panel and its operations should filter out unsupported layers

### DIFF
--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
 
         propTypes: {
             document: React.PropTypes.object.isRequired,
-            layers: React.PropTypes.instanceOf(Immutable.Iterable).isRequired,
+            layers: React.PropTypes.instanceOf(Immutable.Iterable), // undefined => doc-level export
             index: React.PropTypes.number.isRequired,
             exportAssets: React.PropTypes.instanceOf(Immutable.Iterable).isRequired
         },
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
         propTypes: {
             document: React.PropTypes.object.isRequired,
             documentExports: React.PropTypes.object.isRequired,
-            layers: React.PropTypes.instanceOf(Immutable.Iterable)
+            layers: React.PropTypes.instanceOf(Immutable.Iterable) // undefined => doc-level export
         },
 
         render: function () {
@@ -200,59 +200,53 @@ define(function (require, exports, module) {
                 assetGroups,
                 exportComponents;
 
-            if (documentExports) {
-                if (layers && layers.size > 0) {
-                    assetGroups = documentExports.getAssetGroups(layers).toList();
-                } else {
-                    assetGroups = collection.zip(Immutable.List.of(documentExports.rootExports)).toList();
-                }
-            }
-
-            if (!assetGroups || assetGroups.size < 1) {
-                return null;
+            if (layers) {
+                assetGroups = documentExports.getAssetGroups(layers).toList();
             } else {
-                exportComponents = assetGroups.map(function (i, k) {
-                    var key = keyprefix + "-" + k;
-                    return (
-                        <ExportAssetFace
-                            document={document}
-                            layers={layers}
-                            index={k}
-                            key={key}
-                            faceKey={key}
-                            exportAssets={i} />
-                    );
-                }, this).toArray();
-
-                return (
-                    <div className="layer-exports__header" >
-                        <div className="formline">
-                            <Label
-                                title={strings.EXPORT.TITLE_SCALE}
-                                size="column-4"
-                                className="label__medium__left-aligned">
-                                {strings.EXPORT.TITLE_SCALE}
-                            </Label>
-                            <Gutter />
-                            <Label
-                                title={strings.EXPORT.TITLE_SUFFIX}
-                                size="column-6"
-                                className="label__medium__left-aligned">
-                                {strings.EXPORT.TITLE_SUFFIX}
-                            </Label>
-                            <Gutter />
-                            <Label
-                                title={strings.EXPORT.TITLE_SETTINGS}
-                                size="column-4"
-                                className="label__medium__left-aligned">
-                                {strings.EXPORT.TITLE_SETTINGS}
-                            </Label>
-                            <Gutter />
-                        </div>
-                        {exportComponents}
-                    </div>
-                );
+                assetGroups = collection.zip(Immutable.List.of(documentExports.rootExports)).toList();
             }
+
+            exportComponents = assetGroups.map(function (i, k) {
+                var key = keyprefix + "-" + k;
+                return (
+                    <ExportAssetFace
+                        document={document}
+                        layers={layers}
+                        index={k}
+                        key={key}
+                        faceKey={key}
+                        exportAssets={i} />
+                );
+            }, this).toArray();
+
+            return (
+                <div className="layer-exports__header" >
+                    <div className="formline">
+                        <Label
+                            title={strings.EXPORT.TITLE_SCALE}
+                            size="column-4"
+                            className="label__medium__left-aligned">
+                            {strings.EXPORT.TITLE_SCALE}
+                        </Label>
+                        <Gutter />
+                        <Label
+                            title={strings.EXPORT.TITLE_SUFFIX}
+                            size="column-6"
+                            className="label__medium__left-aligned">
+                            {strings.EXPORT.TITLE_SUFFIX}
+                        </Label>
+                        <Gutter />
+                        <Label
+                            title={strings.EXPORT.TITLE_SETTINGS}
+                            size="column-4"
+                            className="label__medium__left-aligned">
+                            {strings.EXPORT.TITLE_SETTINGS}
+                        </Label>
+                        <Gutter />
+                    </div>
+                    {exportComponents}
+                </div>
+            );
         }
     });
 

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -217,7 +217,7 @@ define(function (require, exports, module) {
                         faceKey={key}
                         exportAssets={i} />
                 );
-            }, this).toArray();
+            }, this);
 
             return (
                 <div className="layer-exports__header" >

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -828,6 +828,19 @@ define(function (require, exports, module) {
     }));
 
     /**
+     * Given a set of layers, return only those layers which will support being exported
+     * This excludes background layers and empty layers
+     *
+     * @param {Immutable.Iterable.<Layer>} layers
+     * @return {Immutable.Iterable.<Layer>}
+     */
+    Object.defineProperty(LayerStructure.prototype, "filterExportable", objUtil.cachedLookupSpec(function (layers) {
+        return layers.filterNot(function (layer) {
+            return !layer.bounds || layer.bounds.empty || layer.isBackground || this.isEmptyGroup(layer);
+        }, this);
+    }));
+
+    /**
      * Create a new non-group layer model from a Photoshop layer descriptor and
      * add it to the structure.
      *

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -836,7 +836,11 @@ define(function (require, exports, module) {
      */
     Object.defineProperty(LayerStructure.prototype, "filterExportable", objUtil.cachedLookupSpec(function (layers) {
         return layers.filterNot(function (layer) {
-            return !layer.bounds || layer.bounds.empty || layer.isBackground || this.isEmptyGroup(layer);
+            return !layer.bounds ||
+                layer.bounds.empty ||
+                layer.isBackground ||
+                layer.kind === layer.layerKinds.ADJUSTMENT ||
+                this.isEmptyGroup(layer);
         }, this);
     }));
 

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -381,7 +381,9 @@
         "TITLE_SCALE": "Scale",
         "TITLE_SUFFIX": "Suffix",
         "TITLE_SETTINGS": "Settings",
-        "EXPORT_DOCUMENT_FILENAME": "document"
+        "EXPORT_DOCUMENT_FILENAME": "document",
+        "ONLY_UNSUPPORTED_LAYERS_SELECTED": "Unsupported Layer",
+        "NO_ASSETS": "Nothing configured"
     },
     "TEMPLATES": {
         "IPHONE_6_PLUS": "iPhone 6+",

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -377,13 +377,12 @@
         "EXPORT_LIST_ALL_ASSETS": "All Assets",
         "BUTTON_EXPORT": "Export",
         "BUTTON_CANCEL": "Cancel",
-        "SELECT_SINGLE_LAYER": "DEPRECATED",
         "TITLE_SCALE": "Scale",
         "TITLE_SUFFIX": "Suffix",
         "TITLE_SETTINGS": "Settings",
         "EXPORT_DOCUMENT_FILENAME": "document",
-        "ONLY_UNSUPPORTED_LAYERS_SELECTED": "Unsupported Layer",
-        "NO_ASSETS": "Nothing configured"
+        "ONLY_UNSUPPORTED_LAYERS_SELECTED": "No supported layers selected",
+        "NO_ASSETS": "No exports configured"
     },
     "TEMPLATES": {
         "IPHONE_6_PLUS": "iPhone 6+",


### PR DESCRIPTION
- Only show and operate on "supported" subset of selected layers
- Currently unsupported: background layers, empty artboards, empty groups, zero-bound layers
- If layers are selected, but none are supported, a message is shown
- If layers are selected, but there are no common assets, a message is shown
- Uses @placegraphichere 's Panel Message pattern
- Includes some minor react housekeeping
- Review note: Added new function `filterExportable` to `layerstructure` (instead of documentExport) so that it would have easy access to `isEmptyGroup`

This addressees part of #2273
(A separate plugin change will make the error message better when we DO request export of layers that generator pukes on)