### PR TITLE
When stroke is in empty color state, initialize it at default color

### DIFF
--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
         _downsampleStrokes: function (strokes) {
             var colors = strokes.map(function (stroke) {
                     if (!stroke) {
-                        return null;
+                        return Color.DEFAULT;
                     }
                     if (stroke.type === contentLayerLib.contentTypes.SOLID_COLOR) {
                         return stroke.color;


### PR DESCRIPTION
If we had an image coming from PS, where stroke was set to empty color (red line crossing white square), we would get "null" as the color, and downsample would accept that as mixed. Instead, we consider those layers (where stroke is null) to be default color.

Reason for this is: if any property of stroke other than color is set (or the eye icon is clicked to enable stroke), it'll start with the default color anyways, so this removes the ambiguity of the mixed stroke for no-stroke layers.

Addresses #2207 