### PR TITLE
Export dialog styling changes only, not positioning changes 

### DIFF
--- a/src/js/jsx/shared/TitleHeader.jsx
+++ b/src/js/jsx/shared/TitleHeader.jsx
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
+        classnames = require("classnames"),
         strings = require("i18n!nls/strings");
     
     var TitleHeader = React.createClass({
@@ -38,6 +39,12 @@ define(function (require, exports, module) {
         render: function () {
             var workingTitle = this.props.title;
 
+            var classNameSet = {
+                "section-title": true
+            };
+
+            var className = classnames(classNameSet, this.props.className);
+
             if (this.props.onDoubleClick && !this.props.disabled) {
                 if (this.props.visible) {
                     workingTitle += strings.TOOLTIPS.SECTION_COLLAPSE;
@@ -48,7 +55,7 @@ define(function (require, exports, module) {
 
             return (
                 <header className="section-header" onDoubleClick={this.props.onDoubleClick}>
-                    <div className="section-title" title={workingTitle}>
+                    <div className={className} title={workingTitle}>
                         <h2>
                             {this.props.title}
                         </h2>

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -114,6 +114,7 @@
 @text-small: 1.2rem;
 @text-medium: 1.4rem;
 @text-large: 1.6rem;
+@text-xxlarge: 2.0rem;
 
 .size(@sz) {
     width: @sz;

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -22,8 +22,9 @@
  */
 
 .exports-panel__dialog {
-    background-color: @bg-app;
-    color:@item-active;
+    background-color: @bg-panel;
+    color:@item;
+    border-color: @bg-border;
     line-height: normal;
     width: 66rem;
     max-height: 66rem; //this is important for use with dialog.showModa()
@@ -40,37 +41,57 @@
     margin-left: 5rem;
     margin-right: 5rem;
     width: 56rem;
-    font-size: 1.5rem;
+}
+
+.exports-panel__container .section-header {
+    padding-left: 0;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
 }
 
 .exports-panel__two-column {
     display: flex;
     flex-grow: 1;
     justify-content: space-between;
+    height: 50rem;
 
     .layout-gutter {
         flex-grow: 0;
     }
 }
 
+.export-dialog-right_column {
+    width: 40%;
+}
+
 .exports-panel__asset-list__container {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    margin-left: 1.5rem;
+
 }
 
 .exports-panel__asset-list__quick-selection {
     display: flex;
     flex-direction: row;
+    font-size: @text-large;
+    color: @item;
+    font-weight: 400;
+    margin-bottom: 1rem;
+}
+
+.exports-panel__asset-list__quick-selection span {
+    opacity: .9;
 }
 
 .exports-panel__asset-list__list {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    max-height: 51rem;
+    height: 40rem;
     overflow-y: auto;
-    border: @hairline solid @color-subsection-rule;
+    border: 1.5px solid @color-subsection-rule;
     border-left: none;
     border-right: none;
     margin: 1rem 0;
@@ -89,12 +110,10 @@
     svg {
         width: 3rem;
         height: 3rem;
-        fill:  @color-subsection-rule;
+        fill:  @item-active;
         stroke: none;
     }
 }
-
-.exports-panel__layer {}
 
 .exports-panel__layer__name {
     font-size: 1.5rem;
@@ -107,11 +126,15 @@
     font-size: 1.3rem;
     margin-right: 0.8rem;
     color: @warm-gray;
+    font-size: @text-large;
+    color: @item;
+    opacity: .9;
 }
 
 .exports-panel__layer-assets {
-    font-size: 1.3rem;
+    font-size: @text-medium;
     display: flex;
+    color: @item-active;
 }
 
 .exports-panel__layer-asset {
@@ -144,17 +167,13 @@
     flex-grow: 0;
     justify-content: flex-end;
     margin: .5rem 0rem;
+    color: @item-active;
 }
 
-.exports-panel__button-group .button-simple {
-    margin: 0.5rem;
-    padding: 1rem;
-    font-size: 1.5rem;
-    justify-content: center;
-    opacity: 0.9;
-
-    &:hover {
-        opacity: 1;
+.exports-panel__button-group {
+    
+    .button-simple {
+        color: @item-active;
     }
 
     svg {
@@ -163,6 +182,25 @@
         fill:  @item-active;
         stroke: none;
     }
+}
+
+.exports-panel__button-group .button-simple:hover {
+    color: @item-hover;
+}
+
+.exports-panel__button-group {
+    
+    .button-simple {
+        margin: 0.5rem;
+        padding-top: .25rem;
+        font-size: 1.5rem;
+        justify-content: center;
+        opacity: 0.9;
+
+        &:hover {
+            opacity: 1;
+        }
+    }  
 }
 
 .exports-panel__button-group__separator {

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -205,7 +205,7 @@ button {
         position: absolute;
         top: 0;
         left: 0;
-        background-color: @warm-gray;
+        background-color: @item-active;
         border-radius: .2rem;
         &:after {
             content: '';

--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -178,3 +178,18 @@ dialog::backdrop {
 .select {
     width: 100%;
 }
+
+.dialog-header {
+    font-weight: 400;
+    white-space: nowrap;
+    text-overflow: ellipsis; 
+    font-size: @text-xxlarge;
+    letter-spacing: .05rem;
+    overflow: hidden;
+    color: @item;
+    text-transform: capitalize;
+}
+
+.section-title.dialog-header {
+    opacity: .9;
+}

--- a/src/style/shared/scrollbar.less
+++ b/src/style/shared/scrollbar.less
@@ -27,7 +27,9 @@
 }
 
 /* Bar */
-.section-container::-webkit-scrollbar, .libraries__content::-webkit-scrollbar {
+.section-container::-webkit-scrollbar, 
+.libraries__content::-webkit-scrollbar, 
+.exports-panel__asset-list__list::-webkit-scrollbar {
     background: transparent;
     width: .4rem;
     display: block;


### PR DESCRIPTION
As per the designs found here: https://trello.com/c/KR5wYVkW/494-design (@placegraphichere said we are following the Stripped down version). Position changes will be separate PR.

- Created a new class to style the types of headers that we use in the dialog (.dialog-header) 
- Created a new class to denote left and right column of the export dialog to add different widths 
- Took away all <Gutter> elements in ExportAllPanel.jsx and replaced with the new class .control-group__vertical
- Add correct colors for the header, export asset icons, export asset names, and checkboxes
- Adjusted the positioning of the "Cancel | Export" buttons
- Add correct scrolling properties and colors for the scroll bar 

Current look after these changes: 
![Export Dialog](https://www.dropbox.com/s/kurhbkad9cm0n5a/Screenshot%202015-09-11%2009.36.11.png?raw=1)
