### PR TITLE
Delay loading inessential layer properties

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -162,11 +162,10 @@ define(function (require, exports) {
      * @return {Promise.<{document: object, layers: Array.<object>}>}
      */
     var _getLayersForDocument = function (doc) {
-        var docRef = documentLib.referenceBy.id(doc.documentID),
-            startIndex = (doc.hasBackgroundLayer ? 0 : 1),
+        var startIndex = (doc.hasBackgroundLayer ? 0 : 1),
             numberOfLayers = (doc.hasBackgroundLayer ? doc.numberOfLayers + 1 : doc.numberOfLayers);
 
-        return layerActions._getLayersForDocumentRef(docRef, startIndex, numberOfLayers)
+        return layerActions._getLayersForDocument(doc, startIndex, numberOfLayers)
             .then(function (layers) {
                 return {
                     document: doc,

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -225,7 +225,15 @@ define(function (require, exports, module) {
          * Should this layer be included in the "export all" process?
          * @type {boolean}
          */
-        exportEnabled: false
+        exportEnabled: false,
+
+        /**
+         * Indicates whether or not the lazy properties have yet been loaded
+         * into this layer.
+         *
+         * @type {boolean}
+         */
+        initialized: false
     });
 
     Layer.layerKinds = layerLib.layerKinds;
@@ -429,7 +437,8 @@ define(function (require, exports, module) {
             isArtboard: !!isArtboard,
             bounds: isArtboard ? new Bounds(boundsDescriptor) : null,
             isLinked: false,
-            vectorMaskEnabled: false
+            vectorMaskEnabled: false,
+            initialized: true
         });
     };
 
@@ -439,9 +448,10 @@ define(function (require, exports, module) {
      * @param {object|Immutable.Record} document Document descriptor or Document model
      * @param {object} layerDescriptor
      * @param {boolean} selected Whether or not this layer is currently selected
+     * @param {boolean=} initialized
      * @return {Layer}
      */
-    Layer.fromDescriptor = function (document, layerDescriptor, selected) {
+    Layer.fromDescriptor = function (document, layerDescriptor, selected, initialized) {
         var id = layerDescriptor.layerID,
             documentID,
             resolution;
@@ -478,7 +488,9 @@ define(function (require, exports, module) {
             isArtboard: layerDescriptor.artboardEnabled,
             vectorMaskEnabled: layerDescriptor.vectorMaskEnabled,
             exportEnabled: layerDescriptor.exportEnabled,
-            isLinked: _extractIsLinked(layerDescriptor)
+            isLinked: _extractIsLinked(layerDescriptor),
+            initialized: initialized || selected
+            // if not explicitly marked as initialized, then it is initialized iff it is selected
         };
 
         object.assignIf(model, "blendMode", _extractBlendMode(layerDescriptor));
@@ -516,7 +528,8 @@ define(function (require, exports, module) {
                 isArtboard: layerDescriptor.artboardEnabled,
                 vectorMaskEnabled: layerDescriptor.vectorMaskEnabled,
                 exportEnabled: layerDescriptor.exportEnabled,
-                isLinked: _extractIsLinked(layerDescriptor)
+                isLinked: _extractIsLinked(layerDescriptor),
+                initialized: true
             };
 
         object.assignIf(model, "blendMode", _extractBlendMode(layerDescriptor));

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -892,7 +892,7 @@ define(function (require, exports, module) {
                 descriptor = descriptors[i],
                 layerIndex = descriptor.itemIndex - 1,
                 isNewSelected = selected && i + 1 === layerIDs.length,
-                newLayer = Layer.fromDescriptor(document, descriptor, isNewSelected);
+                newLayer = Layer.fromDescriptor(document, descriptor, isNewSelected, true);
 
             if (i === 0 && replace) {
                 // Replace the single selected layer (derived above)
@@ -962,7 +962,7 @@ define(function (require, exports, module) {
             descriptors.forEach(function (descriptor) {
                 var i = descriptor.itemIndex,
                     previousLayer = this.byIndex(i),
-                    nextLayer = Layer.fromDescriptor(document, descriptor, previousLayer.selected);
+                    nextLayer = Layer.fromDescriptor(document, descriptor, previousLayer.selected, true);
 
                 // update layers map
                 layers.delete(previousLayer.id);

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -169,7 +169,17 @@ define(function (require, exports, module) {
 
             this._openDocuments[nextDocument.id] = nextDocument;
 
-            if (!suppressChange) {
+            if (suppressChange) {
+                return;
+            }
+
+            // If some selected layer remains uninitialized, a new document will
+            // come along shortly. Wait until then to trigger the change event.
+            var initialized = nextDocument.layers.selected.every(function (layer) {
+                return layer.initialized;
+            });
+
+            if (initialized) {
                 this.emit("change");
             }
         },


### PR DESCRIPTION
This PR delays requests for "inessential" properties on layer descriptors until layers are first selected. This is designed to improve startup performance by reducing the amount of information fetched from Photoshop. On VermilonArtboards.psd, for example, startup time is reduced by about 25% (from 7.1s to 5.3s).

This change is accomplished first by splitting off from the `_optionalLayerProperties` array in `actions.layers` another array, `_lazyLayerProperties`. When a document is initialized with `layers._getLayersForDocument`, the (remaining) optional properties are fetched for all layers, while the lazy properties are only fetched for the selected layers. Layer models for which the full suite of properties have not been fetched have their `initialized` property set to false until fully initialized. 

The behavior of sibling helper function `layers._getLayersByRef` remains unchanged; it always fetches _all_ of the properties. This function is used to reset or initialize subsets of layers after the document has been initialized. This makes it easy to be sure that selected layers are always initialized without making major architectural changes. For example, `addLayers` just works. Note also that there are no JSX changes whatsoever here; the bulk of the work is in the mildly elaborated `layers._getLayersForDocument` as well as `layers.select`. Easy peasy!

Future work: do not load lazy properties at all for inactive documents, and load them for selected layers in those documents upon first activation.

**Review only** until after the MAX deadline. In the meantime, please help test this! Potential problems might involve the panels not showing up-to-date information when the layer selection changes, as well as errors resulting in other components attempting to access null properties of uninitialized models.