### PR TITLE
Color Picker grabbag

### DIFF
--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
             var document = props.document,
                 // We only care about vector layers. If at least one exists, then this component should render
                 layers = document.layers.selected.filter(function (layer) {
-                    return layer.isVector;
+                    return layer.isVector();
                 }),
                 strokes = collection.pluck(layers, "stroke"),
                 downsample = this._downsampleStrokes(strokes);

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -310,6 +310,7 @@ define(function (require, exports, module) {
                         dismissOnWindowClick>
                         <ColorPicker
                             ref="colorpicker"
+                            swatchOverlay={this.props.swatchOverlay}
                             label={label}
                             editable={this.props.editable}
                             opaque={this.props.opaque}

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -50,7 +50,8 @@ define(function (require, exports, module) {
      */
     var DISSMISS_ON_KEYS = [
         { key: os.eventKeyCode.ESCAPE, modifiers: null },
-        { key: os.eventKeyCode.ENTER, modifiers: null }
+        { key: os.eventKeyCode.ENTER, modifiers: null },
+        { key: os.eventKeyCode.TAB, modifiers: null}
     ];
 
     var ColorInput = React.createClass({
@@ -115,7 +116,7 @@ define(function (require, exports, module) {
          * @private
          * @param {Color} color
          */
-        _handleColorChanged: function (color) {
+        _handleColorChanged: function (color, coalesce) {
             var coalesce = this.shouldCoalesce();
             this.props.onColorChange(color, coalesce);
             if (!coalesce) {
@@ -160,6 +161,11 @@ define(function (require, exports, module) {
         },
 
         _handleSwatchFocus: function (event) {
+            var target = event.target;
+            if (target === window.document.activeElement) {
+                return;
+            }
+
             return this._toggleColorPicker(event);
         },
 

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -307,9 +307,9 @@ define(function (require, exports, module) {
             });
 
             var overlay;
-            if (this.props.hasOwnProperty("hue")) {
+            if (this.props.hasOwnProperty("color")) {
                 // this is an alpha slider
-                var bgColor = tinycolor({ h: this.props.hue, s: 1, v: 1 }).toHexString(),
+                var bgColor = tinycolor(this.props.color.toJS()).toHexString(),
                     bgGradient = "linear-gradient(to right, rgba(1, 1, 1, 0) 0%, " + bgColor + " 100%)";
 
                 overlay = (
@@ -510,15 +510,14 @@ define(function (require, exports, module) {
         },
 
         render: function () {
+            var swatchOverlay = this.props.swatchOverlay(tinycolor(this.props.color.toJS()));
+
             return (
                 <div
                     className="color-picker__colortype">
                     <div
-                        className="color-picker__colortype__thumb empty">
-                    </div>
-                    <Gutter/>
-                    <div
                         className="color-picker__colortype__thumb selected">
+                        {swatchOverlay}
                     </div>
                     <Gutter/>
                     <Gutter/>
@@ -963,7 +962,7 @@ define(function (require, exports, module) {
                         <Slider
                             vertical={false}
                             value={color.a}
-                            hue={color.h}
+                            color={color}
                             max={1}
                             disabled={this.props.opaque}
                             onMouseUp={this._handleMouseUp}

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -756,6 +756,17 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Event handler for the transparency input
+         * Converts from percentage to decimal
+         *
+         * @param {SyntheticEvent} event
+         * @param {number} alpha
+         */
+        _handleTransparencyInput: function (event, alpha) {
+            this._handleTransparencyChange(alpha / 100);
+        },
+
+        /**
          * Event handler for the hue slider.
          * 
          * @param {number} hue
@@ -944,7 +955,9 @@ define(function (require, exports, module) {
                             size="column-5"
                             placeholder="100"
                             ref="opacity"
-                            onKeyDown={this._handleKeyDown}/>
+                            value={Math.round(color.a * 100)}
+                            onKeyDown={this._handleKeyDown}
+                            onChange={this._handleTransparencyInput}/>
                     </div>
                     <div className="color-picker__transparency-slider">
                         <Slider

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -490,6 +490,19 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Special case handler for shift_tab to focus back on opacity input
+         *
+         * @private
+         * @param {KeyboardEvent} event
+         */
+        _handleKeyDown: function (event) {
+            if (event.shiftKey && event.key === "Tab") {
+                this.props.onShiftTabPress();
+                event.preventDefault();
+            }
+        },
+
+        /**
          * Begin the edit of the TextInput
          */
         focus: function () {
@@ -515,6 +528,7 @@ define(function (require, exports, module) {
                         editable={this.props.editable}
                         value={this.props.label}
                         singleClick={true}
+                        onKeyDown={this._handleKeyDown}
                         onChange={this._handleInputChanged}
                         onFocus={this._handleFocus}
                         onClick={this._handleInputClicked} />
@@ -857,10 +871,31 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Special case handler for tab key on the Opacity input
+         * to transfer the focus back to color input
+         *
+         * @private
+         * @param {KeyboardEvent} event
+         */
+        _handleKeyDown: function (event) {
+            if (!event.shiftKey && event.key === "Tab") {
+                this.focusInput();
+                event.preventDefault();
+            }
+        },
+
+        /**
          * Focuses on the ColorType component
          */
         focusInput: function () {
             this.refs.input.focus();
+        },
+
+        /**
+         * Focuses on the opacity input component
+         */
+        focusOpacityInput: function () {
+            React.findDOMNode(this.refs.opacity).focus();
         },
 
         render: function () {
@@ -877,6 +912,7 @@ define(function (require, exports, module) {
                 <div className="color-picker">
                     <ColorType {...this.props}
                         ref="input"
+                        onShiftTabPress={this.focusOpacityInput}
                         onChange={this._handleColorTypeChange}/>
                     <Map
                         x={color.s}
@@ -907,7 +943,8 @@ define(function (require, exports, module) {
                         <NumberInput
                             size="column-5"
                             placeholder="100"
-                            onTabPress={this.focusInput}/>
+                            ref="opacity"
+                            onKeyDown={this._handleKeyDown}/>
                     </div>
                     <div className="color-picker__transparency-slider">
                         <Slider

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -906,7 +906,8 @@ define(function (require, exports, module) {
                         </Label>
                         <NumberInput
                             size="column-5"
-                            placeholder="100" />
+                            placeholder="100"
+                            onTabPress={this.focusInput}/>
                     </div>
                     <div className="color-picker__transparency-slider">
                         <Slider

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -453,10 +453,7 @@ define(function (require, exports, module) {
          * @param {SyntheticEvent} event
          */
         _handleInputClicked: function (event) {
-            var dialog = this.refs.dialog;
-            if (dialog.isOpen()) {
-                event.stopPropagation();
-            }
+            event.stopPropagation();
         },
 
         /**
@@ -518,7 +515,7 @@ define(function (require, exports, module) {
         },
 
         focus: function () {
-            React.findDOMNode(this.refs.input).focus();
+            this.refs.input._beginEdit();
         }
     });
 
@@ -807,8 +804,7 @@ define(function (require, exports, module) {
 
         _handleColorTypeChange: function (color) {
             this.setColor(color, true);
-            this.props.onChange(color, false); // do not coalesce this change
-            // FIXME: need to move the Coalesce state into ColorPicker from ColorInput.
+            this.props.onColorChange(color);
         },
 
         render: function () {

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -896,17 +896,17 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Focuses on the opacity input component
+         */
+        _focusOpacityInput: function () {
+            React.findDOMNode(this.refs.opacity).focus();
+        },
+
+        /**
          * Focuses on the ColorType component
          */
         focusInput: function () {
             this.refs.input.focus();
-        },
-
-        /**
-         * Focuses on the opacity input component
-         */
-        focusOpacityInput: function () {
-            React.findDOMNode(this.refs.opacity).focus();
         },
 
         render: function () {
@@ -923,7 +923,7 @@ define(function (require, exports, module) {
                 <div className="color-picker">
                     <ColorType {...this.props}
                         ref="input"
-                        onShiftTabPress={this.focusOpacityInput}
+                        onShiftTabPress={this._focusOpacityInput}
                         onChange={this._handleColorTypeChange}/>
                     <Map
                         x={color.s}

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -324,6 +324,12 @@ define(function (require, exports, module) {
                 }
                 event.preventDefault();
                 break;
+            case "Tab":
+                if (this.props.onTabPress) {
+                    this.props.onTabPress();
+                    event.preventDefault();
+                }
+                break;
             }
 
             if (this.props.onKeyDown) {

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -324,12 +324,6 @@ define(function (require, exports, module) {
                 }
                 event.preventDefault();
                 break;
-            case "Tab":
-                if (this.props.onTabPress) {
-                    this.props.onTabPress();
-                    event.preventDefault();
-                }
-                break;
             }
 
             if (this.props.onKeyDown) {

--- a/src/style/shared/color-input.less
+++ b/src/style/shared/color-input.less
@@ -53,6 +53,9 @@
     border-radius: 0.2rem;
     .background-checkerboard();
     overflow: hidden;
+    &:focus {
+        box-shadow: 0 0 0 0.2rem @focus-highlight;
+    }
 }
 
 .color-input__swatch__color {
@@ -68,6 +71,7 @@
     justify-content: center;
     overflow: hidden;
 }
+
 
 .color-input__empty {
     height: 3.7rem; 

--- a/src/style/shared/color-input.less
+++ b/src/style/shared/color-input.less
@@ -72,7 +72,6 @@
     overflow: hidden;
 }
 
-
 .color-input__empty {
     height: 3.7rem; 
     width: 4rem;


### PR DESCRIPTION
 - Moved coalescing functionality into color picker
 - Add focus state highlight to color picker swatch so when it's tabbed to, it's highlighted, and toggles dialog with Enter/Esc
 - On dialog open, focus on the ColorInput, and tab becomes locked into the color picker dialog. Tab on Opacity input goes to Color input, and shift tab on color input goes to opacity input.
 - Fix a stroke issue #2382 