### PR TITLE
CC Libraries - handle update graphic asset for the close-document model dialog.

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -400,9 +400,10 @@ define(function (require, exports) {
      *
      * @private
      * @param {!number} documentID
+     * @param {boolean} isDocumentSaved - true if the user chooses save in the close-document modal dialog.
      * @return {Promise}
      */
-    var disposeDocument = function (documentID) {
+    var disposeDocument = function (documentID, isDocumentSaved) {
         return _getSelectedDocumentID()
             .bind(this)
             .then(function (currentDocumentID) {
@@ -417,7 +418,8 @@ define(function (require, exports) {
                     resetLinkedPromise = this.transfer(layerActions.resetLinkedLayers, newDocument),
                     recentFilesPromise = this.transfer(application.updateRecentFiles),
                     updateTransformPromise = this.transfer(ui.updateTransform),
-                    deleteTempFilesPromise = this.transfer(libraryActions.deleteGraphicTempFiles, documentID),
+                    deleteTempFilesPromise = this.transfer(libraryActions.deleteGraphicTempFiles,
+                        documentID, isDocumentSaved),
                     policyPromise = this.transfer(toolActions.resetBorderPolicies);
 
                 return Promise.join(resetLinkedPromise,
@@ -611,8 +613,10 @@ define(function (require, exports) {
             .then(function () {
                 return descriptor.playObject(closeObj, playOptions);
             })
-            .then(function () {
-                return this.transfer(disposeDocument, document.id);
+            .then(function (result) {
+                var isDocumentSaved = result.saving && result.saving._value === "yes";
+                
+                return this.transfer(disposeDocument, document.id, isDocumentSaved);
             }, function () {
                 // the play command fails if the user cancels the close dialog
             });

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -694,13 +694,18 @@ define(function (require, exports) {
      * Delete graphic asset's temp document and preview files.
      *
      * @param {number} documentID
+     * @param {boolean} isDocumentSaved - true if the user choose to save the document before close.
      */
-    var deleteGraphicTempFiles = function (documentID) {
+    var deleteGraphicTempFiles = function (documentID, isDocumentSaved) {
         var libraryStore = this.flux.stores.library,
             editStatus = libraryStore.getEditStatus().get(documentID);
             
-        if (!editStatus) {
+        if (!editStatus || editStatus.isUpdatingContent) {
             return Promise.resolve();
+        }
+
+        if (isDocumentSaved) {
+            return this.transfer(updateGraphicContent, documentID);
         }
         
         var tempFiles = [editStatus.documentPath, editStatus.previewPath];
@@ -716,7 +721,8 @@ define(function (require, exports) {
     };
     deleteGraphicTempFiles.reads = [];
     deleteGraphicTempFiles.writes = [locks.JS_LIBRARIES, locks.CC_LIBRARIES];
-    deleteGraphicTempFiles.transfers = [exportActions.deleteFiles, preferencesActions.setPreference];
+    deleteGraphicTempFiles.transfers = [exportActions.deleteFiles, preferencesActions.setPreference,
+        updateGraphicContent];
 
     /**
      * Removes asset from the library it belongs to.

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -178,7 +178,6 @@ define(function (require, exports, module) {
             OPEN_GRAPHIC_FOR_EDIT: "libraryOpenGraphicForEdit",
             UPDATING_GRAPHIC_CONTENT: "libraryUpdatingGraphicContent",
             UPDATED_GRAPHIC_CONTENT: "libraryUpdatedGraphicContent",
-            CLOSED_GRAPHIC_DOCUMENT: "libraryClosedGraphicDocument",
             DELETED_GRAPHIC_TEMP_FILES: "libraryDeletedGraphicTempFiles",
             LIBRARY_CREATED: "libraryCreated",
             LIBRARY_REMOVED: "libraryRemoved",

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
                 events.libraries.OPEN_GRAPHIC_FOR_EDIT, this._handleOpenGraphicForEdit,
                 events.libraries.UPDATING_GRAPHIC_CONTENT, this._handleUpdatingGraphicContent,
                 events.libraries.UPDATED_GRAPHIC_CONTENT, this._handleUpdatedGraphicContent,
-                events.libraries.CLOSED_GRAPHIC_DOCUMENT, this._handleClosedGraphicDocument,
+                events.document.CLOSE_DOCUMENT, this._handleClosedGraphicDocument,
                 events.libraries.DELETED_GRAPHIC_TEMP_FILES, this._handleDeletedGraphicTempFiles
             );
 


### PR DESCRIPTION
If user click the save button in the close-document model dialog, we are not going to receive a save event for the document, and this cause lost changes when editing a graphic asset. This PR check if the document is saved when closed, and trigger the update-graphic-asset event to properly save the changes.

 #2495 