### PR TITLE
Allow all text justification values 

### DIFF
--- a/src/js/models/paragraphstyle.js
+++ b/src/js/models/paragraphstyle.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
      */
     var _paragraphStylePrototype = {
         /*
-         * @type {string} Either "left", "center", "right" or "justifyAll"
+         * @type {string} Either "left", "center", "right", "justifyAll",
+         *  "justifyLeft", "justifyRight", or "justifyCenter".
          */
         alignment: "left"
     };
@@ -63,15 +64,8 @@ define(function (require, exports, module) {
 
         if (paragraphStyle.hasOwnProperty("align")) {
             var alignment = paragraphStyle.align._value;
-            switch (alignment) {
-            case "left":
-            case "center":
-            case "right":
-            case "justifyAll":
+            if (alignment) {
                 model.alignment = alignment;
-                break;
-            default:
-                throw new Error("Unexpected paragraph alignment value: " + alignment);
             }
         }
 


### PR DESCRIPTION
This relaxes an overly strict check in the `ParagraphStyle` construction function that would throw if it found a justification value it didn't understand. As it turns out, there are more valid justification values than those previously checked for! Namely, `justifyLeft`, `justifyCenter` and `justifyRight`. This just lets anything pass through into the model as long as it's not falsey.

Addresses #2375. Instructions for testing are in that issue.