### PR TITLE
Reset guide policy ID on reset

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -434,6 +434,8 @@ define(function (require, exports) {
         descriptor.removeListener("set", _guideSetHandler);
         descriptor.removeListener("delete", _guideDeleteHandler);
 
+        _currentGuidePolicyID = null;
+
         return Promise.resolve();
     };
     onReset.reads = [];


### PR DESCRIPTION
This was causing issues where an error would put us in a constant loop of resets, because we forgot to nullify the guide policy ID between failures.