### PR TITLE
Speed up layers.selectedNormalized

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -426,7 +426,7 @@ define(function (require, exports, module) {
          */
         "selectedNormalized": function () {
             // For each layer, remove all it's descendants from the group
-            var selected = this.selected;
+            var selected = this.selected.toSet();
             return selected.filterNot(function (layer) {
                 return this.strictAncestors(layer)
                     .some(function (ancestor) {


### PR DESCRIPTION
In #2434 I observed that selection of layer ranges with many ancestors was very slow. A quick profiler run showed that almost all of the time was being spent in the `Flip` component's `componentWillReceiveProps` method, and in particular that method's call to `LayerStructure.prototype.selectedNormalized`. That method has an `O(m^2*n)` algorithm, for `n` layers and `m` selected layers, where an `O(m*log(m)*n)` algorithm suffices. Making this small change improves performance significantly.

However, I found it mysterious that this should be the case, since in #2434 `m` is should be very small. It turns out that there is a _different_ bug wherein PS is interpreting range selection to include all descendants, even hidden ones, in the range. This seems wrong to me, but it does explain why the change makes a pretty significant improvement. Seperately, however, I'm looking into why PS is doing this. In the meantime, this simple change stanches the bleeding somewhat. 