### PR TITLE
Always install arrow policies for focusable, and remove them correctly

### DIFF
--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -61,12 +61,7 @@ define(function (require, exports, module) {
                         return;
                     }
 
-                    var flux = this.getFlux();
-                    if (!flux.store("tool").getModalToolState()) {
-                        return;
-                    }
-
-                    return flux.actions.policy.addKeyboardPolicies(keyboardPolicyList)
+                    return this.getFlux().actions.policy.addKeyboardPolicies(keyboardPolicyList)
                         .bind(this)
                         .then(function (policy) {
                             _keyboardPolicy = policy;
@@ -90,7 +85,7 @@ define(function (require, exports, module) {
                 .bind(this)
                 .then(function () {
                     if (keyboardPolicy) {
-                        return this.getFlux().actions.policy.removeKeyboardPolicies(keyboardPolicy);
+                        return this.getFlux().actions.policy.removeKeyboardPolicies(keyboardPolicy, true);
                     }
                 })
                 .catch(function (err) {


### PR DESCRIPTION
This removes one of @iwehrman's change from couple days ago for #2454 because we need those policies to be installed at all times. 

We also had a dormant bug where we were calling `removeKeyboardPolicies` with an undefined `commit` variable, so they were never being sent to PS to be removed.

Here is the scenario where this bug shows:

1 - Create shape layer
2 - Switch to super select tool
3 - Use arrow keys to nudge layer
4 - Click one of the transform inputs
5 - Use arrow keys to change that value
6 - Press escape / click outside to lose focus
7 - Use arrow keys again - at this point, arrow keys no longer work until we switch back and forth to superselect tool

As far as Ian's change of installing policies only in modal state goes... We need the never_prop policies for arrow keys because superselect tool has the always policies installed and they need to be masked over.