### PR TITLE
Add a null check for layer highlighting

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -496,7 +496,9 @@ define(function (require, exports, module) {
                 .bind(this)
                 .then(function (hitLayerIDs) {
                     return hitLayerIDs.findLast(function (id) {
-                        return !this.state.document.layers.byID(id).isArtboard;
+                        var layer = this.state.document.layers.byID(id);
+
+                        return layer && !layer.isArtboard;
                     }, this);
                 })
                 .then(function (topID) {


### PR DESCRIPTION
Addresses #2456, it must have been a timing issue where the OS.mouseMoveHandler got a layer ID from PS that's not in our models.