### PR TITLE
Don't replace the empty layer while creating layers from library elem…

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -804,7 +804,7 @@ define(function (require, exports) {
                     existingLayerIDs = currentDocument.layers.index.toArray(),
                     newLayerIDs = _.difference(nextLayerIDs, existingLayerIDs).reverse();
 
-                return this.transfer(layerActions.addLayers, currentDocument, newLayerIDs, true);
+                return this.transfer(layerActions.addLayers, currentDocument, newLayerIDs, true, false);
             });
     };
     createLayerFromElement.reads = [locks.CC_LIBRARIES, locks.JS_DOC, locks.JS_UI, locks.JS_APP];

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -874,7 +874,7 @@ define(function (require, exports, module) {
                 var selectedLayers = document.layers.selected;
                 replaceLayer = selectedLayers && selectedLayers.size === 1 && selectedLayers.first();
             }
-            
+
             // The selected layer should be empty and a non-background layer unless replace is explicitly provided true
             replace = replaceLayer &&
                 (replace ||

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -869,15 +869,12 @@ define(function (require, exports, module) {
             if (Number.isInteger(replace)) {
                 // if explicitly replacing, then replace by current ID
                 replaceLayer = this.byID(replace);
-            } else if (this.selected && this.selected.size === 1) {
-                // otherwise, replace the selected layer if it has the same index with the new layer.
-                var selectedLayer = this.selected.first(),
-                    selectedLayerIndex = this.indexOf(selectedLayer),
-                    newLayerIndex = descriptors[0].itemIndex;
-                    
-                replaceLayer = selectedLayerIndex === newLayerIndex && selectedLayer;
+            } else {
+                // otherwise, replace the selected layer
+                var selectedLayers = document.layers.selected;
+                replaceLayer = selectedLayers && selectedLayers.size === 1 && selectedLayers.first();
             }
-
+            
             // The selected layer should be empty and a non-background layer unless replace is explicitly provided true
             replace = replaceLayer &&
                 (replace ||


### PR DESCRIPTION
So creating a new layer works right.

@iwehrman, in #2201 thought that the empty layer left behind in our model was a bug. But PS actually leaves this empty layer when we do a library place. So I'm reverting @shaoshing's changes from #2268 (bcbb1ed) so we don't break replace algorithm for add layers in other places.

Will address #2484 alongside correct layer positioning.