### PR TITLE
Global export button added to document header

### DIFF
--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -31,8 +31,11 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
 
     var os = require("adapter/os");
-    
-    var DocumentHeaderTab = require("jsx!js/jsx/DocumentHeaderTab");
+
+    var DocumentHeaderTab = require("jsx!js/jsx/DocumentHeaderTab"),
+        Button = require("jsx!js/jsx/shared/Button"),
+        SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
+        strings = require("i18n!nls/strings");
 
     var DocumentHeader = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("application", "document")],
@@ -112,7 +115,7 @@ define(function (require, exports, module) {
             
             window.addEventListener("resize", this._handleWindowResize);
         },
-        
+
         componentWillUnmount: function () {
             os.removeListener("displayConfigurationChanged", this._updatePanelSizes);
             window.removeEventListener("resize", this._handleWindowResize);
@@ -130,7 +133,7 @@ define(function (require, exports, module) {
                 headerWidth: React.findDOMNode(this).clientWidth
             });
         },
-        
+
         /** @ignore */
         _handleTabClick: function (documentID) {
             var selectedDoc = this.getFlux().store("document").getDocument(documentID);
@@ -139,15 +142,24 @@ define(function (require, exports, module) {
             }
         },
 
+        /**
+         * Opens the export dialog 
+         */
+        _openExportPanel: function () {
+            this.getFlux().actions.export.openExportPanel();
+        },
+
         render: function () {
             var documentStore = this.getFlux().store("document"),
                 document = this.state.document,
                 smallTab = this.state.headerWidth / this.state.documentIDs.size < 175;
             // Above: This number tunes when tabs should be shifted to small tabs
 
+            var exportDisabled = !document || document.unsupported;
+
             var documentTabs = this.state.documentIDs.map(function (docID) {
                 var doc = documentStore.getDocument(docID);
-                
+
                 if (doc) {
                     return (
                         <DocumentHeaderTab
@@ -166,6 +178,18 @@ define(function (require, exports, module) {
                 <div className="document-container">
                     <div className="document-header" ref="tabContainer">
                             {documentTabs}
+                    </div>
+                    <div className="export-header">
+                        <div className="export-header-buttons">
+                            <Button
+                                className="button-plus button-simple"
+                                title={strings.TOOLTIPS.EXPORT_DIALOG}
+                                disabled={exportDisabled}
+                                onClick={this._openExportPanel}>
+                                <SVGIcon
+                                    CSSID="extract-all" />
+                            </Button>
+                        </div>
                     </div>
                 </div>
             );

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -244,7 +244,8 @@
         "EXPORT_ADD_ASSET": "Add export asset",
         "EXPORT_REMOVE_ASSET": "Remove asset configuration",
         "EXPORT_IOS_PRESETS": "Add 3 iOS assets + SVG",
-        "EXPORT_HDPI_PRESETS": "Add 6 HDPI assets + SVG"
+        "EXPORT_HDPI_PRESETS": "Add 6 HDPI assets + SVG",
+        "EXPORT_DIALOG": "Export..."
     },
     "LAYER_KIND": {
         "0": "Any Layer",

--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -59,11 +59,44 @@
 .document-header {
     height: @toolbar-button-size;
     line-height: @toolbar-button-size;
-    max-width: 100%;
-    width: 100%;
+    flex-grow: 10;
     position: relative;
     overflow: hidden;
     display: flex;
+}
+
+.export-header {
+    height: @toolbar-button-size;
+    line-height: @toolbar-button-size;
+    max-width: 5rem;
+    width: 5rem;
+    display: flex;
+    flex-grow: 1;
+}
+
+.export-header-buttons { 
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.export-header-buttons .button-simple.button-plus {
+    margin-right: 2rem;
+
+    & svg:hover {
+        fill: @item;
+    }
+
+    &.button-simple__disabled svg{
+        fill: @item-disabled;
+
+        &:hover {
+            fill: @item-disabled;
+        }
+    }
 }
 
 .document-container {


### PR DESCRIPTION
Adds an "open export dialog" to the document header 

Things to note: 

1.) Despite some of the comps regarding the UI (example: https://trello.com/c/zD4DGHqz/452-epic-ui-overhaul), I was told to only insert "open export dialog" icon for the time being. 

2.) @designedbyscience and I talked about the DOM structure and he said it is best to keep the new class .generator-header as a sibling to .document-header for CSS stability. 

This is what the UI looks currently: 

![](https://www.dropbox.com/s/xuh1jit7g4qg8q9/Screenshot%202015-09-14%2015.29.08.png?raw=1)

![](https://www.dropbox.com/s/0weo7ialy3f2qg4/Screenshot%202015-09-14%2015.30.14.png?raw=1)

![](https://www.dropbox.com/s/9wvlrti4jf6vu7n/Screenshot%202015-09-14%2015.30.22.png?raw=1)
