### PR TITLE
Export grab bag; history, busy state, sorting, auto-asset creation...

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -487,6 +487,34 @@ define(function (require, exports) {
     addAsset.transfers = [];
 
     /**
+     * Add a default document to the layer specified by layerID, if it doesn't already have any assets
+     * Does not create a history state
+     *
+     * @param {number} documentID
+     * @param {number} layerID
+     */
+    var addDefaultAsset = function (documentID, layerID) {
+        var documentExports = this.flux.stores.export.getDocumentExports(documentID, true),
+            document = this.flux.stores.document.getDocument(documentID);
+
+        if (!document) {
+            return Promise.reject(new Error("Can not find document " + documentID + " to addDefaultAsset"));
+        }
+
+        var layer = document.layers.byID(layerID),
+            layerExports = documentExports.getLayerExports(layerID);
+
+        if (!layerExports || layerExports.isEmpty()) {
+            return this.transfer(updateExportAsset, document, Immutable.List.of(layer), 0, {}, true);
+        } else {
+            Promise.resolve();
+        }
+    };
+    addDefaultAsset.reads = [locks.JS_DOC, locks.JS_EXPORT];
+    addDefaultAsset.writes = [];
+    addDefaultAsset.transfers = [updateExportAsset];
+
+    /**
      * Delete the Export Asset configuration specified by the given index
      *
      * If layers is empty, or not supplied, delete a document-level asset
@@ -911,6 +939,7 @@ define(function (require, exports) {
     exports.updateLayerAssetSuffix = updateLayerAssetSuffix;
     exports.updateLayerAssetFormat = updateLayerAssetFormat;
     exports.addAsset = addAsset;
+    exports.addDefaultAsset = addDefaultAsset;
     exports.deleteExportAsset = deleteExportAsset;
     exports.setLayerExportEnabled = setLayerExportEnabled;
     exports.setAllArtboardsExportEnabled = setAllArtboardsExportEnabled;

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -533,7 +533,7 @@ define(function (require, exports) {
                 assetIndex: assetIndex
             };
 
-        return this.dispatchAsync(events.export.DELETE_ASSET, payload)
+        return this.dispatchAsync(events.export.history.optimistic.DELETE_ASSET, payload)
             .bind(this)
             .then(function () {
                 return _syncExportMetadata.call(this, documentID, layerIDs);

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -698,6 +698,7 @@ define(function (require, exports) {
             // No layers provided, so get all layers that have exports configured and which are "exportEnabled"
             layersList = documentExports.getLayersWithExports(document, undefined, true);
             layersList = document.layers.filterExportable(layersList);
+            quickAddPromise = Promise.resolve();
         }
 
         // prompt for folder and then export to the result.
@@ -711,7 +712,7 @@ define(function (require, exports) {
                 return _setAssetsRequested.call(this, document.id, layerIdList);
             })
             .then(_setServiceBusy.bind(this, true))
-            .then(quickAddPromise)
+            .return(quickAddPromise)
             .then(function () {
                 // fetch documentExports anew, in case quick-add added any assets
                 var documentExports = this.flux.stores.export.getDocumentExports(documentID, true);

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -470,7 +470,7 @@ define(function (require, exports) {
                 layerIDs: collection.pluck(_layers, "id"),
                 exportEnabled: true
             };
-            updatePromise = this.dispatchAsync(events.document.LAYER_EXPORT_ENABLED_CHANGED, payload);
+            updatePromise = this.dispatchAsync(events.document.history.amendment.LAYER_EXPORT_ENABLED_CHANGED, payload);
         } else {
             updatePromise = Promise.resolve();
         }
@@ -533,7 +533,7 @@ define(function (require, exports) {
                 exportEnabled: exportEnabled
             };
 
-        return this.dispatchAsync(events.document.LAYER_EXPORT_ENABLED_CHANGED, payload)
+        return this.dispatchAsync(events.document.history.amendment.LAYER_EXPORT_ENABLED_CHANGED, payload)
             .bind(this)
             .then(function () {
                 return _syncExportMetadata.call(this, document.id, layerIDs, true);

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -168,7 +168,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var _exportAsset = function (document, layer, assetIndex, asset, baseDir, prefix) {
-        var fileName = (layer ? layer.name : strings.EXPORT.EXPORT_DOCUMENT_FILENAME) + asset.suffix,
+        var baseName = layer ? layer.name : document.nameWithoutExtension || strings.EXPORT.EXPORT_DOCUMENT_FILENAME,
+            fileName = baseName + asset.suffix,
             _layers = layer ? Immutable.List.of(layer) : null;
 
         fileName = prefix ? prefix + fileName : fileName;
@@ -763,7 +764,7 @@ define(function (require, exports) {
 
         // prompt for folder and then export to the result.
         // resolve immediately if no folder is returned
-        this.transfer(promptForFolder)
+        return this.transfer(promptForFolder)
             .bind(this)
             .then(function (baseDir) {
                 _lastFolderPath = baseDir;

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -156,7 +156,11 @@ define(function (require, exports) {
      * Helper function to export a single asset using the export service, and update the metadata afterwards.
      *
      * When the export service's promise is resolved, a fresh flux action is called
-     * to perform the metadata sync (to wit: it does not transfer to updateExportAsset)
+     * to perform the metadata sync (to wit: it does not transfer to updateExportAsset).
+     * This is because the websocket export call is asynchronous, and should not be handled within the
+     * action that initiates the export.  This is analogous to handling photoshop events with a flux action,
+     * except that here we are not listening to an event,
+     * but rather keeping an unfulfilled promise in the action's state
      *
      * @private
      * @param {Document} document
@@ -164,7 +168,7 @@ define(function (require, exports) {
      * @param {number} assetIndex index of this asset within the layer's list
      * @param {ExportAsset} asset asset to export
      * @param {string=} baseDir Optional directory path in to which assets should be exported
-     * @param {string=} prefix
+     * @param {string=} prefix Optional prefix to apply to the fileName
      * @return {Promise}
      */
     var _exportAsset = function (document, layer, assetIndex, asset, baseDir, prefix) {
@@ -521,7 +525,7 @@ define(function (require, exports) {
         if (!layerExports || layerExports.isEmpty()) {
             return this.transfer(updateExportAsset, document, Immutable.List.of(layer), 0, {}, true);
         } else {
-            Promise.resolve();
+            return Promise.resolve();
         }
     };
     addDefaultAsset.reads = [locks.JS_DOC, locks.JS_EXPORT];

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -154,7 +154,7 @@ define(function (require, exports) {
 
     /**
      * Helper function to export a single asset using the export service, and update the metadata afterwards.
-     * 
+     *
      * When the export service's promise is resolved, a fresh flux action is called
      * to perform the metadata sync (to wit: it does not transfer to updateExportAsset)
      *
@@ -433,7 +433,7 @@ define(function (require, exports) {
     updateLayerAssetFormat.transfers = [updateExportAsset];
 
     /**
-     * Adds an asset, or assets, to the end of the document's root asset list, or to that of a set of layers. 
+     * Adds an asset, or assets, to the end of the document's root asset list, or to that of a set of layers.
      * If props not provided, choose the next reasonable scale and create an otherwise vanilla asset
      *
      * Recognizes an empty list of layers as implying doc-level export

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -75,7 +75,8 @@ define(function (require, exports, module) {
                 },
                 amendment: {
                     REORDER_LAYERS: "reorderLayersAmendment",
-                    RESET_LAYERS: "resetLayersAmendement"
+                    RESET_LAYERS: "resetLayersAmendement",
+                    LAYER_EXPORT_ENABLED_CHANGED: "layerExportEnabledChanged"
                 }
             },
             DELETE_LAYERS_NO_HISTORY: "deleteLayersNoHistory",
@@ -85,7 +86,6 @@ define(function (require, exports, module) {
             VISIBILITY_CHANGED: "layerVisibilityChanged",
             REORDER_LAYERS: "reorderLayersNoHistory",
             LAYER_BOUNDS_CHANGED: "layerBoundsChanged",
-            LAYER_EXPORT_ENABLED_CHANGED: "layerExportEnabledChanged",
             RESET_BOUNDS: "resetBoundsNoHistory", // slightly different than above LAYER_BOUNDS_CHANGED
             RESET_LAYERS: "resetLayers",
             RESET_LAYERS_BY_INDEX: "resetLayersByIndex",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -114,7 +114,8 @@ define(function (require, exports, module) {
             ASSET_ADDED: "exportAssetAdded",
             DELETE_ASSET: "exportDeleteLayerAsset",
             SERVICE_STATUS_CHANGED: "exportServiceStatusChanged",
-            SET_AS_REQUESTED: "exportSetStatusRequested"
+            SET_AS_REQUESTED: "exportSetStatusRequested",
+            SET_STATE_PROPERTY: "setUseArtboardPrefix"
         },
         tool: {
             SELECT_TOOL: "selectTool",

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -110,12 +110,17 @@ define(function (require, exports, module) {
             TYPE_COLOR_CHANGED: "typeColorChangedNoHistory"
         },
         export: {
-            ASSET_CHANGED: "exportAssetChanged",
-            ASSET_ADDED: "exportAssetAdded",
-            DELETE_ASSET: "exportDeleteLayerAsset",
+            ASSET_CHANGED: "exportAssetChangedQuietly",
             SERVICE_STATUS_CHANGED: "exportServiceStatusChanged",
             SET_AS_REQUESTED: "exportSetStatusRequested",
-            SET_STATE_PROPERTY: "setUseArtboardPrefix"
+            SET_STATE_PROPERTY: "setUseArtboardPrefix",
+            history: {
+                optimistic: {
+                    ASSET_CHANGED: "exportAssetChanged",
+                    ASSET_ADDED: "exportAssetAdded",
+                    DELETE_ASSET: "exportDeleteLayerAsset"
+                }
+            }
         },
         tool: {
             SELECT_TOOL: "selectTool",

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -252,6 +252,8 @@ define(function (require, exports, module) {
                 "exports-panel__container__busy": serviceBusy
             });
 
+            var exportButton = serviceBusy ? (<SVGIcon CSSID="loader" />) : strings.EXPORT.BUTTON_EXPORT;
+
             return (
                 <div className={panelClassnames}>
                     <TitleHeader
@@ -302,7 +304,7 @@ define(function (require, exports, module) {
                         <Button
                             disabled={serviceBusy}
                             onClick={this._exportAllAssets}>
-                            {strings.EXPORT.BUTTON_EXPORT}
+                            {exportButton}
                         </Button>
                     </div>
                 </div>

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -221,7 +221,9 @@ define(function (require, exports, module) {
 
             // Iterate over all configured assets, build the individual components,
             // and separate into separate lists (artboards vs. non-artboards)
-            var artboardLayers = gridSort(documentExports.getLayersWithExports(document, true)),
+            var artboards = documentExports.getLayersWithExports(document, true),
+                artboardsFiltered = document.layers.filterExportable(artboards),
+                artboardsSorted = gridSort(artboardsFiltered),
                 nonABLayers = documentExports.getLayersWithExports(document, false);
 
             // Helper to generate a LayerExportsItem component
@@ -240,9 +242,9 @@ define(function (require, exports, module) {
                 );
             };
 
-            var allArtboardsExportComponents = artboardLayers.map(layerExportComponent),
+            var allArtboardsExportComponents = artboardsSorted.map(layerExportComponent),
                 allNonABLayerExportComponents = nonABLayers.reverse().map(layerExportComponent),
-                allArtboardsExportEnabled = collection.pluck(artboardLayers, "exportEnabled"),
+                allArtboardsExportEnabled = collection.pluck(artboardsSorted, "exportEnabled"),
                 allNonABLayersExportEnabled = collection.pluck(nonABLayers, "exportEnabled");
 
             var panelClassnames = classnames({

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -172,7 +172,7 @@ define(function (require, exports, module) {
 
             this.setState({ fresh: false });
 
-            exportActions.exportLayerAssets(document);
+            exportActions.exportLayerAssetsDebounced(document);
         },
 
         /**
@@ -210,7 +210,9 @@ define(function (require, exports, module) {
                 documentExports = this.state.documentExports,
                 layerExportsMap = documentExports && documentExports.layerExportsMap,
                 exportStore = this.state.exportStore,
-                useArtboardPrefix = exportStore.getState().useArtboardPrefix,
+                exportState = exportStore.getState(),
+                useArtboardPrefix = exportState.useArtboardPrefix,
+                serviceBusy = exportState.serviceBusy,
                 freshState = this.state.fresh;
 
             if (!document || !documentExports) {
@@ -243,8 +245,13 @@ define(function (require, exports, module) {
                 allArtboardsExportEnabled = collection.pluck(artboardLayers, "exportEnabled"),
                 allNonABLayersExportEnabled = collection.pluck(nonABLayers, "exportEnabled");
 
+            var panelClassnames = classnames({
+                "exports-panel__container": true,
+                "exports-panel__container__busy": serviceBusy
+            });
+
             return (
-                <div className="exports-panel__container">
+                <div className={panelClassnames}>
                     <TitleHeader
                         title={strings.TITLE_EXPORT} />
                     <div className="exports-panel__two-column">
@@ -291,6 +298,7 @@ define(function (require, exports, module) {
                         </Button>
                         <div className="exports-panel__button-group__separator"></div>
                         <Button
+                            disabled={serviceBusy}
                             onClick={this._exportAllAssets}>
                             {strings.EXPORT.BUTTON_EXPORT}
                         </Button>

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -247,12 +247,11 @@ define(function (require, exports, module) {
                 allArtboardsExportEnabled = collection.pluck(artboardsSorted, "exportEnabled"),
                 allNonABLayersExportEnabled = collection.pluck(nonABLayers, "exportEnabled");
 
-            var panelClassnames = classnames({
-                "exports-panel__container": true,
-                "exports-panel__container__busy": serviceBusy
-            });
+            var panelClassnames = classnames("exports-panel__container");
 
-            var exportButton = serviceBusy ? (<SVGIcon CSSID="loader" />) : strings.EXPORT.BUTTON_EXPORT;
+            var exportButton = serviceBusy ?
+                (<SVGIcon CSSID="loader" viewbox="0 0 16 16" />)
+                : strings.EXPORT.BUTTON_EXPORT;
 
             return (
                 <div className={panelClassnames}>

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -152,6 +152,7 @@ define(function (require, exports, module) {
                         list={scaleListID}
                         className="dialog-export-scale"
                         options={_scaleOptions.toList()}
+                        value={scaleOption.title}
                         defaultSelected={scaleOption.id}
                         onChange={this._handleUpdateScale}
                         live={false}
@@ -169,6 +170,7 @@ define(function (require, exports, module) {
                         list={formatListID}
                         className="dialog-export-format"
                         options={_formatOptions.toList()}
+                        value={exportAsset.format.toUpperCase()}
                         defaultSelected={exportAsset.format}
                         onChange={this._handleUpdateFormat}
                         live={false}

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -152,7 +152,6 @@ define(function (require, exports, module) {
                         list={scaleListID}
                         className="dialog-export-scale"
                         options={_scaleOptions.toList()}
-                        value={scaleOption.title}
                         defaultSelected={scaleOption.id}
                         onChange={this._handleUpdateScale}
                         live={false}
@@ -162,6 +161,7 @@ define(function (require, exports, module) {
                         value={exportAsset.suffix}
                         singleClick={true}
                         editable={true}
+                        live={true}
                         onChange={this._handleUpdateSuffix}
                         size="column-6" />
                     <Gutter />
@@ -169,7 +169,6 @@ define(function (require, exports, module) {
                         list={formatListID}
                         className="dialog-export-format"
                         options={_formatOptions.toList()}
-                        value={exportAsset.format.toUpperCase()}
                         defaultSelected={exportAsset.format}
                         onChange={this._handleUpdateFormat}
                         live={false}

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -153,6 +153,7 @@ define(function (require, exports, module) {
                         className="dialog-export-scale"
                         options={_scaleOptions.toList()}
                         value={scaleOption.title}
+                        defaultSelected={scaleOption.id}
                         onChange={this._handleUpdateScale}
                         live={false}
                         size="column-4" />
@@ -169,6 +170,7 @@ define(function (require, exports, module) {
                         className="dialog-export-format"
                         options={_formatOptions.toList()}
                         value={exportAsset.format.toUpperCase()}
+                        defaultSelected={exportAsset.format}
                         onChange={this._handleUpdateFormat}
                         live={false}
                         size="column-4" />

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -197,8 +197,7 @@ define(function (require, exports, module) {
 
             var containerClasses = classnames({
                 "section-container": true,
-                "section-container__collapsed": !this.props.visible,
-                "exports-panel__container__busy": exportState.serviceBusy // TEMP
+                "section-container__collapsed": !this.props.visible
             });
 
             var sectionClasses = classnames({

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -224,7 +224,7 @@ define(function (require, exports, module) {
                                 onClick={this._exportAssetsClickHandler}
                                 onDoubleClick={this._addAssetDoubleClickHandler}>
                                 <SVGIcon
-                                    CSSID="export" />
+                                    CSSID={exportState.serviceBusy ? "loader" : "export"} />
                             </Button>
                             <Gutter />
                             <Button

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
             options: React.PropTypes.instanceOf(Immutable.List),
             // ID of the item that should initially be selected
             defaultSelected: React.PropTypes.string,
-            // Initial text value to display
+            // Initial text value to display.  TODO: explain how this behaves differently based on other options
             value: React.PropTypes.string,
             // Callback to handle change of selection. Return false will cancel the selection.
             onChange: React.PropTypes.func,
@@ -302,7 +302,7 @@ define(function (require, exports, module) {
         _handleSelectChange: function (id, force) {
             var confirmSelection = true;
 
-            if (this.props.live || force) {
+            if ((this.props.live || force) && (!this.props.defaultSelected || this.props.defaultSelected !== id)) {
                 confirmSelection = (this.props.onChange(id) !== false);
             }
 

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -42,6 +42,10 @@ define(function (require, exports, module) {
     var Datalist = React.createClass({
         propTypes: {
             options: React.PropTypes.instanceOf(Immutable.List),
+            // ID of the item that should initially be selected
+            defaultSelected: React.PropTypes.string,
+            // Initial text value to display
+            value: React.PropTypes.string,
             // Callback to handle change of selection. Return false will cancel the selection.
             onChange: React.PropTypes.func,
             // If true, mouse over selection will fire invoke the onChange callback.

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -208,7 +208,10 @@ define(function (require, exports, module) {
             });
 
             event.stopPropagation();
-            this.props.onChange(event, nextValue);
+
+            if (nextValue !== this.props.value) {
+                this.props.onChange(event, nextValue);
+            }
 
             if (!this.state.editing) {
                 this._releaseFocus();

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -185,6 +185,15 @@ define(function (require, exports, module) {
             } else {
                 return this.bounds;
             }
+        },
+
+        /**
+         * Strip the file extension from the document name
+         *
+         * @return {string}
+         */
+        "nameWithoutExtension": function () {
+            return this.name.replace(/\.psd$/i, "");
         }
     }));
 

--- a/src/js/models/documentexports.js
+++ b/src/js/models/documentexports.js
@@ -150,6 +150,19 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Given a list of layers, return the sub-set that has no export assets configured
+     *
+     * @param {Immutable.List.<Layer>} layers
+     * @return {Immutable.List.<Layer>}
+     */
+    DocumentExports.prototype.filterLayersWithoutExports = function (layers) {
+        return layers.filter(function (layer) {
+            var layerExports = this.getLayerExports(layer.id);
+            return !layerExports || layerExports.isEmpty();
+        }, this);
+    };
+
+    /**
      * Given a set of layers, produce a "zipped" list of of lists of ExportAssets for those layers,
      * grouped by index within the layers
      *

--- a/src/js/models/historystate.js
+++ b/src/js/models/historystate.js
@@ -37,6 +37,11 @@ define(function (require, exports, module) {
         document: null,
 
         /**
+         * @type {DocumentExports}
+         */
+        documentExports: null,
+
+        /**
          * @type {string}
          */
         name: null,
@@ -52,6 +57,31 @@ define(function (require, exports, module) {
         rogue: false
 
     });
+
+    /**
+     * Return true if either a document or documentExports is provided,
+     * and it is not equal to its associated property on this object
+     *
+     * @param {Document} document
+     * @param {DocumentExports} documentExports
+     * @return {boolean}
+     */
+    HistoryState.prototype.isInconsistent = function (document, documentExports) {
+        return (this.document && this.document !== document) ||
+            (this.documentExports && this.documentExports !== documentExports);
+    };
+
+    /**
+     * Make a copy of this state that is suitable for generating a new "revert" state
+     *
+     * @return {HistoryState}
+     */
+    HistoryState.prototype.cloneForRevert = function () {
+        return new HistoryState({
+            document: this.document,
+            documentExports: this.documentExports
+        });
+    };
 
     module.exports = HistoryState;
 });

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -837,7 +837,7 @@ define(function (require, exports, module) {
     Object.defineProperty(LayerStructure.prototype, "filterExportable", objUtil.cachedLookupSpec(function (layers) {
         return layers.filterNot(function (layer) {
             return !layer.bounds ||
-                layer.bounds.empty ||
+                this.childBounds(layer).empty ||
                 layer.isBackground ||
                 layer.kind === layer.layerKinds.ADJUSTMENT ||
                 this.isEmptyGroup(layer);

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_LEADING_CHANGED, this._handleTypeLeadingChanged,
                 events.document.TYPE_ALIGNMENT_CHANGED, this._handleTypeAlignmentChanged,
                 events.document.TYPE_PROPERTIES_CHANGED, this._handleTypePropertiesChanged,
-                events.document.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
+                events.document.history.amendment.LAYER_EXPORT_ENABLED_CHANGED, this._handleLayerExportEnabledChanged,
                 events.document.history.nonOptimistic.GUIDE_SET, this._handleGuideSet,
                 events.document.history.nonOptimistic.GUIDE_DELETED, this._handleGuideDeleted,
                 events.document.history.nonOptimistic.GUIDES_CLEARED, this._handleGuidesCleared

--- a/src/js/stores/export.js
+++ b/src/js/stores/export.js
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
         /**
          * state
          *
-         * @type {[type]}
+         * @type {State}
          */
         _state: new State(),
 
@@ -86,8 +86,8 @@ define(function (require, exports, module) {
                 events.export.history.optimistic.DELETE_ASSET, this._deleteAsset,
                 events.export.SET_AS_REQUESTED, this._setAssetsRequested,
                 events.export.SERVICE_STATUS_CHANGED, this._setState,
-                events.document.DOCUMENT_UPDATED, this._documentUpdated,
-                events.export.SET_STATE_PROPERTY, this._setState
+                events.export.SET_STATE_PROPERTY, this._setState,
+                events.document.DOCUMENT_UPDATED, this._documentUpdated
             );
         },
 
@@ -106,10 +106,16 @@ define(function (require, exports, module) {
          * Get the DocumentExports model object associated to the provided documentID
          *
          * @param {number} documentID
+         * @param {boolean=} initialize Optional, if true then create documentExports on the fly if necessary
          * @return {?DocumentExports}
          */
-        getDocumentExports: function (documentID) {
-            return this._documentExportsMap.get(documentID);
+        getDocumentExports: function (documentID, initialize) {
+            var documentExports = this._documentExportsMap.get(documentID);
+            if (!documentExports && initialize) {
+                return new DocumentExports();
+            } else {
+                return documentExports;
+            }
         },
 
         /**

--- a/src/js/stores/export.js
+++ b/src/js/stores/export.js
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
          * @return {?string}
          */
         getExportPrefix: function (layer, index) {
-            if (this._useArtboardPrefix && layer.isArtboard) {
+            if (this._state.useArtboardPrefix && layer.isArtboard) {
                 return _.padLeft(index + 1, 3, "0");
             }
         },

--- a/src/js/stores/export.js
+++ b/src/js/stores/export.js
@@ -81,8 +81,9 @@ define(function (require, exports, module) {
             this.bindActions(
                 events.RESET, this._deleteExports,
                 events.export.ASSET_CHANGED, this._assetUpdated,
-                events.export.ASSET_ADDED, this._assetAdded,
-                events.export.DELETE_ASSET, this._deleteAsset,
+                events.export.history.optimistic.ASSET_CHANGED, this._assetUpdated,
+                events.export.history.optimistic.ASSET_ADDED, this._assetAdded,
+                events.export.history.optimistic.DELETE_ASSET, this._deleteAsset,
                 events.export.SET_AS_REQUESTED, this._setAssetsRequested,
                 events.export.SERVICE_STATUS_CHANGED, this._setState,
                 events.document.DOCUMENT_UPDATED, this._documentUpdated,
@@ -109,6 +110,24 @@ define(function (require, exports, module) {
          */
         getDocumentExports: function (documentID) {
             return this._documentExportsMap.get(documentID);
+        },
+
+        /**
+         * Update a given DocumentExports
+         * This should only be called by other stores.
+         *
+         * @param {number} documentID
+         * @param {DocumentExports} nextDocumentExports
+         */
+        setDocumentExports: function (documentID, nextDocumentExports) {
+            var oldDocumentExports = this.getDocumentExports(documentID);
+
+            if (Immutable.is(oldDocumentExports, nextDocumentExports)) {
+                return;
+            }
+
+            this._documentExportsMap = this._documentExportsMap.set(documentID, nextDocumentExports);
+            this.emit("change");
         },
 
         /**

--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -151,8 +151,9 @@ define(function (require, exports, module) {
 
     /**
      * Pop the folder chooser
+     * Rejects with ExportService.CancelPromptError if the user cancels the dialog
      *
-     * @return {Promise.<?string>} Promise of a File Path of the chosen folder, returns null if user-canceled
+     * @return {Promise.<?string>} Promise of a File Path of the chosen folder, 
      */
     ExportService.prototype.promptForFolder = function (folderPath) {
         return this._spacesDomain.exec("promptForFolder", { folderPath: folderPath })
@@ -162,7 +163,7 @@ define(function (require, exports, module) {
                     log.warn("Prompt for folder failed, and it wasn't a simple 'cancel'");
                     throw new Error("Failed to open an OS folder chooser dialog: " + err.message);
                 }
-                return Promise.resolve();
+                throw new ExportService.CancelPromptError();
             });
     };
     
@@ -192,6 +193,12 @@ define(function (require, exports, module) {
      * @type {string}
      */
     ExportService.domainPrefKey = GeneratorConnection.domainPrefKey(GENERATOR_DOMAIN_NAME);
+
+    /**
+     * A custom error that occurs when the user cancels the OS dialog prompt
+     */
+    ExportService.CancelPromptError = function MyCustomError () {};
+    ExportService.CancelPromptError.prototype = Object.create(Error.prototype);
 
     module.exports = ExportService;
 });

--- a/src/js/util/gridsort.js
+++ b/src/js/util/gridsort.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
      * @private
      * @param {Array.<object>} rows
      * @param {Layer} layer
-     * @param {number=} index if not supplied, start at zero
+     * @param {number=} index Optional. If not supplied, start at zero
      * @return {Array.<object>} rows, updated with the layer in its correct row
      */
     var _addLayerToRow = function (rows, layer, index) {

--- a/src/js/util/gridsort.js
+++ b/src/js/util/gridsort.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Immutable = require("immutable"),
+        _ = require("lodash");
+
+    /**
+     * Add a new "row" with this layer, or update an existing one if supplied
+     * A row contains an array of layers, as well as max vertical bounds for the row
+     *
+     * @private
+     * @param {Layer} layer
+     * @param {object=} row Optional, merge with this row if supplied
+     * @return {object} row representation
+     */
+    var _upsertRow = function (layer, row) {
+        var bounds = layer.bounds;
+        if (row) {
+            row.layers.push(layer);
+            row.top = Math.min(row.top, bounds.top);
+            row.bottom = Math.max(row.bottom, bounds.bottom);
+            return row;
+        } else {
+            return {
+                top: bounds.top,
+                bottom: bounds.bottom,
+                layers: [layer]
+            };
+        }
+    };
+
+    /**
+     * Recursively search rows to determine where the given layer's bounds fit
+     * And then merge it in.
+     *
+     * @private
+     * @param {Array.<object>} rows
+     * @param {Layer} layer
+     * @param {number=} index if not supplied, start at zero
+     * @return {Array.<object>} rows, updated with the layer in its correct row
+     */
+    var _addLayerToRow = function (rows, layer, index) {
+        index = index || 0;
+
+        var row = rows[index],
+            bounds = layer.bounds,
+            newIndex;
+
+        if (!row) {
+            newIndex = index;
+        } else if (bounds.bottom < row.top) {
+            newIndex = index - 1;
+        } else if (bounds.top < row.bottom && bounds.bottom > row.top) {
+            newIndex = index;
+        } else if (index === rows.length - 1) {
+            newIndex = index + 1;
+        } else {
+            return _addLayerToRow(rows, layer, index + 1);
+        }
+
+        if (rows.length === 0) {
+            rows[0] = _upsertRow(layer);
+        } else if (rows[newIndex]) {
+            rows[newIndex] = _upsertRow(layer, rows[newIndex]);
+        } else if (newIndex < 0) {
+            rows.unshift(_upsertRow(layer));
+        } else {
+            rows.push(_upsertRow(layer));
+        }
+
+        return rows;
+    };
+
+    /**
+     * Sort layers in a grid like order, left-to-right, top-to-bottom
+     *
+     * @param {Immutable.Iterable.<Layer>} layers
+     * @return {Immutable.List.<Layer>}
+     */
+    var gridSort = function (layers) {
+        // filter any layers without bounds, just in case
+        // sort left-to-right, then reduce them into a grid.
+        // note the use of '_.ary()' to pass only the first two reducer args into _addLayerToRow
+        var grid = layers.filter(function (layer) {
+                return layer.bounds && !layer.bounds.empty;
+            })
+            .sort(function (a, b) {
+                return a.bounds.left - b.bounds.left;
+            })
+            .reduce(_.ary(_addLayerToRow, 2), []);
+
+        // flatten the array of "rows" into a simple list of layers
+        return Immutable.List(_.flatten(_.pluck(grid, "layers")));
+    };
+
+    module.exports = gridSort;
+});

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -36,7 +36,8 @@
         "SET_TYPE_LEADING": "Set Type Leading",
         "SET_TYPE_TRACKING": "Set Type Tracking",
         "SET_TYPE_ALIGNMENT": "Set Type Alignment",
-        "UNGROUP_LAYERS": "Ungroup layers"
+        "UNGROUP_LAYERS": "Ungroup layers",
+        "MODIFY_EXPORT_ASSETS": "Updated Export Asset Configurations"
     },
     "APP_NAME": "Photoshop",
     "FIRST_LAUNCH": {

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -44,7 +44,6 @@
 }
 
 .exports-panel__container__busy {
-    border: 2px solid red;
 }
 
 .exports-panel__two-column {

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -43,6 +43,10 @@
     font-size: 1.5rem;
 }
 
+.exports-panel__container__busy {
+    border: 2px solid red;
+}
+
 .exports-panel__two-column {
     display: flex;
     flex-grow: 1;

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -98,6 +98,15 @@
 
 .exports-panel__layer__name {
     font-size: 1.5rem;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: baseline;
+}
+
+.exports-panel__layer__prefix {
+    font-size: 1.3rem;
+    margin-right: 0.8rem;
+    color: @warm-gray;
 }
 
 .exports-panel__layer-assets {

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -43,9 +43,6 @@
     font-size: 1.5rem;
 }
 
-.exports-panel__container__busy {
-}
-
 .exports-panel__two-column {
     display: flex;
     flex-grow: 1;
@@ -159,6 +156,13 @@
     &:hover {
         opacity: 1;
     }
+
+    svg {
+        width: 1.6rem;
+        height: 1.6rem;
+        fill:  @item-active;
+        stroke: none;
+    }
 }
 
 .exports-panel__button-group__separator {
@@ -175,6 +179,14 @@
 .layer-exports__workflow-buttons {
     display: flex;
     flex-direction: row;
+}
+
+.layer-exports__workflow-buttons .button-simple {
+    &__disabled, &__disabled:hover {
+        svg {
+            fill: @item-disabled;
+        }
+    }
 }
 
 .layer-exports__delete-button {

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -35,7 +35,6 @@ button {
 }
 
 .button-simple__disabled {
-    border: 1px solid red;
 }
 
 .button-toggle__disabled {

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -35,6 +35,7 @@ button {
 }
 
 .button-simple__disabled {
+    border: 1px solid red;
 }
 
 .button-toggle__disabled {


### PR DESCRIPTION
A handful of export-related changes...

1. History store now tracks the export store' state, and modifications to export assets create history states.
1. Pursuant to the above, DataList and TextInput were modified so that selecting the same (default) value will not call its `onChange` (thus not causing frivolous history states when tabbing through export configuration values)
1. Artboards in the Export dialog are now sorted via their "grid" layout on canvas as opposed to by Z-index in the layer's panel (this partially mitigates #2212, I think)
1. Artboards in the Export dialog: optionally prefix the filename with a three digit value, generated on the fly by the grid-sorted order of artboards
1. The above "prefix" option is defaulted to false, but the user's choice is sticky, via DS preferences.
1. Export Panel: :arrow_down: icon will auto-generate a default asset if none exist, making simple export a one-click operation
1. Creating a new artboard will auto-populate a simple 1x asset configuration.  Note that it will not be fully supported until the artboard has at least one visible component (otherwise generator will not export it, so it is marked as not export-supported initially)
1. Exports are now done without blocking the UI, and the "busy" state is reflected in both Export dialog and panel.  This UI will need to improve, but this is a start.
1. The folder prompt process will throw a custom error if the user cancels, which allowed for a more readable (IMO) refactoring of the export* actions.
1. Document-level exports will use the document's name as the base file name
1. Addresses disabled state export button icon bug #2302
1. Addresses non-empty-group support bug #2376
