### PR TITLE
Disable focus on color swatches temporarily

### DIFF
--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -286,7 +286,6 @@ define(function (require, exports, module) {
                 <div className={swatchClassSet}>
                     <div
                         ref="swatch"
-                        tabIndex="0"
                         className="color-input__swatch__background"
                         onFocus={this._handleSwatchFocus}
                         onKeyDown={this._handleKeyDown}


### PR DESCRIPTION
The swatch that is part of `ColorInput` components needs to be able to take focus so that the color picker can be part of the focus change. But, currently, the color swatch does not correctly implement focus management between CEF and PS. In particular, if the swatch has focus, it isn't easy to release focus back to PS, and when in this state none of the keyboard shortcuts will work. This is a short-term workaround for the issue which temporarily removes the ability for the color swatch to take focus. After the MAX deadline, we'll reinstate this and also implement correct swatch focus management.