### PR TITLE
CC Libraries - improve character style titles in the panel and search result

### DIFF
--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -29,8 +29,8 @@ define(function (require, exports) {
     var events = require("js/events"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),
-        tinycolor = require("tinycolor"),
-        libraryActions = require("js/actions/libraries");
+        libraryActions = require("js/actions/libraries"),
+        librariesUtil = require("js/util/libraries");
 
     /**
      * Map from element IDs to corresponding element and type
@@ -85,19 +85,12 @@ define(function (require, exports) {
                         }
                     }
 
-                    if (categoryKey === "CHARACTERSTYLE" && !title) {
-                        var charStyle = element.getPrimaryRepresentation().getValue("characterstyle", "data"),
-                            font = charStyle.adbeFont,
-                            fontString = font.family + " " + font.style,
-
-                            fontSize = charStyle.fontSize,
-                            fontSizeString = fontSize.value + fontSize.type,
-
-                            fontColor = charStyle.color && charStyle.color[0],
-                            fontColorString = fontColor ?
-                                ", " + tinycolor(fontColor.value).toHexString().toUpperCase() : "";
-
-                        title = fontString + ", " + fontSizeString + fontColorString;
+                    if (categoryKey === "CHARACTERSTYLE") {
+                        if (!title) {
+                            title = librariesUtil.formatCharStyle(element, ["fontFamily", "fontStyle"], " ");
+                        }
+                        
+                        title = title + " - " + librariesUtil.formatCharStyle(element, ["color", "fontSize"], ", ");
                     }
 
                     _idMap[id] = { asset: element, type: categoryKey };

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -190,7 +190,8 @@ define(function (require, exports, module) {
                     </SplitButtonList>
                 );
             } else {
-                var subTitle = this.props.subTitle && (<div className="libraries__asset__subtitle">
+                var subTitle = this.props.subTitle &&
+                    (<div className="libraries__asset__subtitle" title={this.props.title}>
                         {this.props.subTitle}
                     </div>);
 

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -26,11 +26,10 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
-        tinycolor = require("tinycolor"),
-        _ = require("lodash");
+        FluxMixin = Fluxxor.FluxMixin(React);
 
-    var strings = require("i18n!nls/strings");
+    var strings = require("i18n!nls/strings"),
+        librariesUtil = require("js/util/libraries");
 
     var AssetSection = require("jsx!./AssetSection"),
         AssetPreviewImage = require("jsx!./AssetPreviewImage");
@@ -77,18 +76,11 @@ define(function (require, exports, module) {
                 return null;
             }
 
-            var fontSize = charStyle.fontSize,
-                fontSizeStr = fontSize ? Math.ceil(fontSize.value * 10) / 10 + fontSize.type : null,
-                fontColorHex = null;
-
-            if (charStyle.color) {
-                var color = charStyle.color instanceof Array ? charStyle.color[0] : charStyle.color;
-                fontColorHex = tinycolor(color.value).toHexString().toUpperCase();
-            }
-
-            var fontSizeAndColorStr = _.remove([fontSizeStr, fontColorHex], null).join(", "),
-                fontInfo = font.family + " " + font.style,
-                displayName = element.displayName || fontInfo,
+            var displayName = element.displayName ||
+                    librariesUtil.formatCharStyle(element, ["fontFamily", "fontStyle"], " "),
+                subtitle = librariesUtil.formatCharStyle(element, ["color", "fontSize", "leading", "tracking"], ", "),
+                color = librariesUtil.getCharStyleColor(element),
+                fontColorHex = color && color.toHexString(),
                 colorPreview = this.state.hasPreview && fontColorHex && (<div
                     style={{ backgroundColor: fontColorHex }}
                     className="libraries__asset__preview-character-style__color-swatch"/>);
@@ -99,8 +91,8 @@ define(function (require, exports, module) {
                     onSelect={this.props.onSelect}
                     selected={this.props.selected}
                     displayName={displayName}
-                    title={fontInfo}
-                    subTitle={fontSizeAndColorStr}
+                    title={subtitle}
+                    subTitle={subtitle}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style"
                          title={strings.LIBRARIES.CLICK_TO_APPLY}

--- a/src/js/util/libraries.js
+++ b/src/js/util/libraries.js
@@ -1,0 +1,110 @@
+/*
+
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+    
+    var tinycolor = require("tinycolor"),
+        _ = require("lodash");
+        
+    var strings = require("i18n!nls/strings");
+        
+    /**
+     * Return character style's color object.
+     * 
+     * @param  {AdobeLibraryElement} element
+     * @return {?TinyColor}
+     */
+    var getCharStyleColor = function (element) {
+        var charStyle = element.getPrimaryRepresentation().getValue("characterstyle", "data"),
+            color;
+            
+        if (charStyle.color) {
+            var colorData = charStyle.color instanceof Array ? charStyle.color[0] : charStyle.color;
+            
+            color = tinycolor(colorData.value);
+        }
+        
+        return color;
+    };
+    
+    /**
+     * Format character style by attribute names.
+     * 
+     * @param  {AdobeLibraryElement} element
+     * @param  {Array.<string>} attrs - accepted attributes: color, fontFamily, fontSize, fontStyle, leading, tracking
+     * @param  {String} separator - separator of the result attributes
+     * @return {String}
+     */
+    var formatCharStyle = function (element, attrs, separator) {
+        var style = element.getPrimaryRepresentation().getValue("characterstyle", "data"),
+            font = style.adbeFont;
+        
+        var strs = attrs.map(function (attr) {
+            switch (attr) {
+                case "color":
+                    var color = getCharStyleColor(element);
+                    return color ? color.toHexString().toUpperCase() : null;
+                    
+                case "fontFamily":
+                    return font ? font.family : null;
+                
+                case "fontSize":
+                    var fontSize = style.fontSize;
+                    return fontSize ? Math.ceil(fontSize.value * 10) / 10 + fontSize.type : null;
+
+                case "fontStyle":
+                    return font ? font.style : null;
+                
+                case "leading":
+                    var leading;
+                    
+                    if (style.adbeAutoLeading) {
+                        leading = strings.LIBRARIS.LEADING_AUTO;
+                    } else if (style.lineHeight && style.lineHeight.value) {
+                        leading = (Math.round(style.lineHeight.value * 100) / 100) + style.lineHeight.type;
+                    }
+                    
+                    return leading ? strings.LIBRARIES.LEADING.replace("%s", leading) : null;
+                
+                case "tracking":
+                    var tracking;
+                    
+                    if (style.adbeTracking) {
+                        tracking = style.adbeTracking;
+                    } else if (style.letterSpacing) {
+                        tracking = style.letterSpacing.value * 1000;
+                    }
+                    
+                    return tracking ? strings.LIBRARIES.TRACKING.replace("%s", tracking) : null;
+                
+            }
+        });
+        
+        return _.remove(strs, null).join(separator);
+    };
+
+    exports.formatCharStyle = formatCharStyle;
+    exports.getCharStyleColor = getCharStyleColor;
+});

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -500,7 +500,10 @@
         "INTRO_BODY": "Use Libraries to organize, access, and share your assets across desktop and mobile.",
         "INTRO_LINK_TITLE": "Learn how to use Libraries",
         "INTRO_URL": "https://helpx.adobe.com/creative-cloud/help/libraries.html",
-        "NO_CONNECTION": "To use Creative Cloud Libraries, please sign in to Creative Cloud."
+        "NO_CONNECTION": "To use Creative Cloud Libraries, please sign in to Creative Cloud.",
+        "LEADING": "Leading: %s",
+        "LEADING_AUTO": "Auto",
+        "TRACKING": "Tracking: %s"
     },
     "ERR": {
         "UNRECOVERABLE": "Design Space has encountered an unrecoverable error."


### PR DESCRIPTION
This PR displays leading and tracking of character styles in the libraries panel, and fix their title in the search result. It also extracts the code of formatting character style into `util/libraries` to avoid duplicates in search and libraries panel, and make them less error prone..

<img width="317" alt="screen shot 2015-09-18 at 11 27 14 am" src="https://cloud.githubusercontent.com/assets/118264/9967719/26b5647c-5df9-11e5-9734-daee680ac7a5.png">

<img width="525" alt="screen shot 2015-09-18 at 11 27 36 am" src="https://cloud.githubusercontent.com/assets/118264/9967722/280fe946-5df9-11e5-87ef-7e2d4cbd056d.png">
