### PR TITLE
Fix error loading documents with a background layer

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -162,10 +162,7 @@ define(function (require, exports) {
      * @return {Promise.<{document: object, layers: Array.<object>}>}
      */
     var _getLayersForDocument = function (doc) {
-        var startIndex = (doc.hasBackgroundLayer ? 0 : 1),
-            numberOfLayers = (doc.hasBackgroundLayer ? doc.numberOfLayers + 1 : doc.numberOfLayers);
-
-        return layerActions._getLayersForDocument(doc, startIndex, numberOfLayers)
+        return layerActions._getLayersForDocument(doc)
             .then(function (layers) {
                 return {
                     document: doc,

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1289,6 +1289,10 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setOpacity = function (document, layers, opacity, coalesce) {
+        layers = layers.filterNot(function (layer) {
+            return layer.isBackground;
+        });
+
         var payload = {
                 documentID: document.id,
                 layerIDs: collection.pluck(layers, "id"),
@@ -1459,6 +1463,10 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setBlendMode = function (document, layers, mode) {
+        layers = layers.filterNot(function (layer) {
+            return layer.isBackground;
+        });
+
         var documentRef = documentLib.referenceBy.id(document.id),
             layerIDs = collection.pluck(layers, "id"),
             layerRef = layerIDs

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -158,12 +158,11 @@ define(function (require, exports) {
      * 
      * @private
      * @param {object} doc A document descriptor
-     * @param {number} startIndex
-     * @param {number} numberOfLayers
      * @return {Promise.<Array.<object>>}
      */
-    var _getLayersForDocument = function (doc, startIndex, numberOfLayers) {
+    var _getLayersForDocument = function (doc) {
         var documentID = doc.documentID,
+            startIndex = doc.hasBackgroundLayer ? 0 : 1,
             docRef = documentLib.referenceBy.id(documentID),
             rangeOpts = {
                 range: "layer",
@@ -183,7 +182,7 @@ define(function (require, exports) {
             targetRefs = targetLayers.map(function (target) {
                 return [
                     documentLib.referenceBy.id(documentID),
-                    layerLib.referenceBy.index(target._index + 1)
+                    layerLib.referenceBy.index(startIndex + target._index)
                 ];
             });
 
@@ -196,6 +195,7 @@ define(function (require, exports) {
         // the photoshop action will fail.
         // And it is safe to ignore ALL bg layers because we don't use extension data on them
         var nameSpace = global.EXTENSION_DATA_NAMESPACE,
+            numberOfLayers = doc.hasBackgroundLayer ? doc.numberOfLayers + 1 : doc.numberOfLayers,
             indexRange = _.range(1, startIndex + numberOfLayers),
             extensionPlayObjects = indexRange.map(function (i) {
                 var layerRef = layerLib.referenceBy.index(i);

--- a/src/js/jsx/sections/style/LayerBlendMode.jsx
+++ b/src/js/jsx/sections/style/LayerBlendMode.jsx
@@ -67,13 +67,16 @@ define(function (require, exports, module) {
                 modes = collection.pluck(layers, "blendMode"),
                 allGroups = layers.every(function (layer) {
                     return layer.kind === layer.layerKinds.GROUP;
+                }),
+                disabled = this.props.disabled || layers.every(function (layer) {
+                    return layer.isBackground;
                 });
 
             var listID = "blendmodes-" + this.props.id + this.props.containerType + "-" + this.props.document.id;
 
             return (
                 <BlendMode
-                    disabled={this.props.disabled}
+                    disabled={disabled}
                     listID={listID}
                     modes={modes}
                     handleChange={this._handleChange}

--- a/src/js/jsx/sections/style/Opacity.jsx
+++ b/src/js/jsx/sections/style/Opacity.jsx
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps) {
             var getRelevantProps = function (props) {
-                return collection.pluck(props.layers, "opacity");
+                return collection.pluckAll(props.layers, ["id", "opacity"]);
             };
 
             return !Immutable.is(getRelevantProps(this.props), getRelevantProps(nextProps));
@@ -55,7 +55,11 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var opacities = collection.pluck(this.props.layers, "opacity");
+            var opacities = collection.pluck(this.props.layers, "opacity"),
+                disabled = this.props.disabled || this.props.layers.every(function (layer) {
+                    return layer.isBackground;
+                });
+
             return (
                 <NumberInput
                     value={opacities}
@@ -63,7 +67,7 @@ define(function (require, exports, module) {
                     onFocus={this.props.onFocus}
                     min={0}
                     max={100}
-                    disabled={this.props.disabled}
+                    disabled={disabled}
                     size="column-4" />
             );
         }

--- a/src/style/shared/number-input.less
+++ b/src/style/shared/number-input.less
@@ -32,10 +32,6 @@
     border-bottom: @hairline solid @item-active;
 }
 
-.number-input:disabled:hover {
-    border: none;
-}
-
 .number-input__dirty:focus,
 .number-input__clean:focus {
     color: @item;


### PR DESCRIPTION
@volfied pointed out this morning that he was unable to load a picture of his puppy dog. This was due to my recent change in #2439 to `layers._getLayersForDoc` handling layer indexing incorrectly for documents with background layers. In my defense, the way Photoshop does this is completely :banana: :banana:.

CC @mcilroyc since you reviewed #2439 and CC @volfied because it was your puppy. 