### PR TITLE
Disable MRU add for library opened files

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -586,12 +586,16 @@ define(function (require, exports) {
                 // preview whenever the file is saved
                 
                 var previewSetting = {
-                    path: tempPreviewPath,
-                    width: RENDITION_GRAPHIC_SIZE,
-                    height: RENDITION_GRAPHIC_SIZE
-                };
+                        path: tempPreviewPath,
+                        width: RENDITION_GRAPHIC_SIZE,
+                        height: RENDITION_GRAPHIC_SIZE
+                    },
+                    openSettings = {
+                        externalPreview: previewSetting,
+                        forceMRU: false
+                    };
                 
-                return this.transfer(documentActions.open, tempFilePath, { externalPreview: previewSetting });
+                return this.transfer(documentActions.open, tempFilePath, openSettings);
             })
             .then(function () {
                 var documentID = this.flux.stores.application.getCurrentDocumentID(),


### PR DESCRIPTION
Will require https://github.com/adobe-photoshop/spaces-adapter/pull/149, and CL 1043494 to work.

Addresses #2414 

All other open operations will still add file to MRU list