### PR TITLE
Exportability: do not validate existence of bounds, only of childBounds

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -837,8 +837,10 @@ define(function (require, exports, module) {
      */
     Object.defineProperty(LayerStructure.prototype, "filterExportable", objUtil.cachedLookupSpec(function (layers) {
         return layers.filterNot(function (layer) {
-            return !layer.bounds ||
-                this.childBounds(layer).empty ||
+            var childBounds = this.childBounds(layer);
+            
+            return !childBounds ||
+                childBounds.empty ||
                 layer.isBackground ||
                 layer.kind === layer.layerKinds.ADJUSTMENT ||
                 this.isEmptyGroup(layer);


### PR DESCRIPTION
This seems to be a workaround for a caching bug, but seems safe.  When a document that contains groups is loaded, the group layers have a bounds object (albeit empty).  When you *create* a group, the bounds are null.  This seems wrong. Regardless, removing the test for bounds existence, and simply testing for childBounds existence and non-emptiness seems to be a sufficient workaround.

Note that I tried testing just for childBounds emptiness, but when creating a group out of an empty layer (edge case) even the childBounds is null.

Second attempt at fixing #2376