### PR TITLE
Spaced out buttons in the exports panel header

### DIFF
--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -230,10 +230,21 @@
 }
 
 .layer-exports__workflow-buttons .button-simple {
+
     &__disabled, &__disabled:hover {
         svg {
             fill: @item-disabled;
         }
+    }
+}
+
+.layer-exports__workflow-buttons .button-simple.button {
+    &-plus {
+        margin-left: 1rem;
+    } 
+
+    &-iOS, &-xdpi {
+        margin-left: .5rem;
     }
 }
 


### PR DESCRIPTION
@designedbyscience Suggested this tweak to the Exports Panel 

Before:
![](https://www.dropbox.com/s/nlo571djvjinpmr/Screenshot%202015-09-15%2014.47.14.png?raw=1)

After: 
![](https://www.dropbox.com/s/zqaea10tvmw4r9s/Screenshot%202015-09-15%2015.07.26.png?raw=1)