### PR TITLE
Move typefaces for Datalist calculation to the font store

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -65,38 +65,12 @@ define(function (require, exports, module) {
                 return collection.pluck(document.layers.selected, "opacity");
             };
 
-            if (!Immutable.is(this.state.postScriptMap, nextState.postScriptMap)) {
-                if (nextState.postScriptMap) {
-                    // The list of all selectable type faces
-                    var typefaces = nextState.postScriptMap
-                        .entrySeq()
-                        .sortBy(function (entry) {
-                            return entry[0];
-                        })
-                        .map(function (entry) {
-                            var psName = entry[0],
-                                fontObj = entry[1];
-
-                            return {
-                                id: psName,
-                                title: fontObj.font
-                            };
-                        })
-                        .toList();
-
-                    this.setState({
-                        typefaces: typefaces
-                    });
-                }
-
-                return true;
-            }
-
             if (this.state.opaque !== nextState.opaque) {
                 return true;
             }
 
-            return !Immutable.is(this.state.typefaces, nextState.typefaces) ||
+            return !Immutable.is(this.state.postScriptMap, nextState.postScriptMap) ||
+                !Immutable.is(this.state.typefaces, nextState.typefaces) ||
                 !Immutable.is(getTexts(this.props.document), getTexts(nextProps.document)) ||
                 !Immutable.is(getOpacities(this.props.document), getOpacities(nextProps.document));
         },
@@ -112,6 +86,7 @@ define(function (require, exports, module) {
                 initialized: fontState.initialized,
                 postScriptMap: fontState.postScriptMap,
                 familyMap: fontState.familyMap,
+                typefaces: fontState.typefaces,
                 // Force opacity while in the type modal tool state
                 opaque: modalState
             };

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -56,6 +56,13 @@ define(function (require, exports, module) {
          */
         _postScriptMap: Immutable.Map(),
 
+        /**
+         * List of typefaces for populating datalists
+         *
+         * @type {Immutable.List.<{id: string, font: string}>}
+         */
+        _typefaces: Immutable.List(),
+
         initialize: function () {
             this.bindActions(
                 events.RESET, this._handleReset,
@@ -84,7 +91,8 @@ define(function (require, exports, module) {
             return {
                 initialized: this._initialized,
                 familyMap: this._familyMap,
-                postScriptMap: this._postScriptMap
+                postScriptMap: this._postScriptMap,
+                typefaces: this._typefaces
             };
         },
 
@@ -276,6 +284,23 @@ define(function (require, exports, module) {
                     font: fontName
                 }));
             }, new Map()));
+
+            // The list of all selectable type faces
+            this._typefaces = this._postScriptMap
+                .entrySeq()
+                .sortBy(function (entry) {
+                    return entry[0];
+                })
+                .map(function (entry) {
+                    var psName = entry[0],
+                        fontObj = entry[1];
+
+                    return {
+                        id: psName,
+                        title: fontObj.font
+                    };
+                })
+                .toList();
 
             this._initialized = true;
             this.emit("change");


### PR DESCRIPTION
Because we were setting `state.typefaces` in the shouldComponentUpdate of Type.jsx, if the two postScriptMaps between two instances of a Type.jsx were equal, we wouldn't recompute the new state.typefaces, and it would be passed `undefined` into the Typeface datalist, causing #2295, not rendering the Dialog.

Now we calculate the typefaces in the font store, this is not ideal, as they're very UI specific... but at the same time this is the sanest way of doing this.

@iwehrman Since we chatted about this, please review the fix.