### PR TITLE
Reset from pen tool to default when selected layer is not pen friendly

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -714,13 +714,16 @@ define(function (require, exports) {
                     }
                 }).then(function () {
                     return this.transfer(tools.resetBorderPolicies);
+                }).then(function () {
+                    return this.transfer(tools.resetPenTool);
                 });
 
         return Promise.join(dispatchPromise, selectPromise, revealPromise);
     };
     select.reads = [];
     select.writes = [locks.PS_DOC, locks.JS_DOC];
-    select.transfers = [revealLayers, resetSelection, tools.resetBorderPolicies];
+    select.transfers = [revealLayers, resetSelection,
+        tools.resetBorderPolicies, tools.resetPenTool];
     select.post = [_verifyLayerSelection];
 
     /**


### PR DESCRIPTION
Addresses #1681, if we select a shape layer or a completed pen path layer, clicking with the pen tool causes an error.

A better fix would be to change behavior in core and in those situations start a new path layer with the pen tool. That can be done on core side and will be tracked as such.