### PR TITLE
Re-add addStroke and wire it correctly to stroke being added

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
 
     var Layer = require("./layer"),
         LayerNode = require("./layernode"),
+        Stroke = require("./stroke"),
         Bounds = require("./bounds"),
         Radii = require("./radii");
 
@@ -1311,6 +1312,37 @@ define(function (require, exports, module) {
             return map.set(layerID, nextLayer);
         }, new Map(), this));
 
+        return this.mergeDeep({
+            layers: nextLayers
+        });
+    };
+
+    /**
+     * Add a new stroke, described by a Photoshop descriptor, to the given layers.
+     * If strokeStyleDescriptor is a single object, it will be applied to all layers
+     * otherwise it should be a List of descriptors which corresponds by index to the provided layerIDs
+     *
+     * @param {Immutable.Iterable.<number>} layerIDs
+     * @param {object | Immutable.Iterable.<object>} strokeStyleDescriptor
+     * @return {LayerStructure}
+     */
+    LayerStructure.prototype.addStroke = function (layerIDs, strokeStyleDescriptor) {
+        var isList = Immutable.List.isList(strokeStyleDescriptor);
+       
+        var getStroke = function (index) {
+            return isList ?
+                Stroke.fromStrokeStyleDescriptor(strokeStyleDescriptor.get(index)) :
+                Stroke.fromStrokeStyleDescriptor(strokeStyleDescriptor);
+        };
+       
+        var nextLayers = Immutable.Map(layerIDs.reduce(function (map, layerID, index) {
+            var layer = this.byID(layerID),
+                nextStroke = getStroke(index),
+                nextLayer = layer.set("stroke", nextStroke);
+
+            return map.set(layerID, nextLayer);
+        }, new Map(), this));
+       
         return this.mergeDeep({
             layers: nextLayers
         });

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.STROKE_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.STROKE_COLOR_CHANGED, this._handleStrokePropertiesChanged,
                 events.document.history.optimistic.STROKE_OPACITY_CHANGED, this._handleStrokePropertiesChanged,
-                events.document.history.nonOptimistic.STROKE_ADDED, this._handleStrokePropertiesChanged,
+                events.document.history.nonOptimistic.STROKE_ADDED, this._handleStrokeAdded,
                 events.document.history.optimistic.LAYER_EFFECT_CHANGED, this._handleLayerEffectPropertiesChanged,
                 events.document.history.optimistic.LAYER_EFFECT_DELETED, this._handleDeletedLayerEffect,
                 events.document.history.optimistic.LAYER_EFFECTS_BATCH_CHANGED, this._handleLayerEffectsBatchChanged,
@@ -736,6 +736,24 @@ define(function (require, exports, module) {
                 strokeProperties = payload.strokeProperties,
                 document = this._openDocuments[documentID],
                 nextLayers = document.layers.setStrokeProperties(layerIDs, strokeProperties),
+                nextDocument = document.set("layers", nextLayers);
+
+            this.setDocument(nextDocument, true);
+        },
+
+        /**
+         * Adds a stroke to the specified document and layers
+         * This also handles updating strokes where we're refetching from Ps
+         *
+         * @private
+         * @param {{documentID: !number, strokeStyleDescriptor: object}} payload
+         */
+        _handleStrokeAdded: function (payload) {
+            var documentID = payload.documentID,
+                layerIDs = payload.layerIDs,
+                strokeStyleDescriptor = payload.strokeStyleDescriptor,
+                document = this._openDocuments[documentID],
+                nextLayers = document.layers.addStroke(layerIDs, strokeStyleDescriptor),
                 nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);


### PR DESCRIPTION
I messed up during singularizing strokes and fills and removed these necessary methods and wired them to the wrong store handler. This undoes the damage.

Addresses #2207