### PR TITLE
Export Panel UI updates

### DIFF
--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -29,8 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable");
 
-    var Gutter = require("jsx!js/jsx/shared/Gutter"),
-        Label = require("jsx!js/jsx/shared/Label"),
+    var Label = require("jsx!js/jsx/shared/Label"),
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         Datalist = require("jsx!js/jsx/shared/Datalist"),
@@ -147,37 +146,37 @@ define(function (require, exports, module) {
                 formatListID = "exportAsset-format-" + keySuffix;
 
             return (
-                <div className="formline">
-                    <Datalist
-                        list={scaleListID}
-                        className="dialog-export-scale"
-                        options={_scaleOptions.toList()}
-                        value={scaleOption.title}
-                        defaultSelected={scaleOption.id}
-                        onChange={this._handleUpdateScale}
-                        live={false}
-                        size="column-4" />
-                    <Gutter />
-                    <TextInput
-                        value={exportAsset.suffix}
-                        singleClick={true}
-                        editable={true}
-                        live={true}
-                        onChange={this._handleUpdateSuffix}
-                        size="column-6" />
-                    <Gutter />
-                    <Datalist
-                        list={formatListID}
-                        className="dialog-export-format"
-                        options={_formatOptions.toList()}
-                        value={exportAsset.format.toUpperCase()}
-                        defaultSelected={exportAsset.format}
-                        onChange={this._handleUpdateFormat}
-                        live={false}
-                        size="column-4" />
-                    <Gutter />
+                <div className="formline formline__space-between">
+                    <div className="control-group__vertical">
+                        <Datalist
+                            list={scaleListID}
+                            className="dialog-export-scale"
+                            options={_scaleOptions.toList()}
+                            value={scaleOption.title}
+                            onChange={this._handleUpdateScale}
+                            live={false}
+                            size="column-4" />
+                    </div>
+                    <div className="control-group__vertical">
+                        <TextInput
+                            value={exportAsset.suffix}
+                            singleClick={true}
+                            editable={true}
+                            onChange={this._handleUpdateSuffix}
+                            size="column-8" />
+                    </div>
+                    <div className="control-group__vertical">
+                        <Datalist
+                            list={formatListID}
+                            className="dialog-export-format"
+                            options={_formatOptions.toList()}
+                            value={exportAsset.format.toUpperCase()}
+                            onChange={this._handleUpdateFormat}
+                            live={false}
+                            size="column-8" />
+                    </div>
                     <Button
-                        className="layer-exports__delete-button"
+                        className="layer-exports__delete-button control-group__vertical"
                         title={strings.TOOLTIPS.EXPORT_REMOVE_ASSET}
                         onClick={this._handleDeleteClick}>
                         <SVGIcon CSSID="delete" />
@@ -224,28 +223,26 @@ define(function (require, exports, module) {
 
             return (
                 <div className="layer-exports__header" >
-                    <div className="formline">
+                    <div className="formline formline__space-between">
                         <Label
                             title={strings.EXPORT.TITLE_SCALE}
                             size="column-4"
                             className="label__medium__left-aligned">
                             {strings.EXPORT.TITLE_SCALE}
                         </Label>
-                        <Gutter />
                         <Label
                             title={strings.EXPORT.TITLE_SUFFIX}
-                            size="column-6"
+                            size="column-8"
                             className="label__medium__left-aligned">
                             {strings.EXPORT.TITLE_SUFFIX}
                         </Label>
-                        <Gutter />
                         <Label
                             title={strings.EXPORT.TITLE_SETTINGS}
-                            size="column-4"
+                            size="column-8"
                             className="label__medium__left-aligned">
                             {strings.EXPORT.TITLE_SETTINGS}
                         </Label>
-                        <Gutter />
+                        <div className="column-2"></div>
                     </div>
                     {exportComponents}
                 </div>

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
     var ExportList = require("jsx!js/jsx/sections/export/ExportList"),
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         Button = require("jsx!js/jsx/shared/Button"),
-        Gutter = require("jsx!js/jsx/shared/Gutter"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         strings = require("i18n!nls/strings"),
         ExportAsset = require("js/models/exportasset"),
@@ -214,13 +213,11 @@ define(function (require, exports, module) {
                     supportedLayers = undefined;
                 }
 
-                containerContents = containerContents || this.props.visible && (
-                    <div>
-                        <ExportList {...this.props}
-                            documentExports={this.state.documentExports}
-                            layers={supportedLayers}
-                            onFocus={this._handleFocus}/>
-                    </div>
+                containerContents = containerContents || (
+                    <ExportList {...this.props}
+                        documentExports={this.state.documentExports}
+                        layers={supportedLayers}
+                        onFocus={this._handleFocus}/>
                 );
             }
 
@@ -254,7 +251,6 @@ define(function (require, exports, module) {
                                 <SVGIcon
                                     CSSID={exportState.serviceBusy ? "loader" : "export"} />
                             </Button>
-                            <Gutter />
                             <Button
                                 className="button-plus"
                                 disabled={disabled}
@@ -265,7 +261,6 @@ define(function (require, exports, module) {
                                     viewbox="0 0 16 16"
                                     CSSID="add-new" />
                             </Button>
-                            <Gutter />
                             <Button
                                 className="button-iOS"
                                 disabled={disabled}
@@ -276,7 +271,6 @@ define(function (require, exports, module) {
                                     viewbox="0 0 24 16"
                                     CSSID="iOS" />
                             </Button>
-                            <Gutter />
                             <Button
                                 className="button-xdpi"
                                 disabled={disabled}

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -149,7 +149,7 @@ define(function (require, exports, module) {
             if (this.props.document.layers.selected.isEmpty()) {
                 return null;
             }
-            
+
             var containerClasses = classnames({
                 "section-container": true,
                 "section-container__collapsed": !this.props.visible

--- a/src/js/jsx/sections/style/VectorAppearance.jsx
+++ b/src/js/jsx/sections/style/VectorAppearance.jsx
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
             var onlyTextLayers = this.props.document.layers.selected.every(function (layer) {
                 return layer.kind === layer.layerKinds.TEXT;
             });
-            
+
             if (onlyTextLayers) {
                 return null;
             }

--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -65,17 +65,17 @@ define(function (require, exports, module) {
                 }),
                 fills = collection.pluck(layers, "fill"),
                 downsample = this._downsampleFills(fills);
-            
+
             this.setState({
                 layers: layers,
                 fill: downsample
             });
         },
-        
+
         componentWillMount: function () {
             this._setFillState(this.props);
         },
-        
+
         componentWillReceiveProps: function (nextProps) {
             this._setFillState(nextProps);
         },
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
                 if (!fill) {
                     return null;
                 }
-            
+
                 if (fill.type === contentLayerLib.contentTypes.SOLID_COLOR) {
                     return fill.color;
                 } else {
@@ -116,11 +116,11 @@ define(function (require, exports, module) {
             var onlyTextLayers = this.props.document.layers.selected.every(function (layer) {
                 return layer.kind === layer.layerKinds.TEXT;
             });
-            
+
             if (onlyTextLayers) {
                 return null;
             }
-            
+
             return (
                 <div className="formline">
                     <div className="control-group__vertical">
@@ -152,10 +152,10 @@ define(function (require, exports, module) {
                             layers={this.props.document.layers.selected} />
                     </div>
                     <div className="control-group__vertical control-group__no-label">
-                            <FillVisiblity
-                                document={this.props.document}
-                                layers={this.state.layers}
-                                fill={this.state.fill} />
+                        <FillVisiblity
+                            document={this.props.document}
+                            layers={this.state.layers}
+                            fill={this.state.fill} />
                     </div>
                 </div>
             );

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -52,7 +52,6 @@ define(function (require, exports, module) {
                         <div className="formline column-24 formline__padded-first-child">
                             <div className="control-group">
                                 <Size document={this.props.document} />
-                                
                             </div>
                             <div className="control-group">
                                 <div className="control-group reference-mark">

--- a/src/js/jsx/shared/SplitButton.jsx
+++ b/src/js/jsx/shared/SplitButton.jsx
@@ -79,7 +79,6 @@ define(function (require, exports, module) {
             
             if (!this.props.size) {
                 var numberOfItems = React.Children.count(this.props.children);
-
                 // TODO make this more readable and move complexity to LESS
                 buttonWrapperClasses = classnames({
                     "column-12": numberOfItems < 4,

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -155,7 +155,8 @@ input[type="text"]:hover {
 .transform,
 .appearance,
 .effects,
-.type {
+.type,
+.export {
     input[type="text"] {
         border-bottom: @hairline solid @underlines;
         

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -176,6 +176,7 @@
 /**
  * Exports Panel
  */
+
 .layer-exports__workflow-buttons {
     display: flex;
     flex-direction: row;
@@ -189,11 +190,23 @@
     }
 }
 
+.layer-exports__header {
+   width: 100%;
+
+   .formline.formline__space-between div input {
+        font-size: 1.4rem;
+    }
+}
+
 .layer-exports__delete-button {
     svg {
         width: 1.6rem;
         height: 1.6rem;
         fill:  @item-disabled;
         stroke: none;
+    }
+
+    svg:hover {
+        fill: @item-active;
     }
 }

--- a/src/style/shared/drop-down.less
+++ b/src/style/shared/drop-down.less
@@ -45,6 +45,9 @@
     background-size: 1rem;
     border-bottom: @hairline solid transparent;
 
+    svg {
+        fill: @item-active;
+    }
 }
 
 .drop-down:hover {
@@ -56,7 +59,8 @@
 
 .appearance,
 .type,
-.effects {
+.effects,
+.export {
     .drop-down {
         border-bottom: @hairline solid @underlines;
         


### PR DESCRIPTION
With reference to the designs here: https://trello.com/c/KR5wYVkW/494-design
This has been reviewed once by @designedbyscience in the Review Only PR #2341 

- I used the new stylings written for `.formline` and `.formline__space-between` to have the elements span the entire width of the Export Panel, as the designs show. 
- In order to have the formlines span the entire width of the Export Panel, I had to take away some of the modularity that `containerContents` provided so that an extra div would not be inserted. Then I could have dictate that the width of the `<ExportList>` will span the container. 
- Took out <Gutter> components in `ExportList.jsx` and `ExportPanel.jsx`
- Made every element of the formline have an underline 
- Changed the font size of the `TextInput` to match the font size in the datalists.
- Update the column widths 

Final look of the Export Panel: 

![alt text](https://www.dropbox.com/s/llf9twrzy7vtmdu/Screenshot%202015-09-10%2011.23.09.png?raw=1 "Logo Title Text 1")

![alt text](https://www.dropbox.com/s/szdqf1s727vm7sp/Screenshot%202015-09-10%2011.23.19.png?raw=1 "Logo Title Text 1")