### PR TITLE
Fix the zoom level within the valid increments during panZoom

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -315,6 +315,13 @@ define(function (require, exports) {
      * @return {{x: number, y: number, z: number}}
      */
     var _calculatePanZoom = function (bounds, offset, zoom, factor) {
+        var incrementsLen = ZOOM_INCREMENTS.length;
+        if (zoom < ZOOM_INCREMENTS[0]) {
+            zoom = ZOOM_INCREMENTS[0];
+        } else if (zoom > ZOOM_INCREMENTS[incrementsLen - 1]) {
+            zoom = ZOOM_INCREMENTS[incrementsLen - 1];
+        }
+
         return {
             x: zoom * bounds.xCenter / factor + (offset.right - offset.left) / 2,
             y: zoom * bounds.yCenter / factor + (offset.bottom - offset.top) / 2,


### PR DESCRIPTION
Problem was, with tiny layers, we'd get a zoom factor much bigger than our allowed zoom, and this would break bounds calculation. Now we limit the zoom factor to [0.05, 32], even when it's fit selection.

Addresses #2526 