### PR TITLE
Reset cursor when updating Guard

### DIFF
--- a/src/js/jsx/Guard.jsx
+++ b/src/js/jsx/Guard.jsx
@@ -27,6 +27,10 @@ define(function (require, exports, module) {
     var React = require("react"),
         classnames = require("classnames");
 
+    var os = require("adapter/os");
+
+    var synchronization = require("js/util/synchronization");
+
     /**
      * @const
      * @type {Array.<string>} Input events to block when the component becomes inactive.
@@ -50,6 +54,14 @@ define(function (require, exports, module) {
         "paste",
         "selectionchange"
     ];
+
+    /**
+     * Debounced version of os.resetCursor to prevent very quick cursor changes.
+     *
+     * @private
+     * @type {function}
+     */
+    var _resetCursorDebounced = synchronization.debounce(os.resetCursor, os, 100);
 
     var Guard = React.createClass({
 
@@ -109,6 +121,13 @@ define(function (require, exports, module) {
                 this._enableInput();
             } else if (this.props.disabled && !nextProps.disabled) {
                 this._disableInput();
+            }
+        },
+
+        componentDidUpdate: function (prevProps) {
+            if (prevProps.disabled !== this.props.disabled) {
+                // The cursor doesn't automatically reset until moved
+                _resetCursorDebounced();
             }
         },
 


### PR DESCRIPTION
It looks like the cursor doesn't automatically reset itself when changed until the after mouse moves next. The `Guard` component frequently changes the cursor when the UI is disabled, but it can get stick around in the disabled state for an unwelcome amount of time if you're not moving the mouse. This fixes the problem by calling `os.resetCursor` when the `Guard` switches between enabled and disabled states.

Addresses: concerns.