### PR TITLE
Properly merge dismissal policy during dialog open of previously registered dialog

### DIFF
--- a/src/js/stores/dialog.js
+++ b/src/js/stores/dialog.js
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
                 }
             } else {
                 // merge the new policy, if it was provided
-                newState = this._registeredDialogs.get(id).merge(newState);
+                newState = this._registeredDialogs.get(id).mergeDeep(newState);
             }
 
             if (newState.getIn(["policy", "documentChange"])) {


### PR DESCRIPTION
This addresses #2400.

Because the dialog state is a nested map, it must be merged deeply.  Otherwise, an undefined dismissalPolicy blows away the previous policy instead of the desired behavior of leaving it untouched.

Note that dragging files onto the PS icon (to open as a new document) seems to also suffer from some weird issues, especially if layers are selected?  Anyway, when it works, then this change addresses 2400.