### PR TITLE
Show the document header in the no-doc state

### DIFF
--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -28,8 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        Immutable = require("immutable"),
-        classnames = require("classnames");
+        Immutable = require("immutable");
 
     var os = require("adapter/os");
     
@@ -146,11 +145,6 @@ define(function (require, exports, module) {
                 smallTab = this.state.headerWidth / this.state.documentIDs.size < 175;
             // Above: This number tunes when tabs should be shifted to small tabs
 
-            var containerClassName = classnames({
-                "document-container": true,
-                "document-container__withdoc": !!document
-            });
-
             var documentTabs = this.state.documentIDs.map(function (docID) {
                 var doc = documentStore.getDocument(docID);
                 
@@ -169,7 +163,7 @@ define(function (require, exports, module) {
             }, this);
 
             return (
-                <div className={containerClassName} >
+                <div className="document-container">
                     <div className="document-header" ref="tabContainer">
                             {documentTabs}
                     </div>

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -153,8 +153,7 @@ define(function (require, exports, module) {
         
             var toolbarClassName = classnames({
                 "expanded": this.state.pinned || this.state.expanded,
-                "toolbar": true,
-                "toolbar__hidden": !document && !this.state.pinned
+                "toolbar": true
             });
         
             return (

--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -74,9 +74,6 @@
     z-index: 0;
     flex-shrink: 1;
     flex-grow: 10;
-}
-
-.document-container__withdoc {
     background-color: @bg-panel;
     border-left: 0.2rem solid @bg-border;
     border-right: 0.2rem solid @bg-border;

--- a/src/style/toolbar.less
+++ b/src/style/toolbar.less
@@ -57,10 +57,6 @@
     }
 }
 
-.toolbar__hidden {
-    display: none;
-}
-
 .toolbar li .button-simple:first-child {
     margin: 0;
 }


### PR DESCRIPTION
This makes the document header visible in both the doc and no-doc states to reduce UI flashing when going back and forth between those states. I also think it looks less weird, given that the toolbar is also enabled in the no-doc state.

![no-doc header](https://s3.amazonaws.com/f.cl.ly/items/0H0Z3t1E2C2o3h0Q3O3L/Image%202015-09-11%20at%204.46.35%20PM.png)

There's no technical reason for this change. I just think it looks nicer. Over to @placegraphichere to decide whether he agrees or not.