### PR TITLE
Use alpha propagate instead of always for border policies

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -177,7 +177,7 @@ define(function (require, exports) {
                 }
             ),
             // Used for distort/skew transformations
-            noOutsetCommandPolicy = new PointerEventPolicy(adapterUI.policyAction.ALWAYS_PROPAGATE,
+            noOutsetCommandPolicy = new PointerEventPolicy(adapterUI.policyAction.ALPHA_PROPAGATE,
                 adapterOS.eventKind.LEFT_MOUSE_DOWN,
                 distortModifier,
                 {
@@ -187,7 +187,7 @@ define(function (require, exports) {
                     height: psSelectionHeight + inset * 2
                 }
             ),
-            outsidePolicy = new PointerEventPolicy(adapterUI.policyAction.ALWAYS_PROPAGATE,
+            outsidePolicy = new PointerEventPolicy(adapterUI.policyAction.ALPHA_PROPAGATE,
                 adapterOS.eventKind.LEFT_MOUSE_DOWN,
                 {},
                 {


### PR DESCRIPTION
Always propagate sends all mouse clicks to PS, and this causes an issue when the resize border is below the panels.

Addresses #2354