### PR TITLE
Focusable color swatch

### DIFF
--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -56,6 +56,14 @@ define(function (require, exports, module) {
     var ColorSwatch = React.createClass({
         mixins: [FluxMixin, Focusable],
 
+        propTypes: {
+            onKeyDown: React.PropTypes.func.isRequired,
+            onFocus: React.PropTypes.func.isRequired,
+            onClick: React.PropTypes.func.isRequired,
+            title: React.PropTypes.string.isRequired,
+            overlay: React.PropTypes.element
+        },
+
         /**
          * On escape, release focus and blur the swatch.
          *


### PR DESCRIPTION
This factors out a `ColorSwatch` component from the `ColorInput` component and makes it a `Focusable component. Once you focus the swatch by tabbing to it, you can hit enter to open the color picker. After the picker closes, the swatch regains focus. From there, you can keep tabbing or hit escape to return focus to PS. 

It's possible, though perhaps not likely, that this addresses #2490. 