### PR TITLE
Render one libraries panel for all documents to maintain consistent state

### DIFF
--- a/src/js/jsx/PanelColumn.jsx
+++ b/src/js/jsx/PanelColumn.jsx
@@ -28,10 +28,8 @@ define(function (require, exports, module) {
         classnames = require("classnames");
 
     var PanelColumn = React.createClass({
-
         shouldComponentUpdate: function (nextProps) {
-            // The document is inactive
-            if (!nextProps.current) {
+            if (!this.props.visible && !nextProps.visible) {
                 return false;
             }
 

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -69,7 +69,8 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps) {
-            if (this.props.disabled !== nextProps.disabled) {
+            if (this.props.disabled !== nextProps.disabled ||
+                this.props.active !== nextProps.active) {
                 return true;
             }
 
@@ -229,6 +230,7 @@ define(function (require, exports, module) {
             var sectionClasses = classnames({
                 "export": true,
                 "section": true,
+                "section__active": this.props.active,
                 "section__collapsed": !this.props.visible
             });
 

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -125,7 +125,8 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            if (this.props.disabled !== nextProps.disabled) {
+            if (this.props.disabled !== nextProps.disabled ||
+                this.props.active !== nextProps.active) {
                 return true;
             }
 
@@ -149,7 +150,8 @@ define(function (require, exports, module) {
                 return true;
             }
 
-            return this.state.dragTargets !== nextState.dragTargets ||
+            return this.props.active !== nextProps.active ||
+                this.state.dragTargets !== nextState.dragTargets ||
                 this.state.dropTarget !== nextState.dropTarget ||
                 this.state.dragPosition !== nextState.dragPosition ||
                 !Immutable.is(_getFaces(this.props), _getFaces(nextProps));
@@ -603,6 +605,7 @@ define(function (require, exports, module) {
             var sectionClasses = classnames({
                 "layers": true,
                 "section": true,
+                "section__active": this.props.active,
                 "section__collapsed": !this.props.visible
             });
 

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
                 "section": true,
                 "section__collapsed": !this.props.visible,
                 "libraries_no-drop": this.state.isDropTarget && !this.state.selectedLibrary
-            });
+            }, this.props.className);
 
             var librariesContent = this._renderLibrariesContent(),
                 dropOverlay;

--- a/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
+++ b/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
                 }, this);
 
             return (
-                <section className="artboard-presets section">
+                <section className="artboard-presets section section__active">
                     <TitleHeader title={strings.NO_DOC.ARTBOARD_PRESETS_TITLE} />
                     <div className="section-container artboard-launcher__body">
                         <ul className="link-list__list">

--- a/src/js/jsx/sections/nodoc/RecentFiles.jsx
+++ b/src/js/jsx/sections/nodoc/RecentFiles.jsx
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
                 }, this);
 
             return (
-                <section className="recent-files section">
+                <section className="recent-files section section__active">
                     <TitleHeader title={strings.NO_DOC.RECENT_FILES_TITLE} />
                     <div className="section-container">
                         <ul className="link-list__list">

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -79,11 +79,9 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps) {
-            if (this.props.disabled !== nextProps.disabled) {
-                return true;
-            }
-
-            if (nextProps.hidden !== this.props.hidden) {
+            if (this.props.disabled !== nextProps.disabled ||
+                this.props.active !== nextProps.active ||
+                this.props.hidden !== nextProps.hidden) {
                 return true;
             }
             
@@ -158,6 +156,7 @@ define(function (require, exports, module) {
             var sectionClasses = classnames({
                 "section": true,
                 "appearance": true,
+                "section__active": this.props.active,
                 "section__sibling-collapsed": !this.props.visibleSibling,
                 "section__collapsed": !this.props.visible
             });

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -86,7 +86,8 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps) {
-            if (this.props.disabled !== nextProps.disabled) {
+            if (this.props.disabled !== nextProps.disabled ||
+                this.props.active !== nextProps.active) {
                 return true;
             }
 
@@ -194,6 +195,7 @@ define(function (require, exports, module) {
             var sectionClasses = classnames({
                 "effects": true,
                 "section": true,
+                "section__active": this.props.active,
                 "section__collapsed": !this.props.visible,
                 "section__sibling-collapsed": !this.props.visibleSibling
             });

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -36,7 +36,21 @@ define(function (require, exports, module) {
         Flip = require("jsx!./Flip");
 
     var TransformPanel = React.createClass({
+        shouldComponentUpdate: function (nextProps) {
+            if (!this.props.active && !nextProps.active) {
+                return false;
+            }
+            
+            return true;
+        },
+        
         render: function () {
+            var sectionClasses = classnames({
+                "transform": true,
+                "section": true,
+                "section__active": this.props.active
+            });
+            
             var positionRotateClasses = classnames("formline",
                 "formline__bottom-align",
                 "formline__space-between",
@@ -44,7 +58,7 @@ define(function (require, exports, module) {
                 "formline__padded-first-child");
             
             return (
-                <section className="transform section">
+                <section className={sectionClasses}>
                     <header className="section-header">
                         <AlignDistribute document={this.props.document} />
                     </header>

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -693,6 +693,7 @@ define(function (require, exports, module) {
                         placeholderText={this.props.placeholderText}
                         neverSelectAll={this.props.neverSelectAllInput}
                         onFocus={this._handleInputFocus}
+                        onBlur={this._handleInputBlur}
                         onKeyDown={this._handleInputKeyDown}
                         onChange={this._handleInputChange}
                         onDOMChange={this._handleInputDOMChange}

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -42,10 +42,6 @@
 .panel-set {
     height: 100%;
     max-height: 100%;
-    display: none;
-}
-
-.panel-set__active{
     display: flex;
 }
 
@@ -173,7 +169,7 @@
 }
 
 .section {
-    display: flex;
+    display: none;
     flex-direction: column;
     flex-wrap: nowrap;
     border-bottom: 2*@hairline solid @bg-border;
@@ -184,6 +180,10 @@
 
 .section__hidden {
     display: none;
+}
+
+.section__active {
+    display: flex;
 }
 
 .section.section__collapsed {


### PR DESCRIPTION
Currently each document has its own panel set in the DOM, which is reasonable as documents have different attributes and state. However, this cause problems to the library panel as switching between document should maintain the same state (scroll position, selected asset, dialog, etc.). The problem is originally reported in #2312. This PR changed the behavior by rendering only one libraries panel for all documents, and still keep separate copy of other panels. 

(Note that I tried and it is not working by creating a top level libraries panel instance and pass it as a prop to the panel set, because the instance will have different component key (final key = parent keys + component key) when rendered and will result in DOM replacement.)

![ui-separate-libraries](https://cloud.githubusercontent.com/assets/118264/9889519/bd0d4850-5baf-11e5-9c29-fa2323f7013b.gif)

This PR also addressed #2430 by adding the onBlur handler back. 

![ui-datalist](https://cloud.githubusercontent.com/assets/118264/9889526/c03adaec-5baf-11e5-9ecb-de5546e29ee6.gif)

@designedbyscience since you are the master of UI, I am assigning this to you :dancers: 