### PR TITLE
Render the same thumb overlay for all color pickers

### DIFF
--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -310,7 +310,6 @@ define(function (require, exports, module) {
                         dismissOnWindowClick>
                         <ColorPicker
                             ref="colorpicker"
-                            swatchOverlay={this.props.swatchOverlay}
                             label={label}
                             editable={this.props.editable}
                             opaque={this.props.opaque}

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -510,14 +510,22 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var swatchOverlay = this.props.swatchOverlay(tinycolor(this.props.color.toJS()));
-
+            var colortiny = this.props.color ? tinycolor(this.props.color.toJS()) : null,
+                overlayStyle = {
+                    height: "100%",
+                    width: "100%",
+                    backgroundColor: colortiny ? colortiny.toRgbString() : "transparent"
+                };
+                
             return (
                 <div
                     className="color-picker__colortype">
                     <div
-                        className="color-picker__colortype__thumb selected">
-                        {swatchOverlay}
+                        className="color-picker__colortype__thumb">
+                        <div
+                            className="color-picker__colortype__thumb__overlay"
+                            style={overlayStyle}
+                        />
                     </div>
                     <Gutter/>
                     <Gutter/>
@@ -922,6 +930,7 @@ define(function (require, exports, module) {
                 <div className="color-picker">
                     <ColorType {...this.props}
                         ref="input"
+                        color={color}
                         onShiftTabPress={this._focusOpacityInput}
                         onChange={this._handleColorTypeChange}/>
                     <Map

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -256,14 +256,6 @@
         background: @item;
         border-radius: 0.4rem;
         
-        &.selected:after {
-            content: "";
-            position: absolute;
-            bottom: -.4rem;
-            width: 2.4rem;
-            height: .2rem;
-            background: @item;
-        }
         &.empty {
             background: url(../img/ico-color-picker-no-color.svg) no-repeat;
         }
@@ -279,6 +271,10 @@
         flex-basis: 12rem;
         vertical-align: top;
     }
+}
+
+.color-picker__colortype__thumb__overlay {
+    border-radius: 0.2rem;
 }
 
 // Color Sliders


### PR DESCRIPTION
I was mistakenly passing the swatch overlay of ColorInput to the colortype thumbnail... but we should just render the pure color instead.

Addresses #2416 