### PR TITLE
remove policies while in a text modal state

### DIFF
--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -254,6 +254,7 @@ define(function (require, exports) {
     };
     disablePolicies.reads = [];
     disablePolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    disablePolicies.modal = true;
 
     /**
      * Re-enabled cached keyboard policies
@@ -285,6 +286,7 @@ define(function (require, exports) {
     };
     reenablePolicies.reads = [];
     reenablePolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    reenablePolicies.modal = true;
 
     /**
      * Set the default keyboard propagation policy.

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -176,6 +176,16 @@ define(function (require, exports, module) {
             descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
 
             _toolModalStateChangedHandler = function (event) {
+                if (event.tool.ID === "txBx" && event.state._value === "enter" &&
+                    event.kind._value === "tool") {
+                    this.flux.actions.policy.disablePolicies();
+                }
+
+                if (event.tool.ID === "txBx" && event.state._value === "exit" &&
+                    event.kind._value === "tool") {
+                    this.flux.actions.policy.reenablePolicies();
+                }
+
                 if (event.kind._value === "tool" && event.tool.ID === "txBx" &&
                     event.state._value === "exit" && event.reason._value === "cancel") {
                     // If there was a deleteTextLayer event, we've already updated the model.


### PR DESCRIPTION
fix for type tool with Jespers change to keyboard policies on the plugin