### PR TITLE
CC Libraries - bug fixes and improvements

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -60,7 +60,7 @@ define(function (require, exports) {
      *
      * @type {Object}
      */
-    var _EXTENSION_TO_REPRESENTATION_MAP = {
+    var EXTENSION_TO_REPRESENTATION_MAP = {
         "psd": "image/vnd.adobe.photoshop",
         "psb": "application/photoshop.large",
         "ai": "application/illustrator",
@@ -234,8 +234,8 @@ define(function (require, exports) {
 
             var fileExtension = pathUtil.extension(layerFileName);
 
-            if (_EXTENSION_TO_REPRESENTATION_MAP.hasOwnProperty(fileExtension)) {
-                representationType = _EXTENSION_TO_REPRESENTATION_MAP[fileExtension];
+            if (EXTENSION_TO_REPRESENTATION_MAP.hasOwnProperty(fileExtension)) {
+                representationType = EXTENSION_TO_REPRESENTATION_MAP[fileExtension];
             }
         }
 
@@ -1157,6 +1157,7 @@ define(function (require, exports) {
     exports.ELEMENT_COLOR_TYPE = ELEMENT_COLOR_TYPE;
     exports.ELEMENT_BRUSH_TYPE = ELEMENT_BRUSH_TYPE;
     exports.ELEMENT_COLORTHEME_TYPE = ELEMENT_COLORTHEME_TYPE;
+    exports.EXTENSION_TO_REPRESENTATION_MAP = EXTENSION_TO_REPRESENTATION_MAP;
 
     exports.selectLibrary = selectLibrary;
     exports.createLibrary = createLibrary;

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -29,7 +29,8 @@ define(function (require, exports) {
     var events = require("js/events"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),
-        tinycolor = require("tinycolor");
+        tinycolor = require("tinycolor"),
+        libraryActions = require("js/actions/libraries");
 
     /**
      * Map from element IDs to corresponding element and type
@@ -72,8 +73,16 @@ define(function (require, exports) {
                 
                 if (categoryKey) {
                     // If there is no current document, don't add anything but graphics
-                    if (!currentDocument && categoryKey !== "GRAPHIC") {
-                        return;
+                    if (!currentDocument) {
+                        if (categoryKey !== "GRAPHIC") {
+                            return;
+                        }
+                        
+                        var representation = element.getPrimaryRepresentation();
+                        if (!representation ||
+                            !libraryActions.EDITABLE_GRAPHIC_REPRESENTATION_TYPES.hasas(representation.type)) {
+                            return;
+                        }
                     }
 
                     if (categoryKey === "CHARACTERSTYLE" && !title) {

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
                 isSyncing: libraryStore.isSyncing(),
                 isDropTarget: isDropTarget,
                 isValidDropTarget: dndState.hasValidDropTarget,
-                selectedLibrary: libraryStore.getCurrentLibrary()
+                selectedLibrary: libraryStore.getCurrentLibrary(),
+                lastLocallyCreatedElement: libraryStore.getLastLocallyCreatedElement()
             };
         },
 
@@ -116,6 +117,7 @@ define(function (require, exports, module) {
                 containerContents = (
                 <Library
                     addElement={this._handleAddElement}
+                    lastLocallyCreatedElement={this.state.lastLocallyCreatedElement}
                     library={currentLibrary} />
                 );
             } else {

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -155,9 +155,11 @@ define(function (require, exports, module) {
                         });
                     }.bind(this));
             }
+            
+            var classNames = "libraries__assets libraries__assets__" + type;
 
             return (
-                <div className="libraries__assets">
+                <div className={classNames}>
                     <div className="libraries__assets__title">
                         {title}
                     </div>

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -47,7 +47,12 @@ define(function (require, exports, module) {
          * @private
          */
         addGraphic: function () {
-            this.getFlux().actions.libraries.createGraphicFromSelectedLayer();
+            this.getFlux().actions.libraries.createGraphicFromSelectedLayer()
+                .then(function () {
+                    // Scroll to the top of the graphics list to reveal the newly added graphic.
+                    var graphicsListEle = window.document.getElementsByClassName("libraries__assets__graphic")[0];
+                    graphicsListEle.scrollIntoView();
+                });
         },
 
         /**

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -47,12 +47,7 @@ define(function (require, exports, module) {
          * @private
          */
         addGraphic: function () {
-            this.getFlux().actions.libraries.createGraphicFromSelectedLayer()
-                .then(function () {
-                    // Scroll to the top of the graphics list to reveal the newly added graphic.
-                    var graphicsListEle = window.document.getElementsByClassName("libraries__assets__graphic")[0];
-                    graphicsListEle.scrollIntoView();
-                });
+            this.getFlux().actions.libraries.createGraphicFromSelectedLayer();
         },
 
         /**

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
         propTypes: {
             element: React.PropTypes.object.isRequired,
             onSelect: React.PropTypes.func,
-            title: React.PropTypes.string.isRequired,
+            displayName: React.PropTypes.string.isRequired,
+            title: React.PropTypes.string,
             subTitle: React.PropTypes.string
         },
         
@@ -91,7 +92,7 @@ define(function (require, exports, module) {
          * @param {string} newName
          */
         _handleRename: function (event, newName) {
-            if (this.props.title !== newName) {
+            if (this.props.displayName !== newName) {
                 this.getFlux().actions.libraries.renameAsset(this.props.element, newName);
             }
         },
@@ -198,8 +199,8 @@ define(function (require, exports, module) {
                         <TextInput
                             ref="input"
                             editable={true}
-                            title={this.props.title}
-                            value={this.props.title}
+                            title={this.props.title || this.props.displayName}
+                            value={this.props.displayName}
                             preventHorizontalScrolling={true}
                             onClick={this._handleTitleClicked}
                             onDoubleClick={this._handleStartEditingTitle}

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -87,7 +87,8 @@ define(function (require, exports, module) {
             }
 
             var fontSizeAndColorStr = _.remove([fontSizeStr, fontColorHex], null).join(", "),
-                displayName = element.displayName || (font.name + " " + font.style),
+                fontInfo = font.name + " " + font.style,
+                displayName = element.displayName || fontInfo,
                 colorPreview = this.state.hasPreview && fontColorHex && (<div
                     style={{ backgroundColor: fontColorHex }}
                     className="libraries__asset__preview-character-style__color-swatch"/>);
@@ -98,6 +99,7 @@ define(function (require, exports, module) {
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
                     displayName={displayName}
+                    title={fontInfo}
                     subTitle={fontSizeAndColorStr}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style"

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
                     element={this.props.element}
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
-                    title={displayName}
+                    displayName={displayName}
                     subTitle={fontSizeAndColorStr}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style"

--- a/src/js/jsx/sections/libraries/assets/Color.jsx
+++ b/src/js/jsx/sections/libraries/assets/Color.jsx
@@ -26,7 +26,8 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React);
+        FluxMixin = Fluxxor.FluxMixin(React),
+        _ = require("lodash");
 
     var strings = require("i18n!nls/strings"),
         ColorModel = require("js/models/color");
@@ -43,15 +44,12 @@ define(function (require, exports, module) {
          * @return {ColorModel}
          */
         _getColor: function () {
-            var representations = this.props.element.representations;
+            var reps = this.props.element.representations,
+                colors = reps.map(function (r) { return r.getValue("color", "data"); }),
+                // Color Asset is guaranteed to have a RGB representation.
+                rgb = _.find(colors, { "mode": "RGB" });
             
-            for (var i = 0; i < representations.length; i++) {
-                var data = representations[i].getValue("color", "data");
-                
-                if (data.mode === "RGB") {
-                    return new ColorModel({ r: data.value.r, g: data.value.g, b: data.value.b });
-                }
-            }
+            return new ColorModel({ r: rgb.value.r, g: rgb.value.g, b: rgb.value.b });
         },
 
         /**
@@ -106,8 +104,8 @@ define(function (require, exports, module) {
         render: function () {
             var element = this.props.element,
                 title = this._getPrimaryColorStringValue(),
-                hextValue = this._getColor().toTinyColor().toHexString().toUpperCase(),
-                displayName = element.displayName || hextValue;
+                hexValue = this._getColor().toTinyColor().toHexString().toUpperCase(),
+                displayName = element.displayName || hexValue;
 
             return (
                  <AssetSection
@@ -118,7 +116,7 @@ define(function (require, exports, module) {
                     title={title}
                     key={element.id}>
                     <div className="libraries__asset__preview"
-                         style={{ background: hextValue }}
+                         style={{ background: hexValue }}
                          title={strings.LIBRARIES.CLICK_TO_APPLY}
                          onClick={this._handleApply}/>
                 </AssetSection>

--- a/src/js/jsx/sections/libraries/assets/ColorTheme.jsx
+++ b/src/js/jsx/sections/libraries/assets/ColorTheme.jsx
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
                     element={this.props.element}
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
-                    title={element.displayName}
+                    displayName={element.displayName}
                     classNames="libraries__asset-colortheme">
                     <div className="libraries__asset__preview libraries__asset__preview-colortheme">
                         {colorSwatchComponents}

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -27,11 +27,16 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
+        
+    var libraryActions = require("js/actions/libraries");
         
     var Draggable = require("jsx!js/jsx/shared/Draggable"),
         AssetSection = require("jsx!./AssetSection"),
         AssetPreviewImage = require("jsx!./AssetPreviewImage");
+        
+    var _REPRESENTATION_TO_EXTENSION_MAP = _.invert(libraryActions.EXTENSION_TO_REPRESENTATION_MAP);
 
     var Graphic = React.createClass({
         mixins: [FluxMixin],
@@ -99,7 +104,10 @@ define(function (require, exports, module) {
 
         render: function () {
             var element = this.props.element,
-                dragPreview = this._renderDragPreview();
+                dragPreview = this._renderDragPreview(),
+                representation = element.getPrimaryRepresentation(),
+                extension = representation && _REPRESENTATION_TO_EXTENSION_MAP[representation.type],
+                title = !extension ? element.displayName : (element.displayName + " - " + extension.toUpperCase());
 
             var classNames = classnames({
                 "assets__graphic__dragging": this.props.isDragging
@@ -111,6 +119,7 @@ define(function (require, exports, module) {
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
                     displayName={element.displayName}
+                    title={title}
                     className={classNames}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-graphic"

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
                     element={this.props.element}
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
-                    title={element.displayName}
+                    displayName={element.displayName}
                     className={classNames}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-graphic"

--- a/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
                     element={this.props.element}
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
-                    title={element.displayName}
+                    displayName={element.displayName}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-layer-style"
                          onClick={this._handleApply}

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -567,7 +567,7 @@ define(function (require, exports, module) {
                             sorted={true}
                             disabled={this.props.disabled || !this.state.initialized}
                             list={typefaceListID}
-                            value={familyName || (this.state.initialized && strings.STYLE.TYPE.MIXED)}
+                            value={familyName || (this.state.initialized ? strings.STYLE.TYPE.MIXED : null)}
                             defaultSelected={postScriptName}
                             options={this.state.typefaces}
                             onChange={this._handleTypefaceChange}

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -85,6 +85,12 @@ define(function (require, exports, module) {
          * @type {Immutable.Map.<number, EditStatus>}
          */
         _editStatusByDocumentID: null,
+        
+        /**
+         * Store the last locally created element.
+         * @type {AdobeLibraryElement}
+         */
+        _lastLocallyCreatedElement: null,
 
         initialize: function () {
             this.bindActions(
@@ -124,6 +130,7 @@ define(function (require, exports, module) {
             this._serviceConnected = false;
             this._isSyncing = false;
             this._editStatusByDocumentID = null;
+            this._createdNewGraphicLocally = false;
         },
 
         /** @ignore */
@@ -229,8 +236,8 @@ define(function (require, exports, module) {
          *
          * @private
          */
-        _handleElementCreated: function () {
-            // Update is already reflected in _libraries. No further action required.
+        _handleElementCreated: function (payload) {
+            this._lastLocallyCreatedElement = payload.element;
             this.emit("change");
         },
 
@@ -509,6 +516,15 @@ define(function (require, exports, module) {
                     
                 return documentName.indexOf(status.elementID) !== -1;
             }.bind(this));
+        },
+        
+        /**
+         * Return the last locally created element.
+         * 
+         * @return {?AdobeLibraryElement}
+         */
+        getLastLocallyCreatedElement: function () {
+            return this._lastLocallyCreatedElement;
         },
         
         /**


### PR DESCRIPTION
This PR includes the following fixes / improvements:

1. make applying non-RGB color asset works
2. Mouse over character style title will show font info, instead of display name. This allow users to check the font name and style, when they overwrite the default display name.
3. Mouse over graphic asset will show `display name` + `file extension`
4. Add new graphic asset will reveal the new graphic asset by scrolling to top of the graphic list automatically.
5. show only editable graphics in search result when there is no document. Fix for #2211
6. Resolved warning in Type: ```Failed propType: Invalid prop `value` of type `boolean` supplied to `Datalist`, expected `string`. Check the render method of `Type`.```