### PR TITLE
CC Libraries - bug fixes

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -35,6 +35,7 @@ define(function (require, exports) {
         layerEffectAdapter = require("adapter/lib/layerEffect"),
         textLayerAdapter = require("adapter/lib/textLayer"),
         libraryAdapter = require("adapter/lib/libraries"),
+        documentLib = require("adapter/lib/document"),
         os = require("adapter/os");
 
     var events = require("js/events"),
@@ -827,9 +828,15 @@ define(function (require, exports) {
             .bind(this)
             .then(function (path) {
                 var layerRef = layerEffectAdapter.referenceBy.current,
-                    placeObj = layerEffectAdapter.applyLayerStyleFile(layerRef, path);
+                    placeObj = layerEffectAdapter.applyLayerStyleFile(layerRef, path),
+                    options = {
+                        historyStateInfo: {
+                            name: strings.ACTIONS.APPLY_LAYER_STYLE,
+                            target: documentLib.referenceBy.id(currentDocument.id)
+                        }
+                    };
 
-                return descriptor.playObject(placeObj);
+                return descriptor.playObject(placeObj, options);
             })
             .then(function () {
                 // FIXME: This can be more optimistic
@@ -872,9 +879,15 @@ define(function (require, exports) {
 
         var textLayerIDs = collection.pluck(textLayers, "id"),
             layerRef = textLayerIDs.map(textLayerAdapter.referenceBy.id).toArray(),
-            applyObj = textLayerAdapter.applyTextStyle(layerRef, styleData);
+            applyObj = textLayerAdapter.applyTextStyle(layerRef, styleData),
+            options = {
+                historyStateInfo: {
+                    name: strings.ACTIONS.APPLY_TEXT_STYLE,
+                    target: documentLib.referenceBy.id(currentDocument.id)
+                }
+            };
 
-        return layerActionsUtil.playSimpleLayerActions(currentDocument, textLayers, applyObj, true)
+        return layerActionsUtil.playSimpleLayerActions(currentDocument, textLayers, applyObj, true, options)
             .bind(this)
             .then(function () {
                 return this.transfer(layerActions.resetLayers, currentDocument, textLayers);

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -866,9 +866,8 @@ define(function (require, exports) {
             return Promise.resolve();
         }
         
-        // To make textLayerAdapter.applyTextStyle apply text color correctly, styleData.color must be an array.
-        if (styleData.color && !(styleData.color instanceof Array)) {
-            styleData.color = [styleData.color];
+        if (styleData.color instanceof Array) {
+            styleData.color = styleData.color[0];
         }
 
         var textLayerIDs = collection.pluck(textLayers, "id"),

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -76,7 +76,7 @@ define(function (require, exports) {
                         return;
                     }
 
-                    if (categoryKey === "CHARACTERSTYLE") {
+                    if (categoryKey === "CHARACTERSTYLE" && !title) {
                         var charStyle = element.getPrimaryRepresentation().getValue("characterstyle", "data"),
                             font = charStyle.adbeFont,
                             fontString = font.name + " " + font.style,
@@ -134,8 +134,7 @@ define(function (require, exports) {
     var _confirmSearch = function (id) {
         var elementInfo = _idMap[id],
             appStore = this.flux.store("application"),
-            currentDocument = appStore.getCurrentDocument(),
-            currentLayers = currentDocument ? currentDocument.layers.selected : Immutable.List();
+            currentDocument = appStore.getCurrentDocument();
 
         if (elementInfo) {
             var asset = elementInfo.asset,
@@ -161,26 +160,18 @@ define(function (require, exports) {
                     
                     break;
                 case "LAYERSTYLE":
-                    // Only try to apply layer style if a single layer is selected
-                    // Should probably be handled in applyLayerStyle 
-                    if (currentLayers.size === 1) {
-                        selectPromise
-                            .bind(this)
-                            .then(function () {
-                                this.flux.actions.libraries.applyLayerStyle(asset);
-                            });
-                    }
+                    selectPromise
+                        .bind(this)
+                        .then(function () {
+                            this.flux.actions.libraries.applyLayerStyle(asset);
+                        });
                     break;
                 case "CHARACTERSTYLE":
-                    // Only try to apply character style if a single text layer is selected
-                    // Should probably be handled in applyCharacterStyle 
-                    if (currentLayers.size === 1 && currentLayers.first().isTextLayer()) {
-                        selectPromise
-                            .bind(this)
-                            .then(function () {
-                                this.flux.actions.libraries.applyCharacterStyle(asset);
-                            });
-                    }
+                    selectPromise
+                        .bind(this)
+                        .then(function () {
+                            this.flux.actions.libraries.applyCharacterStyle(asset);
+                        });
                     break;
             }
         }

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -76,7 +76,8 @@ define(function (require, exports, module) {
         shouldComponentUpdate: function (nextProps, nextState) {
             // Library's modified time reflects itself and its elements, so there is no need to check its element's 
             // modified time.
-            return this._libraryLastModified !== nextProps.library.modified ||
+            return this.props.library !== nextProps.library ||
+                this._libraryLastModified !== nextProps.library.modified ||
                 !_.isEqual(this.state, nextState);
         },
         
@@ -186,6 +187,15 @@ define(function (require, exports, module) {
 
             return elements;
         },
+        
+        /**
+         * Handle click on list background.
+         * 
+         * @private
+         */
+        _handleClick: function () {
+            this.setState({ selectedElement: null });
+        },
 
         render: function () {
             var library = this.props.library;
@@ -220,7 +230,8 @@ define(function (require, exports, module) {
             });
 
             return (
-                <div className={classNames}>
+                <div className={classNames}
+                     onClick={this._handleClick}>
                     {colorAssets}
                     {colorThemeAssets}
                     {charStyleAssets}

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames"),
         tinycolor = require("tinycolor"),
         _ = require("lodash");
 
@@ -49,8 +48,11 @@ define(function (require, exports, module) {
          * Apply the text style to the selected layers
          *
          * @private
+         * @param {SyntheticEvent} event
          */
-        _handleApply: function () {
+        _handleApply: function (event) {
+            event.stopPropagation();
+            
             this.getFlux().actions.libraries.applyCharacterStyle(this.props.element);
         },
         
@@ -84,21 +86,20 @@ define(function (require, exports, module) {
                 fontColorHex = tinycolor(color.value).toHexString().toUpperCase();
             }
 
-            var fontSizeAndColorStr = _.remove([fontSizeStr, fontColorHex], null).join(", ");
-
-            var classNames = classnames("libraries__asset", {
-                "assets__graphic__dragging": this.props.isDragging,
-                "libraries__asset-selected": this.props.selected
-            });
-
-            var displayName = element.displayName !== "" ? element.displayName : font.name + " " + font.style,
+            var fontSizeAndColorStr = _.remove([fontSizeStr, fontColorHex], null).join(", "),
+                displayName = element.displayName || (font.name + " " + font.style),
                 colorPreview = this.state.hasPreview && fontColorHex && (<div
                     style={{ backgroundColor: fontColorHex }}
                     className="libraries__asset__preview-character-style__color-swatch"/>);
 
             return (
-                <div className={classNames}
-                     key={element.id}>
+                <AssetSection
+                    element={this.props.element}
+                    onSelect={this.props.onSelect}
+                    selected={this.props.selected}
+                    title={displayName}
+                    subTitle={fontSizeAndColorStr}
+                    key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style"
                          title={strings.LIBRARIES.CLICK_TO_APPLY}
                          onClick={this._handleApply}>
@@ -107,14 +108,7 @@ define(function (require, exports, module) {
                             onComplete={this._handlePreviewCompleted}/>
                         {colorPreview}
                     </div>
-
-                    <AssetSection
-                        element={this.props.element}
-                        onSelect={this.props.onSelect}
-                        selected={this.props.selected}
-                        title={displayName}
-                        subTitle={fontSizeAndColorStr}/>
-                </div>
+                </AssetSection>
             );
         }
     });

--- a/src/js/jsx/sections/libraries/assets/Color.jsx
+++ b/src/js/jsx/sections/libraries/assets/Color.jsx
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames"),
         tinycolor = require("tinycolor");
 
     var strings = require("i18n!nls/strings"),
@@ -85,8 +84,11 @@ define(function (require, exports, module) {
          * Apply color to the selected layers.
          *
          * @private
+         * @param {SyntheticEvent} event
          */
-        _handleApply: function () {
+        _handleApply: function (event) {
+            event.stopPropagation();
+
             var colorData = this.state.colorData,
                 color = new ColorModel({ r: colorData.value.r, g: colorData.value.g, b: colorData.value.b });
 
@@ -97,23 +99,18 @@ define(function (require, exports, module) {
             var element = this.props.element,
                 displayName = element.displayName !== "" ? element.displayName : this.state.hexValue;
 
-            var classNames = classnames("libraries__asset", {
-                "libraries__asset-selected": this.props.selected
-            });
-
             return (
-                <div className={classNames}
-                     key={element.id}>
+                 <AssetSection
+                    element={this.props.element}
+                    onSelect={this.props.onSelect}
+                    selected={this.props.selected}
+                    title={displayName}
+                    key={element.id}>
                     <div className="libraries__asset__preview"
                          style={{ background: this.state.hexValue }}
                          title={strings.LIBRARIES.CLICK_TO_APPLY}
                          onClick={this._handleApply}/>
-                     <AssetSection
-                        element={this.props.element}
-                        onSelect={this.props.onSelect}
-                        selected={this.props.selected}
-                        title={displayName}/>
-                </div>
+                </AssetSection>
             );
         }
     });

--- a/src/js/jsx/sections/libraries/assets/ColorTheme.jsx
+++ b/src/js/jsx/sections/libraries/assets/ColorTheme.jsx
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames"),
         tinycolor = require("tinycolor");
 
     var ColorModel = require("js/models/color");
@@ -41,8 +40,12 @@ define(function (require, exports, module) {
          * Apply color to the selected layers.
          *
          * @private
+         * @param {object} colorData
+         * @param {SyntheticEvent} event
          */
-        _handleApply: function (colorData) {
+        _handleApply: function (colorData, event) {
+            event.stopPropagation();
+
             var color = new ColorModel({ r: colorData.value.r, g: colorData.value.g, b: colorData.value.b });
 
             this.getFlux().actions.libraries.applyColor(color);
@@ -62,23 +65,17 @@ define(function (require, exports, module) {
                              onClick={this._handleApply.bind(this, colorData)}/>);
             }.bind(this));
 
-            var classNames = classnames({
-                "libraries__asset": true,
-                "libraries__asset-colortheme": true,
-                "libraries__asset-selected": this.props.selected
-            });
-
             return (
-                <div className={classNames} key={element.id}>
+                <AssetSection
+                    element={this.props.element}
+                    onSelect={this.props.onSelect}
+                    selected={this.props.selected}
+                    title={element.displayName}
+                    classNames="libraries__asset-colortheme">
                     <div className="libraries__asset__preview libraries__asset__preview-colortheme">
                         {colorSwatchComponents}
                     </div>
-                    <AssetSection
-                        element={this.props.element}
-                        onSelect={this.props.onSelect}
-                        selected={this.props.selected}
-                        title={element.displayName}/>
-                </div>
+                </AssetSection>
             );
         }
     });

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -85,33 +85,45 @@ define(function (require, exports, module) {
         _handleOpenForEdit: function () {
             this.getFlux().actions.libraries.openGraphicForEdit(this.props.element);
         },
+        
+        /**
+         * Handle click preview.
+         * 
+         * @private
+         * @param {SyntheticEvent} event
+         */
+        _handleClickPreview: function (event) {
+            // Stop propagation to avoid triggering the select asset event.
+            event.stopPropagation();
+        },
 
         render: function () {
             var element = this.props.element,
                 dragPreview = this._renderDragPreview();
 
-            var classNames = classnames("libraries__asset", {
-                "assets__graphic__dragging": this.props.isDragging,
-                "libraries__asset-selected": this.props.selected
+            var classNames = classnames({
+                "assets__graphic__dragging": this.props.isDragging
             });
 
             return (
-                <div className={classNames}
-                     key={element.id}>
+                <AssetSection
+                    element={this.props.element}
+                    onSelect={this.props.onSelect}
+                    selected={this.props.selected}
+                    title={element.displayName}
+                    className={classNames}
+                    key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-graphic"
+                         key={this.props.element.id + this.props.element.modified}
                          onMouseDown={this.props.handleDragStart}
+                         onClick={this._handleClickPreview}
                          onDoubleClick={this._handleOpenForEdit}>
                         <AssetPreviewImage
                             element={this.props.element}
                             onComplete={this._handlePreviewCompleted}/>
                     </div>
-                    <AssetSection
-                        element={this.props.element}
-                        onSelect={this.props.onSelect}
-                        selected={this.props.selected}
-                        title={element.displayName}/>
                     {dragPreview}
-                </div>
+                </AssetSection>
             );
         }
     });

--- a/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
@@ -26,8 +26,7 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames");
+        FluxMixin = Fluxxor.FluxMixin(React);
 
     var strings = require("i18n!nls/strings");
 
@@ -41,32 +40,30 @@ define(function (require, exports, module) {
          * Apply the layer style to the selected layers
          *
          * @private
+         * @param {SyntheticEvent} event
          */
-        _handleApply: function () {
+        _handleApply: function (event) {
+            event.stopPropagation();
+
             this.getFlux().actions.libraries.applyLayerStyle(this.props.element);
         },
 
         render: function () {
             var element = this.props.element;
 
-            var classNames = classnames("libraries__asset", {
-                "libraries__asset-selected": this.props.selected
-            });
-
             return (
-                <div className={classNames}
-                     key={element.id}
-                     title={strings.LIBRARIES.CLICK_TO_APPLY}>
+                <AssetSection
+                    element={this.props.element}
+                    onSelect={this.props.onSelect}
+                    selected={this.props.selected}
+                    title={element.displayName}
+                    key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-layer-style"
-                         onClick={this._handleApply}>
+                         onClick={this._handleApply}
+                         title={strings.LIBRARIES.CLICK_TO_APPLY}>
                         <AssetPreviewImage element={this.props.element}/>
                     </div>
-                    <AssetSection
-                        element={this.props.element}
-                        onSelect={this.props.onSelect}
-                        selected={this.props.selected}
-                        title={element.displayName}/>
-                </div>
+                </AssetSection>
             );
         }
     });

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -37,7 +37,9 @@
         "SET_TYPE_TRACKING": "Set Type Tracking",
         "SET_TYPE_ALIGNMENT": "Set Type Alignment",
         "UNGROUP_LAYERS": "Ungroup layers",
-        "MODIFY_EXPORT_ASSETS": "Updated Export Asset Configurations"
+        "MODIFY_EXPORT_ASSETS": "Updated Export Asset Configurations",
+        "APPLY_TEXT_STYLE": "Apply Text Style",
+        "APPLY_LAYER_STYLE": "Apply Layer Style"
     },
     "APP_NAME": "Photoshop",
     "FIRST_LAUNCH": {

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -60,6 +60,7 @@
                 border: @hairline solid @item-active;
                 border-radius: .1rem;
                 position: relative;
+                
                 &:before {
                     content: "";
                     position: absolute;
@@ -70,6 +71,10 @@
                     background-color: @item;
                     .background-checkerboard(14.5);
                     z-index: -1;
+                }
+                
+                &:hover {
+                    border: @hairline solid @item-hover;
                 }
             }
         }
@@ -142,6 +147,10 @@
             flex-shrink: 0;
             text-align: center;
             font-size: 1.3rem;
+            
+            &:hover {
+                color: @item-hover;
+            }
         }
 
         .libraries__bar__btn-confirm {
@@ -151,6 +160,10 @@
         .libraires__bar__input {
             font-size: 1.3rem;
             flex-grow: 1;
+            
+            &::-webkit-input-placeholder {
+               color: @item-disabled;
+            }
         }
     }
 
@@ -239,47 +252,39 @@
         &__preview {
             width: @libraries-preview-width;
             height: @libraries-preview-height;
+            margin-right: 1rem;
         }
 
-        &__section {
+        &__title {
             display: flex;
-            flex-direction: column;
-            padding-left: 1rem;
             flex-grow: 1;
-            height: @libraries-preview-height;
+            flex-direction: column;
             justify-content: center;
+            height: @libraries-preview-height;
 
-            &__title {
-                display: flex;
-                flex-grow: 1;
-                flex-direction: column;
-                justify-content: center;
-                height: @libraries-preview-height;
+            input {
+                font-size: 1.2rem;
+                -webkit-user-select: none;
+                
 
-                input {
-                    font-size: 1.2rem;
-                    -webkit-user-select: none;
-                    
-
-                    &:focus {
-                        align-self: stretch;
-                        background-color:@item-active;
-                        color: @bg-alt;
-                        user-select: none;
-                    }
-                    
-                    &[disabled] {
-                        cursor: inherit;
-                    }
+                &:focus {
+                    align-self: stretch;
+                    background-color:@item-active;
+                    color: @bg-alt;
+                    user-select: none;
+                }
+                
+                &[disabled] {
+                    cursor: inherit;
                 }
             }
+        }
 
-            &__subtitle {
-                margin: .3rem 0 0 .2rem;
-                padding-bottom: .3rem;
-                font-size: 1rem;
-                color: @warm-gray;
-            }
+        &__subtitle {
+            margin: .3rem 0 0 .2rem;
+            padding-bottom: .3rem;
+            font-size: 1rem;
+            color: @warm-gray;
         }
 
         &__preview-character-style, &__preview-layer-style, &__preview-graphic {
@@ -336,7 +341,7 @@
         }
 
         &__preview-layer-style {
-            background-color: @layer-style-background;
+            background-color: @layer-style-preview-background;
         }
 
         &__preview-graphic {
@@ -361,10 +366,12 @@
 
         &__buttons {
             flex: none;
-            width: 9rem;
+            width: auto;
 
             .split-button__item {
                 justify-content: flex-start;
+                margin: 0;
+                margin-right: 1.5rem;
             }
         }
     }

--- a/src/style/shared/colors.less
+++ b/src/style/shared/colors.less
@@ -65,7 +65,7 @@
 @locked-black: mix(@item-active, @bg-alt, 50%);
 
 /* Libraries */
-@layer-style-background: #B2B2B2;
+@layer-style-preview-background: #B2B2B2;
 
 /* General Utilities */
 


### PR DESCRIPTION
This PR resolved the following issues:

##### #2308 Discoverability: asset links/icons for delete, send link, view on website

Now you click single click on title to toggle the asset buttons. Note that single click on title will have a delay before showing the buttons, as we have to wait and make sure the single click is not triggered by a double click event (https://github.com/adobe-photoshop/spaces-design/compare/shao/libraries-fixes?diff=unified&expand=1&name=shao%2Flibraries-fixes#diff-9c5b0e09defc4119032323e45a76eab1R128). 

The clickable area for toggling the buttons is also expanded for easier control. 

![ui-lib-buttons](https://cloud.githubusercontent.com/assets/118264/9800838/2b3a132a-57c4-11e5-9374-c0be4ff6ce44.gif)


##### #2248 Error applying style from CC lib after undo

This is caused by the out dated history state because applying text / layer style does not emit new history event. I added the `historyStateInfo` and it is working fine. @mcilroyc can you help me confirm this is the right solution?

##### #2105 CC Lib: applying Text Style does not include color

##### #2091 CC Libraries: Clicking on panel background should deselect all assets

##### #2197 CC Lib: creating a new library should enter name field immediately upon creation and hide previous library assets

Improved the UI to highlight the new library input and buttons.

![ui-lib-new](https://cloud.githubusercontent.com/assets/118264/9800885/6e109de0-57c4-11e5-923c-776d4cbd790c.gif)