### PR TITLE
Reduce UI size on retina displays

### DIFF
--- a/src/style/main.less
+++ b/src/style/main.less
@@ -252,23 +252,23 @@ input {
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1281px) and (max-device-width: 1440px) {
 
-  html { font-size: @base-9; }
+  html { font-size: @base-8; }
 
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1441px) and (max-device-width: 1680px) {
 
-  html { font-size: @base-10; }
+  html { font-size: @base-9; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1681px) and (max-device-width: 2560px) {
 
-  html { font-size: @base-11; }
+  html { font-size: @base-10; }
 
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) {
 
-  html { font-size: @base-12; }
+  html { font-size: @base-11; }
 
 }

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -402,25 +402,25 @@
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1281px) and (max-device-width: 1440px) {
   .color-picker-slider .color-picker-slider__pointer {
-      .pointer-size(9px);
+      .pointer-size(8px);
   }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1441px) and (max-device-width: 1680px) {
   .color-picker-slider .color-picker-slider__pointer {
-      .pointer-size(10px);
+      .pointer-size(9px);
   }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1681px) and (max-device-width: 2560px) {
   .color-picker-slider .color-picker-slider__pointer {
-      .pointer-size(11px);
+      .pointer-size(10px);
   }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) {
   .color-picker-slider .color-picker-slider__pointer {
-      .pointer-size(12px);
+      .pointer-size(11px);
   }
 }
 


### PR DESCRIPTION
For some reason the retina UI sizes are all a little bigger than non-retina UI sizes, which doesn't make any sense. They all also feel a little too big to me. This reduces the sizes across the board on retina. I think it feels better on a big 5k iMac and on a 15" MBP. If anybody can test on smaller retina devices, that would be helpful.

Before:
![before](https://s3.amazonaws.com/f.cl.ly/items/130P3t0e08100y1m3z1Y/Image%202015-09-11%20at%2012.05.14%20PM.png)

After:
![after](https://s3.amazonaws.com/f.cl.ly/items/0c3Y2e3T0i1z3h1B2s2v/Image%202015-09-11%20at%2012.03.52%20PM.png)