### PR TITLE
Toggle overlays on activationChanged events

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -453,6 +453,7 @@ define(function (require, exports) {
      * @type {function()}
      */
     var _scrollHandler,
+        _activationChangeHandler,
         _resizeHandler;
 
     /**
@@ -476,6 +477,12 @@ define(function (require, exports) {
             setTransformDebounced(event);
         }.bind(this);
         descriptor.addListener("scroll", _scrollHandler);
+
+        // Handles Photoshop focus change events
+        _activationChangeHandler = function (event) {
+            this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: event.becameActive });
+        }.bind(this);
+        adapterOS.addListener("activationChanged", _activationChangeHandler);
 
         var windowResizeDebounced = synchronization.debounce(function () {
             return this.flux.actions.ui.setOverlayCloaking();
@@ -518,6 +525,7 @@ define(function (require, exports) {
      */
     var onReset = function () {
         descriptor.removeListener("scroll", _scrollHandler);
+        adapterOS.removeListener("activationChanged", _activationChangeHandler);
         window.removeEventListener("resize", _resizeHandler);
 
         return Promise.resolve();

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -155,6 +155,7 @@ define(function (require, exports, module) {
             svg.selectAll(".guide-edges-group").remove();
 
             if (!currentDocument || this.state.modalState ||
+                !this.state.uiState.overlaysEnabled ||
                 !currentDocument.guidesVisible ||
                 !currentTool || currentTool.id !== "newSelect") {
                 return null;


### PR DESCRIPTION
@jsbache pointed this out. When PS loses focus, we should toggle our overlays so the guides overlay doesn't just stay lit. We re-enable them on app focus.

![activationchanged](https://cloud.githubusercontent.com/assets/386714/9695026/c9475278-5312-11e5-8cf4-e7ef9a994d92.gif)
