### PR TITLE
Fix binary search in Select edge case for index 0

### DIFF
--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
                 middle = Math.floor(high / 2),
                 value;
 
-            while (low < middle && middle < high) {
+            while (low <= middle && middle < high) {
                 value = options.get(middle).id;
                 if (value < key) {
                     low = middle;


### PR DESCRIPTION
If key we're looking for was at index 0, the binary search algorithm would fail. 

Causing index to become -1, and reset to the first item, which would cause the bounces in #2405 and #2391 