### PR TITLE
Unchecked checkboxes should be 'transparent' with a grey border

### DIFF
--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -195,27 +195,27 @@ button {
 }
 
 .button-checkbox {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 1.3rem;
+    height: 1.3rem;
     position: relative;
     label {
-        width: 1.5rem;
-        height: 1.5rem;
+        width: 1.3rem;
+        height: 1.3rem;
         cursor: pointer;
         position: absolute;
         top: 0;
         left: 0;
         background: transparent;
-        border: .25rem solid @warm-gray;
-        border-radius: .3rem;
+        border: .21rem solid @warm-gray;
+        border-radius: .21rem;
         &:after {
             content: '';
             width: 0.7rem;
-            height: 0.4rem;
+            height: 0.3rem;
             position: absolute;
             top: 0.1rem;
             left: 0rem;
-            border: 0.3rem solid @bg-alt;
+            border: 0.2rem solid @bg-alt;
             border-top: none;
             border-right: none;
             background: transparent;
@@ -241,11 +241,44 @@ button {
     label {
         background-color: @warm-gray;
         &:after {
-            top: 0rem;
-            left: 0.2rem;
+            top: 0.1rem;
+            left: 0.1rem;
             border-left: none;
             opacity: 1;
             transform: rotate(0);
         }
     }
+}
+
+// Fixing for Retina
+@media (-webkit-min-device-pixel-ratio: 2) {
+    .button-checkbox {
+        width: 11px;
+        height: 11px;
+
+        label {
+            width: 11px;
+            height: 11px;
+            &:after {
+                content: '';
+                width: 0.7rem;
+                height: 0.3rem;
+                border-width: 2px;
+                position: absolute;
+                top: 2px;
+                left: 0px;
+            }
+        }
+    }
+
+    .button-checkbox__mixed {
+        label {
+            &:after {
+                top: 2px;
+                left: 1px;
+                width: 7px;
+            }
+        }
+    }
+
 }

--- a/src/style/shared/button.less
+++ b/src/style/shared/button.less
@@ -205,15 +205,16 @@ button {
         position: absolute;
         top: 0;
         left: 0;
-        background-color: @warm-gray;
+        background: transparent;
+        border: .25rem solid @warm-gray;
         border-radius: .3rem;
         &:after {
             content: '';
             width: 0.7rem;
             height: 0.4rem;
             position: absolute;
-            top: 0.3rem;
-            left: 0.3rem;
+            top: 0.1rem;
+            left: 0rem;
             border: 0.3rem solid @bg-alt;
             border-top: none;
             border-right: none;
@@ -227,6 +228,9 @@ button {
     }
     input[type=checkbox] {
         visibility: hidden;
+        &:checked + label {
+            background-color: @warm-gray;
+        }
         &:checked + label:after {
           opacity: 1;
         } 
@@ -235,9 +239,10 @@ button {
 
 .button-checkbox__mixed {
     label {
+        background-color: @warm-gray;
         &:after {
-            top: 0.2rem;
-            left: 0.4rem;
+            top: 0rem;
+            left: 0.2rem;
             border-left: none;
             opacity: 1;
             transform: rotate(0);


### PR DESCRIPTION
This is my "best attempt" at styling the unchecked state of checkboxes to match the spectrum standards.  
This is either:

1. "good enough"
1. Needs a ninja like @designedbyscience to carry it forward with CSS tweaks
1. Needs some SVG magic instead of a pure CSS treatment, since my current belief is that the minor alignment issues are not solvable with CSS hackery.

cc: @davealonzo @placegraphichere @DivyaPrabhakar 

![example](http://cl.ly/image/2q1y0G3M060A/Image%202015-09-14%20at%202.33.11%20PM.png)