### PR TITLE
Fixed export panel input configurations - fixing a recent regression

### DIFF
--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -153,6 +153,7 @@ define(function (require, exports, module) {
                             className="dialog-export-scale"
                             options={_scaleOptions.toList()}
                             value={scaleOption.title}
+                            defaultSelected={scaleOption.id}
                             onChange={this._handleUpdateScale}
                             live={false}
                             size="column-4" />
@@ -162,6 +163,7 @@ define(function (require, exports, module) {
                             value={exportAsset.suffix}
                             singleClick={true}
                             editable={true}
+                            live={true}
                             onChange={this._handleUpdateSuffix}
                             size="column-8" />
                     </div>
@@ -171,6 +173,7 @@ define(function (require, exports, module) {
                             className="dialog-export-format"
                             options={_formatOptions.toList()}
                             value={exportAsset.format.toUpperCase()}
+                            defaultSelected={exportAsset.format}
                             onChange={this._handleUpdateFormat}
                             live={false}
                             size="column-8" />


### PR DESCRIPTION
These changes to the inputs were accidentally overwritten by a recent commit.  @placegraphichere this should fix the suffix input disabled issue you mentioned.  It also restores the ability to tab through the inputs without making changes.