### PR TITLE
Suspend policies during modal tool states

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -636,7 +636,7 @@ define(function (require, exports) {
      * @return {Promise.<?string>} Promise of a File Path of the chosen folder
      */
     var promptForFolder = function () {
-        return this.transfer(policyActions.suspendPolicies)
+        return this.transfer(policyActions.suspendAllPolicies)
             .bind(this)
             .then(
                 function () {
@@ -647,12 +647,12 @@ define(function (require, exports) {
                 }
             )
             .finally(function () {
-                return this.transfer(policyActions.restorePolicies);
+                return this.transfer(policyActions.restoreAllPolicies);
             });
     };
     promptForFolder.reads = [];
     promptForFolder.writes = locks.ALL_LOCKS;
-    promptForFolder.transfers = [policyActions.suspendPolicies, policyActions.restorePolicies];
+    promptForFolder.transfers = [policyActions.suspendAllPolicies, policyActions.restoreAllPolicies];
 
     /**
      * Export all layer assets for the given document for which export has been enabled (layer.exportEnabled)

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -636,7 +636,7 @@ define(function (require, exports) {
      * @return {Promise.<?string>} Promise of a File Path of the chosen folder
      */
     var promptForFolder = function () {
-        return this.transfer(policyActions.disablePolicies)
+        return this.transfer(policyActions.suspendPolicies)
             .bind(this)
             .then(
                 function () {
@@ -647,12 +647,12 @@ define(function (require, exports) {
                 }
             )
             .finally(function () {
-                return this.transfer(policyActions.reenablePolicies);
+                return this.transfer(policyActions.restorePolicies);
             });
     };
     promptForFolder.reads = [];
     promptForFolder.writes = locks.ALL_LOCKS;
-    promptForFolder.transfers = [policyActions.disablePolicies, policyActions.reenablePolicies];
+    promptForFolder.transfers = [policyActions.suspendPolicies, policyActions.restorePolicies];
 
     /**
      * Export all layer assets for the given document for which export has been enabled (layer.exportEnabled)

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -194,10 +194,11 @@ define(function (require, exports) {
     removePointerPolicies.modal = true;
 
     /**
-     * Set the propagation mode for the given policy kind.
+     * Set the propagation mode for the given policy kind. If no mode is supplied,
+     * a default mode will be used.
      *
      * @param {number} kind
-     * @param {number} mode
+     * @param {number=} mode
      * @return {Promise}
      */
     var setMode = function (kind, mode) {
@@ -205,9 +206,15 @@ define(function (require, exports) {
         switch (kind) {
         case PolicyStore.eventKind.KEYBOARD:
             setModeFn = adapterUI.setKeyboardPropagationMode;
+            if (mode === undefined) {
+                mode = adapterUI.keyboardPropagationMode.FOCUS_PROPAGATE;
+            }
             break;
         case PolicyStore.eventKind.POINTER:
             setModeFn = adapterUI.setPointerPropagationMode;
+            if (mode === undefined) {
+                mode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE;
+            }
             break;
         default:
             return Promise.reject(new Error("Unknown kind:" + kind));
@@ -240,8 +247,7 @@ define(function (require, exports) {
         
         policyStore.suspend(kind);
 
-        var mode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
-            setModePromise = this.transfer(setMode, kind, mode),
+        var setModePromise = this.transfer(setMode, kind),
             syncPoliciesPromise = this.transfer(syncPolicies, kind);
 
         return Promise.join(setModePromise, syncPoliciesPromise);

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -27,76 +27,56 @@ define(function (require, exports) {
     var Promise = require("bluebird");
 
     var adapterUI = require("adapter/ps/ui"),
-        adapterOS = require("adapter/os"),
-        events = require("js/events"),
+        adapterOS = require("adapter/os");
+
+    var events = require("js/events"),
         locks = require("js/locks"),
         PolicyStore = require("js/stores/policy"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
 
     /**
-     * The previous policies and default modes during temporary policies disabling
-     * {
-     *     keyboardPolicies: EventPolicySet,
-     *     pointerPolicies: EventPolicySet,
-     *     keyboardMode: number,
-     *     pointerMode: number
-     * }
-     * @type {?object}
-     */
-    var _cachedPolicyState = null;
-
-    /**
      * For a given policy kind, fetch the master policy list and set it in photoshop
-     * If a policyListID is provided, then attempt to remove it on error
      *
      * @param {string} kind
-     * @param {number=} policyListID
-     *
      * @return {Promise} Resolves when polices are set in photoshop
      */
-    var _syncPolicies = function (kind, policyListID) {
+    var syncPolicies = function (kind) {
         var policyStore = this.flux.store("policy"),
             masterPolicyList = policyStore.getMasterPolicyList(kind),
-            promise;
+            dispatchPromise = this.dispatchAsync(events.policies.POLICIES_INSTALLED),
+            policyPromise;
 
         if (kind === PolicyStore.eventKind.KEYBOARD) {
-            promise = adapterUI.setKeyboardEventPropagationPolicy(masterPolicyList);
+            policyPromise = adapterUI.setKeyboardEventPropagationPolicy(masterPolicyList);
         } else {
-            promise = adapterUI.setPointerEventPropagationPolicy(masterPolicyList);
+            policyPromise = adapterUI.setPointerEventPropagationPolicy(masterPolicyList);
         }
 
-        return promise.catch(function (err) {
-                if (policyListID) {
-                    try {
-                        policyStore.removePolicyList(kind, policyListID);
-                    } catch (err2) {
-                        // ignore
-                    }
-                }
-                    
-                throw err;
-            })
-            .bind(this)
-            .tap(function () {
-                this.dispatch(events.policies.POLICIES_INSTALLED);
-            });
+        return Promise.join(dispatchPromise, policyPromise);
     };
+    syncPolicies.reads = [locks.JS_POLICY];
+    syncPolicies.writes = [locks.PS_APP];
+    syncPolicies.transfers = [];
+    syncPolicies.modal = true;
 
     /**
      * Install a new policy list.
      *
-     * @private 
      * @param {string} kind A value defined in PolicyStore.eventKind
      * @param {Array.<KeyboardEventPolicy>} policies
-     * @return {Promise}
+     * @return {Promise.<number>} Resolves with the new policy list ID
      */
-    var _addPolicies = function (kind, policies) {
+    var addPolicies = function (kind, policies) {
         var policyStore = this.flux.store("policy"),
             policyListID = policyStore.addPolicyList(kind, policies);
 
-        return _syncPolicies.call(this, kind, policyListID).return(policyListID);
+        return this.transfer(syncPolicies, kind, policyListID).return(policyListID);
     };
+    addPolicies.reads = [];
+    addPolicies.writes = [locks.JS_POLICY];
+    addPolicies.transfers = [syncPolicies];
+    addPolicies.modal = true;
 
     /**
      * Remove an already-installed policy list.
@@ -108,12 +88,12 @@ define(function (require, exports) {
      *  not be updated until the next commit. Useful when swapping policies.
      * @return {Promise}
      */
-    var _removePolicies = function (kind, id, commit) {
+    var removePolicies = function (kind, id, commit) {
         var policyStore = this.flux.store("policy");
 
         if (policyStore.removePolicyList(kind, id)) {
             if (commit) {
-                return _syncPolicies.call(this, kind);
+                return this.transfer(syncPolicies, kind);
             } else {
                 return Promise.resolve();
             }
@@ -121,18 +101,23 @@ define(function (require, exports) {
             return Promise.reject(new Error("No policies found for id: " + id));
         }
     };
+    removePolicies.reads = [];
+    removePolicies.writes = [locks.JS_POLICY];
+    removePolicies.transfers = [syncPolicies];
+    removePolicies.modal = true;
 
     /**
      * Install a new keyboard policy list.
      *
      * @param {Array.<KeyboardEventPolicy>} policies
-     * @return {Promise}
+     * @return {Promise.<number>}
      */
     var addKeyboardPolicies = function (policies) {
-        return _addPolicies.call(this, PolicyStore.eventKind.KEYBOARD, policies);
+        return this.transfer(addPolicies, PolicyStore.eventKind.KEYBOARD, policies);
     };
     addKeyboardPolicies.reads = [];
-    addKeyboardPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    addKeyboardPolicies.writes = [];
+    addKeyboardPolicies.transfers = [addPolicies];
     addKeyboardPolicies.modal = true;
 
     /**
@@ -156,6 +141,7 @@ define(function (require, exports) {
     addKeydownPolicy.reads = [];
     addKeydownPolicy.writes = [locks.PS_APP, locks.JS_POLICY];
     addKeydownPolicy.transfers = [addKeyboardPolicies];
+    addKeydownPolicy.modal = true;
 
     /**
      * Remove an already-installed keyboard policy list.
@@ -168,23 +154,26 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var removeKeyboardPolicies = function (id, commit) {
-        return _removePolicies.call(this, PolicyStore.eventKind.KEYBOARD, id, commit);
+        return this.transfer(removePolicies, PolicyStore.eventKind.KEYBOARD, id, commit);
     };
     removeKeyboardPolicies.reads = [];
-    removeKeyboardPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    removeKeyboardPolicies.writes = [];
+    removeKeyboardPolicies.transfers = [removePolicies];
     removeKeyboardPolicies.modal = true;
 
     /**
      * Install a new pointer policy list.
      *
      * @param {Array.<PointerEventPolicy>} policies
-     * @return {Promise}
+     * @return {Promise.<number>}
      */
     var addPointerPolicies = function (policies) {
-        return _addPolicies.call(this, PolicyStore.eventKind.POINTER, policies);
+        return this.transfer(addPolicies, PolicyStore.eventKind.POINTER, policies);
     };
     addPointerPolicies.reads = [];
-    addPointerPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    addPointerPolicies.writes = [];
+    addPointerPolicies.transfers = [addPolicies];
+    addPointerPolicies.modal = true;
 
     /**
      * Remove an already-installed pointer policy list.
@@ -197,106 +186,127 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var removePointerPolicies = function (id, commit) {
-        return _removePolicies.call(this, PolicyStore.eventKind.POINTER, id, commit);
+        return this.transfer(removePolicies, PolicyStore.eventKind.POINTER, id, commit);
     };
     removePointerPolicies.reads = [];
-    removePointerPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    removePointerPolicies.writes = [];
+    removePointerPolicies.transfers = [removePolicies];
+    removePointerPolicies.modal = true;
 
     /**
-     * Temporarily suspend all policies, caching the previous state
+     * Set the propagation mode for the given policy kind.
      *
+     * @param {number} kind
+     * @param {number} mode
      * @return {Promise}
      */
-    var suspendPolicies = function () {
-        if (_cachedPolicyState) {
-            return Promise.reject(new Error("Can not disable keyboard policies if a cached state exists"));
+    var setMode = function (kind, mode) {
+        var setModeFn;
+        switch (kind) {
+        case PolicyStore.eventKind.KEYBOARD:
+            setModeFn = adapterUI.setKeyboardPropagationMode;
+            break;
+        case PolicyStore.eventKind.POINTER:
+            setModeFn = adapterUI.setPointerPropagationMode;
+            break;
+        default:
+            return Promise.reject(new Error("Unknown kind:" + kind));
         }
 
+        var setModePromise = setModeFn.call(adapterUI, { defaultMode: mode }),
+            dispatchPromise = this.dispatchAsync(events.policies.MODE_CHANGED, {
+                kind: kind,
+                mode: mode
+            });
+
+        return Promise.join(setModePromise, dispatchPromise);
+    };
+    setMode.reads = [];
+    setMode.writes = [locks.PS_APP, locks.JS_POLICY];
+    setMode.transfers = [];
+    setMode.modal = true;
+
+    /**
+     * Temporarily suspend policies of the given kind
+     *
+     * @param {number} kind
+     * @return {Promise}
+     */
+    var suspendPolicies = function (kind) {
         var policyStore = this.flux.store("policy");
+        if (policyStore.isSuspended(kind)) {
+            return Promise.reject(new Error("Policies are already suspended"));
+        }
         
-        _cachedPolicyState = {
-            keyboardPolicies: policyStore.getPolicies(PolicyStore.eventKind.KEYBOARD),
-            pointerPolicies: policyStore.getPolicies(PolicyStore.eventKind.POINTER)
-        };
+        policyStore.suspend(kind);
 
-        policyStore.clearPolicies(PolicyStore.eventKind.KEYBOARD);
-        policyStore.clearPolicies(PolicyStore.eventKind.POINTER);
+        var mode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
+            setModePromise = this.transfer(setMode, kind, mode),
+            syncPoliciesPromise = this.transfer(syncPolicies, kind);
 
-        var setKeyboardModePromise = adapterUI.getKeyboardPropagationMode()
-            .then(function (keyboardMode) {
-                _cachedPolicyState.keyboardMode = keyboardMode;
-
-                return adapterUI.setKeyboardPropagationMode(
-                    { defaultMode: adapterUI.keyboardPropagationMode.FOCUS_PROPAGATE });
-            });
-
-        var setPointerModePromise = adapterUI.getPointerPropagationMode()
-            .then(function (pointerMode) {
-                _cachedPolicyState.pointerMode = pointerMode;
-
-                return adapterUI.setPointerPropagationMode(
-                        { defaultMode: adapterUI.pointerPropagationMode.ALPHA_PROPAGATE });
-            });
-
-        var syncKeyboardPoliciesPromise = _syncPolicies.call(this, PolicyStore.eventKind.KEYBOARD),
-            syncPointerPoliciesPromise = _syncPolicies.call(this, PolicyStore.eventKind.POINTER);
-
-        return Promise.join(
-                setKeyboardModePromise,
-                setPointerModePromise,
-                syncKeyboardPoliciesPromise,
-                syncPointerPoliciesPromise
-            )
-            .catch(function (err) {
-                _cachedPolicyState = null;
-                throw err;
-            });
+        return Promise.join(setModePromise, syncPoliciesPromise);
     };
     suspendPolicies.reads = [];
-    suspendPolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    suspendPolicies.writes = [locks.JS_POLICY];
+    suspendPolicies.transfers = [setMode, syncPolicies];
     suspendPolicies.modal = true;
 
     /**
      * Restore suspended keyboard policies
      *
+     * @param {number} kind     
      * @return {Promise}
      */
-    var restorePolicies = function () {
-        if (!_cachedPolicyState) {
-            return Promise.reject(new Error("Can not re-renable keyboard policies, no previously cached state"));
+    var restorePolicies = function (kind) {
+        var policyStore = this.flux.store("policy");
+        if (!policyStore.isSuspended(kind)) {
+            return Promise.reject(new Error("Policies not suspended"));
         }
 
-        var policyStore = this.flux.store("policy"),
-            currentKeyboardPolicies = policyStore.getPolicies(PolicyStore.eventKind.KEYBOARD),
-            currentPointerPolicies = policyStore.getPolicies(PolicyStore.eventKind.POINTER),
-            nextKeyboardPolicies = _cachedPolicyState.keyboardPolicies.append(currentKeyboardPolicies),
-            nextPointerPolicies = _cachedPolicyState.pointerPolicies.append(currentPointerPolicies);
+        policyStore.restore(kind);
 
-        policyStore.setPolicies(PolicyStore.eventKind.KEYBOARD, nextKeyboardPolicies);
-        policyStore.setPolicies(PolicyStore.eventKind.POINTER, nextPointerPolicies);
+        var mode = policyStore.getMode(kind),
+            setModePromise = this.transfer(setMode, kind, mode),
+            syncPoliciesPromise = this.transfer(syncPolicies, kind);
 
-        var resetKeyboardModePromise = adapterUI.setKeyboardPropagationMode({
-                defaultMode: _cachedPolicyState.keyboardMode
-            }),
-            resetPointerModePromise = adapterUI.setPointerPropagationMode({
-                defaultMode: _cachedPolicyState.pointerMode
-            }),
-            resetKeyboardPoliciesPromise = _syncPolicies.call(this, PolicyStore.eventKind.KEYBOARD),
-            resetPointerPoliciesPromise = _syncPolicies.call(this, PolicyStore.eventKind.POINTER);
-
-        return Promise.join(
-                resetKeyboardModePromise,
-                resetPointerModePromise,
-                resetKeyboardPoliciesPromise,
-                resetPointerPoliciesPromise
-            )
-            .finally(function () {
-                _cachedPolicyState = null;
-            });
+        return Promise.join(setModePromise, syncPoliciesPromise);
     };
     restorePolicies.reads = [];
-    restorePolicies.writes = [locks.PS_APP, locks.JS_POLICY];
+    restorePolicies.writes = [locks.JS_POLICY];
+    restorePolicies.transfers = [setMode, syncPolicies];
     restorePolicies.modal = true;
+
+    /**
+     * Suspend both keyboard and pointer policies.
+     *
+     * @return {Promise}
+     */
+    var suspendAllPolicies = function () {
+        var keyboardPromise = this.transfer(suspendPolicies, PolicyStore.eventKind.KEYBOARD),
+            pointerPromise = this.transfer(suspendPolicies, PolicyStore.eventKind.POINTER);
+
+        return Promise.join(keyboardPromise, pointerPromise);
+    };
+    suspendAllPolicies.reads = [];
+    suspendAllPolicies.writes = [];
+    suspendAllPolicies.transfers = [suspendPolicies];
+    suspendAllPolicies.modal = true;
+
+    /**
+     * Restore both keyboard and pointer policies.
+     *
+     * @return {Promise}
+     */
+    var restoreAllPolicies = function () {
+        var keyboardPromise = this.transfer(restorePolicies, PolicyStore.eventKind.KEYBOARD),
+            pointerPromise = this.transfer(restorePolicies, PolicyStore.eventKind.POINTER);
+
+        return Promise.join(keyboardPromise, pointerPromise);
+    };
+    restoreAllPolicies.reads = [];
+    restoreAllPolicies.writes = [];
+    restoreAllPolicies.transfers = [restorePolicies];
+    restoreAllPolicies.modal = true;
 
     /**
      * Set the default keyboard propagation policy.
@@ -304,37 +314,43 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartup = function () {
-        var policyMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
-            policyDescriptor = {
-                defaultMode: policyMode
-            };
+        var keyboardMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
+            keyboardDescriptor = {
+                defaultMode: keyboardMode
+            },
+            keyboardModePromise = adapterUI.setKeyboardPropagationMode(keyboardDescriptor)
+                .bind(this)
+                .then(function () {
+                    this.dispatch(events.policies.MODE_CHANGED, {
+                        kind: PolicyStore.eventKind.KEYBOARD,
+                        mode: keyboardMode
+                    });
+                }),
+            pointerMode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE,
+            // Alpha is the default pointer mode, so we don't need to change it here
+            pointerModePromise = this.dispatchAsync(events.policies.MODE_CHANGED, {
+                kind: PolicyStore.eventKind.POINTER,
+                mode: pointerMode
+            });
 
-        return adapterUI.setKeyboardPropagationMode(policyDescriptor);
+        return Promise.join(keyboardModePromise, pointerModePromise);
     };
     beforeStartup.reads = [];
     beforeStartup.writes = [locks.PS_APP, locks.JS_POLICY];
 
-    /**
-     * Reset
-     *
-     * @return {Promise}
-     */
-    var onReset = function () {
-        _cachedPolicyState = null;
-
-        return Promise.resolve();
-    };
-    onReset.reads = [];
-    onReset.writes = [];
-
+    exports.syncPolicies = syncPolicies;
+    exports.setMode = setMode;
+    exports.addPolicies = addPolicies;
+    exports.removePolicies = removePolicies;
     exports.addKeydownPolicy = addKeydownPolicy;
     exports.addKeyboardPolicies = addKeyboardPolicies;
     exports.removeKeyboardPolicies = removeKeyboardPolicies;
     exports.addPointerPolicies = addPointerPolicies;
     exports.removePointerPolicies = removePointerPolicies;
     exports.suspendPolicies = suspendPolicies;
+    exports.suspendAllPolicies = suspendAllPolicies;
     exports.restorePolicies = restorePolicies;
+    exports.restoreAllPolicies = restoreAllPolicies;
 
     exports.beforeStartup = beforeStartup;
-    exports.onReset = onReset;
 });

--- a/src/js/actions/preferences.js
+++ b/src/js/actions/preferences.js
@@ -42,6 +42,7 @@ define(function (require, exports) {
     };
     setPreference.reads = [];
     setPreference.writes = [locks.JS_PREF];
+    setPreference.modal = true;
 
     /**
      * Bulk set preferences.
@@ -56,6 +57,7 @@ define(function (require, exports) {
     };
     setPreferences.reads = [];
     setPreferences.writes = [locks.JS_PREF];
+    setPreferences.modal = true;
 
     /**
      * Delete a single preference.
@@ -70,6 +72,7 @@ define(function (require, exports) {
     };
     deletePreference.reads = [];
     deletePreference.writes = [locks.JS_PREF];
+    deletePreference.modal = true;
 
     /**
      * Clear all preferences.
@@ -81,6 +84,7 @@ define(function (require, exports) {
     };
     clearPreferences.reads = [];
     clearPreferences.writes = [locks.JS_PREF];
+    clearPreferences.modal = true;
 
     exports.setPreference = setPreference;
     exports.setPreferences = setPreferences;

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -428,9 +428,9 @@ define(function (require, exports) {
         // Suspend policies during type tool modal states
         if (event.kind._value === "tool" && event.tool.ID === "txBx") {
             if (modalState) {
-                policyPromise = this.transfer(policy.suspendPolicies);
+                policyPromise = this.transfer(policy.suspendAllPolicies);
             } else {
-                policyPromise = this.transfer(policy.restorePolicies);
+                policyPromise = this.transfer(policy.restoreAllPolicies);
             }
         } else {
             policyPromise = Promise.resolve();
@@ -446,7 +446,7 @@ define(function (require, exports) {
     };
     handleToolModalStateChanged.reads = [];
     handleToolModalStateChanged.writes = [];
-    handleToolModalStateChanged.transfers = [policy.suspendPolicies, policy.restorePolicies,
+    handleToolModalStateChanged.transfers = [policy.suspendAllPolicies, policy.restoreAllPolicies,
         changeModalState, "ui.cloak"];
     handleToolModalStateChanged.modal = true;
 

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -521,11 +521,18 @@ define(function (require, exports) {
             properties: properties
         };
 
-        return this.dispatchAsync(events.document.TYPE_PROPERTIES_CHANGED, payload);
+        // The selection change may not yet have completed before the first
+        // updateTextProperties event arrives. Hence, we ensure that the text
+        // layer is initialized before proceeding.
+        return this.transfer(layerActions.initializeLayers, document, layers)
+            .bind(this)
+            .then(function () {
+                this.dispatch(events.document.TYPE_PROPERTIES_CHANGED, payload);
+            });
     };
     updateProperties.reads = [];
     updateProperties.writes = [locks.JS_DOC];
-    updateProperties.transfers = [];
+    updateProperties.transfers = [layerActions.initializeLayers];
     updateProperties.modal = true;
 
     /**

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -171,7 +171,7 @@ define(function (require, exports) {
     };
     updateTransform.reads = [locks.PS_APP, locks.JS_APP];
     updateTransform.writes = [locks.JS_UI];
-    updateTransform.transfers = [tools.resetBorderPolicies];
+    updateTransform.transfers = ["tools.resetBorderPolicies"];
 
     /**
      * Using the center offsets, creates a cloaking rectangle on the canvas outside panels
@@ -228,7 +228,7 @@ define(function (require, exports) {
     };
     setTransform.reads = [locks.PS_APP];
     setTransform.writes = [locks.JS_UI];
-    setTransform.transfers = [tools.resetBorderPolicies];
+    setTransform.transfers = ["tools.resetBorderPolicies"];
     setTransform.modal = true;
 
     /**

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -190,7 +190,8 @@ define(function (require, exports, module) {
             REGISTER_SEARCH_PROVIDER: "registerSearchProvider"
         },
         policies: {
-            POLICIES_INSTALLED: "policiesInstalled"
+            POLICIES_INSTALLED: "policiesInstalled",
+            MODE_CHANGED: "modeChanged"
         }
     };
 });

--- a/src/js/models/eventpolicyset.js
+++ b/src/js/models/eventpolicyset.js
@@ -106,6 +106,16 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Whether the event policy set has the given policy list ID.
+     *
+     * @param {number} id
+     * @return {boolean}
+     */
+    EventPolicySet.prototype.has = function (id) {
+        return !!this._policyLists[id];
+    };
+
+    /**
      * Peek to get the next policy ID.
      *
      * @return {number}

--- a/src/js/models/eventpolicyset.js
+++ b/src/js/models/eventpolicyset.js
@@ -24,17 +24,19 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var math = require("js/util/math"),
-        _ = require("lodash");
+    var _ = require("lodash");
+
+    var math = require("js/util/math");
 
     /**
      * Manages a set of event policy lists.
      * 
      * @constructor
+     * @param {number=} counter
      */
-    var EventPolicySet = function () {
+    var EventPolicySet = function (counter) {
         this._policyLists = {};
-        this._policyListCounter = 0;
+        this._policyListCounter = counter || 0;
     };
 
     /**
@@ -101,6 +103,32 @@ define(function (require, exports, module) {
                 return result;
             }.bind(this), [])
             .value();
+    };
+
+    /**
+     * Peek to get the next policy ID.
+     *
+     * @return {number}
+     */
+    EventPolicySet.prototype.getNextPolicyID = function () {
+        return this._policyListCounter;
+    };
+
+    /**
+     * Create a new EventPolicySet that is derived from this and a derived EventPolicySet.
+     *
+     * @param {EventPolicySet} policySet
+     * @return {EventPolicySet}
+     */
+    EventPolicySet.prototype.append = function (policySet) {
+        if (policySet._policyListCounter < this._policyListCounter) {
+            throw new Error("Only newer event policy sets may be appended to older event event policy sets.");
+        }
+
+        var clone = new EventPolicySet(policySet._policyListCounter);
+        clone._policyLists = _.merge({}, this._policyLists, policySet._policyLists);
+
+        return clone;
     };
 
     module.exports = EventPolicySet;

--- a/src/js/stores/policy.js
+++ b/src/js/stores/policy.js
@@ -89,12 +89,14 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Reset the policy set of the given kind
+         * Reset the policy set of the given kind. The next policy set's counter
+         * will start where the previous one left off.
          *
          * @param {string} kind
          */
         clearPolicies: function (kind) {
-            this._policySets[kind] = new EventPolicySet();
+            var counter = this._policySets[kind].getNextPolicyID();
+            this._policySets[kind] = new EventPolicySet(counter);
         },
 
         /**


### PR DESCRIPTION
1. Convert `disablePolicies` and `reenablePolicies` to `suspendPolicies` and `restorePolicies`, allowing policy actions to be added during the suspended state. This currently does not allow you to remove a policy during the suspended state that was added before the suspended state. This also doesn't allow you to suspect policies twice without restoring them in the middle. The former feature could be added if necessary.
2. Suspend policies while in the type modal tool state.
3. Fix a bug in which clicking a never-before-selected layer with the type tool would fail as a result of the `updateTextProperties` event being handled before the selection change, and hence before initialization.