### PR TITLE
Always set the ID on Select#setSelected

### DIFF
--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
          * @param {string} id
          */
         _setSelected: function (id) {
-            if (id !== this.state.selected && this.props.onChange(id) !== false) {
+            if (this.props.onChange(id) !== false) {
                 this.setState({
                     selected: id
                 });


### PR DESCRIPTION
Problem: updateAutoFill would not match any filter, and set the `state.id` of Datalist to null... Then we would use selectExtreme to select the first result. And as far as Select knew, it was already at that ID, so it didn't need to set it's own state again. So that's why it would work when we typed 'do', but not 'doc'.

Always selecting it makes sure that states are correct.

Addfresses #2347 