### PR TITLE
Place CC Libraries graphic assets asynchronously

### DIFF
--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -28,8 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        classnames = require("classnames"),
-        Promise = require("bluebird");
+        classnames = require("classnames");
 
     var adapterOS = require("adapter/os");
 
@@ -333,14 +332,7 @@ define(function (require, exports, module) {
             uiStore = flux.store("ui"),
             canvasLocation = uiStore.transformWindowToCanvas(dropPosition.x, dropPosition.y);
         
-        // Placing a new layer from the libraries will halt the JavaScript untile the new layer quit the transform mode.
-        // So we set a delay here to allow the draganddrop store to finish its job: reset the drag state and emmit 
-        // change events.
-        Promise.delay(50).then(function () {
-            flux.actions.libraries.createLayerFromElement(dropTarget, canvasLocation);
-        });
-        
-        return Promise.resolve();
+        return flux.actions.libraries.createLayerFromElement(dropTarget, canvasLocation);
     };
     
     /**

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -70,7 +70,6 @@ define(function (require, exports, module) {
         _handleOption: function (itemID) {
             this._closeSearchBar()
                 .bind(this)
-                .delay(100) // HACK: See #2177
                 .then(function () {
                     var searchStore = this.getFlux().store("search");
                     searchStore.handleExecute(itemID);


### PR DESCRIPTION
This changes the execution of the CC Libraries `placeElement` action to be considered "asynchronous" by the adapter, which allows CEF to continue to run while the command is being played, even while in the smart-object placement tracker. A side effect of playing commands in this state is that they can generate additional events, and so it was also necessary to convert the `placeEvent` handler into an action which calmly, safely declines to add layers to the model which have already been added. It also seems to be necessary to explicitly set the required key propagation policies when playing `placeElement` asynchronously.

This fully addresses #2177, and also removes a few `Promise.delay` superhacks that only worked if you were sufficiently lucky.