### PR TITLE
Various Datalist event handling fixes

### DIFF
--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -289,6 +289,7 @@ define(function (require, exports, module) {
 
             return (<div className="libraries__bar__top__content">
                 <Datalist
+                    ref="list"
                     list={listID}
                     className="dialog-libraries"
                     options={listOptions}
@@ -296,6 +297,7 @@ define(function (require, exports, module) {
                     live={false}
                     autoSelect={false}
                     onChange={this._handleChangeLibrary}
+                    releaseOnBlur={true}
                     defaultSelected={selectedLibraryID}
                     disabled={this.props.disabled} />
                 <SplitButtonList className="libraries__split-button-list">

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -49,20 +49,12 @@ define(function (require, exports, module) {
         mixins: [FluxMixin, StoreWatchMixin("font", "tool")],
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            var getTexts = function (document) {
+            var getProperties = function (document) {
                 if (!document) {
                     return null;
                 }
 
-                return collection.pluck(document.layers.selected, "text");
-            };
-
-            var getOpacities = function (document) {
-                if (!document) {
-                    return null;
-                }
-
-                return collection.pluck(document.layers.selected, "opacity");
+                return collection.pluckAll(document.layers.selected, ["text", "opacity", "blendMode"]);
             };
 
             if (this.state.opaque !== nextState.opaque) {
@@ -71,8 +63,7 @@ define(function (require, exports, module) {
 
             return !Immutable.is(this.state.postScriptMap, nextState.postScriptMap) ||
                 !Immutable.is(this.state.typefaces, nextState.typefaces) ||
-                !Immutable.is(getTexts(this.props.document), getTexts(nextProps.document)) ||
-                !Immutable.is(getOpacities(this.props.document), getOpacities(nextProps.document));
+                !Immutable.is(getProperties(this.props.document), getProperties(nextProps.document));
         },
 
         getStateFromFlux: function () {

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -65,7 +65,9 @@ define(function (require, exports, module) {
             // IDs of items that, when selected, won't close the dialog
             dontCloseDialogIDs: React.PropTypes.arrayOf(React.PropTypes.string),
             // SVG class for an icon to show next to the Text Input
-            filterIcon: React.PropTypes.string
+            filterIcon: React.PropTypes.string,
+            // Release keyboard focus when the text input is blurred.
+            releaseOnBlur: React.PropTypes.bool
         },
 
         getDefaultProps: function () {
@@ -205,6 +207,11 @@ define(function (require, exports, module) {
             if (!this.props.live && this.state.id) {
                 this.props.onChange(this.state.id);
             }
+
+            if (this.props.releaseOnBlur) {
+                // Blur the text input and release focus.
+                this.refs.textInput.finish();
+            }
         },
 
         /**
@@ -225,8 +232,6 @@ define(function (require, exports, module) {
                     }
                     return;
                 case "Tab":
-                    this._handleInputClick(event);
-                    event.preventDefault();
                     return;
                 case "Enter":
                 case "Return":
@@ -318,7 +323,7 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Deactivates the datalist when the select menu is closed.
+         * Deactivates the datalist when the select menu is clicked.
          *
          * @private
          * @param {SyntheticEvent} event
@@ -345,9 +350,15 @@ define(function (require, exports, module) {
             }
         },
 
-        /** @ignore */
+        /**
+         * Deactivates the datalist when the select menu is closed.
+         *
+         * @private
+         * @param {SyntheticEvent} event
+         * @param {string} action Either "apply" or "cancel"
+         */
         _handleSelectClose: function (event, action) {
-            if (this.props.autoSelect) {
+            if (this.props.autoSelect || action === "apply") {
                 this._handleSelectClick(event, action);
             }
         },

--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -466,6 +466,17 @@ define(function (require, exports, module) {
             return prevID;
         },
 
+        /**
+         * Prevent the default event action to ensure that the related input does
+         * not blur before the click has been processed.
+         *
+         * @private
+         * @param {SyntheticEvent} event
+         */
+        _handleMouseDown: function (event) {
+            event.preventDefault();
+        },
+
         render: function () {
             var selectedKey = this.state.selected,
                 options = this._getOptions(),
@@ -506,6 +517,7 @@ define(function (require, exports, module) {
             return (
                 <ul {...this.props}
                     className="select"
+                    onMouseDown={this._handleMouseDown}
                     onClick={this._handleClick}
                     onMouseMove={this._handleMouseMove}>
                     {children}

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -178,20 +178,27 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Resets the text field to its last committed value.
-         *
-         * @private
-         * @param {SyntheticEvent} event
+         * Finish editing the text in put and release focus.
          */
-        _reset: function (event) {
+        finish: function () {
             this.setState({
                 value: this.props.value,
                 editing: false,
                 selectDisabled: false
             });
 
-            event.stopPropagation();
             this._releaseFocus();
+        },
+
+        /**
+         * Resets the text field to its last committed value.
+         *
+         * @private
+         * @param {SyntheticEvent} event
+         */
+        _reset: function (event) {
+            event.stopPropagation();
+            this.finish();
         },
 
         /**


### PR DESCRIPTION
1. Ensure that tabbing away from a focused `Datalist` does not open the `Datalist`. Once a `Datalist` is focused, start typing, or use the up/down arrows to open the `Datalist`.
2. Ensure that changing the blend mode updates the `Datalist` in `Type` component.
3. Ensure that the selections can be made in the `LibraryList` `Datalist` can be made either by pressing enter or or clicking to commit.
4. Ensure that tabbing away from the `LibraryList` `Datalist` releases focus back to PS completely. This is the last focusable element in the UI, and otherwise the app ends up in an indeterminate focus state which causes problems with shortcuts, etc.

Remaining known issues:

1. Committing a `Datalist` selection with enter should leave the `Datalist` focused, but it doesn't.
2. Shift-tabbing away from the `LibraryList` `Datalist` should probably _not_ release focus entirely, but it's also not clear that the user would really intend for a shift-tab to do something meaningful in this case...
3. There are lots of weirdnesses with navigating the `LibraryList` `Datalist` due to the distinct sections of the menu.

Addresses #2512 and #2409.