### PR TITLE
Better artboard export prefix handling

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -176,7 +176,7 @@ define(function (require, exports) {
             fileName = baseName + asset.suffix,
             _layers = layer ? Immutable.List.of(layer) : null;
 
-        fileName = prefix ? prefix + fileName : fileName;
+        fileName = prefix ? prefix + "-" + fileName : fileName;
 
         return _exportService.exportAsset(document, layer, asset, fileName, baseDir)
             .bind(this)
@@ -666,9 +666,10 @@ define(function (require, exports) {
      *
      * @param {Document} document
      * @param {Immutable.Iterable.<Layer>=} layers Optional.  If not supplied export all exportEnabled layers
+     * @param {Immutable.Map.<number, string>=} prefixMap Optional map of layerID > asset prefix
      * @return {Promise} Resolves when all assets have been exported, or if canceled via the file chooser
      */
-    var exportLayerAssets = function (document, layers) {
+    var exportLayerAssets = function (document, layers, prefixMap) {
         if (_activeExports) {
             Promise.reject(new Error("Can not export assets while another batch job in progress"));
         }
@@ -683,7 +684,6 @@ define(function (require, exports) {
 
         var documentID = document.id,
             documentExports = this.flux.stores.export.getDocumentExports(documentID, true),
-            exportStore = this.flux.stores.export,
             layersList,
             quickAddPromise;
 
@@ -722,8 +722,8 @@ define(function (require, exports) {
                 var documentExports = this.flux.stores.export.getDocumentExports(documentID, true);
 
                 // Iterate over the layers, find the associated export assets, and export them
-                var exportList = layersList.flatMap(function (layer, index) {
-                    var prefix = exportStore.getExportPrefix(layer, index);
+                var exportList = layersList.flatMap(function (layer) {
+                    var prefix = prefixMap && prefixMap.get(layer.id);
 
                     return documentExports.getLayerExports(layer.id)
                         .map(function (asset, index) {

--- a/src/js/stores/export.js
+++ b/src/js/stores/export.js
@@ -157,6 +157,8 @@ define(function (require, exports, module) {
         getExportPrefix: function (layer, index) {
             if (this._state.useArtboardPrefix && layer.isArtboard) {
                 return _.padLeft(index + 1, 3, "0");
+            } else {
+                return null;
             }
         },
 

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -388,7 +388,8 @@
         "TITLE_SETTINGS": "Settings",
         "EXPORT_DOCUMENT_FILENAME": "document",
         "ONLY_UNSUPPORTED_LAYERS_SELECTED": "No supported layers selected",
-        "NO_ASSETS": "No exports configured"
+        "NO_ASSETS": "No exports configured",
+        "USE_PREFIX": "Use Prefix"
     },
     "TEMPLATES": {
         "IPHONE_6_PLUS": "iPhone 6+",


### PR DESCRIPTION
This fixes a pretty brain-dead mistake in the way artboard prefixes were being derived.  Now, in the react render() method after sorting artboards, a map of layer>prefix is created (if necessary).  That map is provided to the "export all" action.  This maintains consistency of prefixes across the UI, and the actual export process.... but the prefixes are still transient (not persisted to PS metadata, nor maintained in our store which would require a lot more overhead of trying to keep up with AB positions on canvas).  Addresses #2473

bonus: Also add the "Use Prefix" label as a translatable string