### PR TITLE
Export 'loader' icon should be animated

### DIFF
--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -259,7 +259,7 @@ define(function (require, exports, module) {
             var panelClassnames = classnames("exports-panel__container");
 
             var exportButton = serviceBusy ?
-                (<SVGIcon CSSID="loader" viewbox="0 0 16 16" />)
+                (<SVGIcon CSSID="loader" viewbox="0 0 16 16" iconPath="" />)
                 : strings.EXPORT.BUTTON_EXPORT;
 
             return (

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -252,7 +252,8 @@ define(function (require, exports, module) {
                                 onClick={this._exportAssetsClickHandler}
                                 onDoubleClick={this._blockInput}>
                                 <SVGIcon
-                                    CSSID={exportState.serviceBusy ? "loader" : "export"} />
+                                    CSSID={exportState.serviceBusy ? "loader" : "export"}
+                                    iconPath={exportState.serviceBusy ? "" : null} />
                             </Button>
                             <Gutter />
                             <Button


### PR DESCRIPTION
@designedbyscience says he understands why this fix works.  So I guess I'll assign it to him.  I think this is risk-free enough to make it in to the MAX build.