### PR TITLE
Relaxed the condition for isNewSelected in layerstructure's addLayers

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -888,7 +888,7 @@ define(function (require, exports, module) {
                 nextIndex = layerStructure.index,
                 descriptor = descriptors[i],
                 layerIndex = descriptor.itemIndex - 1,
-                isNewSelected = selected && i + 1 === layerIDs.length,
+                isNewSelected = selected,
                 newLayer = Layer.fromDescriptor(document, descriptor, isNewSelected, true);
 
             if (i === 0 && replace) {


### PR DESCRIPTION
This addresses #2504.  @shaoshing passed this to me because he was assuming I remembered the purpose of the second conjunct at line 891.  Alas, I do not.  Removing it fixes the issue (as he suggested) and seems to work correctly for other code paths:

1. dragging a file on to the PS icon
1. new shape layers
1. new text layers

I'd love for someone besides @shaoshing to look at this to double check both of our work.