### PR TITLE
Disable zoom animations

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -285,7 +285,8 @@ define(function (require, exports) {
         return {
             x: zoom * bounds.xCenter / factor + (offset.right - offset.left) / 2,
             y: zoom * bounds.yCenter / factor + (offset.bottom - offset.top) / 2,
-            z: zoom
+            z: zoom,
+            animate: false
         };
     };
 
@@ -381,7 +382,7 @@ define(function (require, exports) {
             zoom = payload.zoom,
             bounds = document.layers.selectedAreaBounds,
             panZoomDescriptor = {
-                animate: true,
+                animate: false,
                 resize: true,
                 z: zoom
             };


### PR DESCRIPTION
On Windows, zoom animations act weird and zoom the doc out to the window center. On Mac, animations don't really work anyways... so I've decided to turn them off by us.

Addresses Win side of #2169