### PR TITLE
Handle unsupported document by disabling more features

### DIFF
--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -278,7 +278,8 @@ define(function (require, exports, module) {
             var document = this.state.document,
                 disabled = this.state.appIsModal || document && document.unsupported,
                 toolOverlay = this._renderToolOverlay(),
-                policyOverlay = this.state.policyFrames ? (<PolicyOverlay/>) : null;
+                policyOverlay = this.state.policyFrames ? (<PolicyOverlay/>) : null,
+                guidesOverlay = !disabled ? (<GuidesOverlay/>) : null;
             
             var classNames = classnames({
                 "scrim": true,
@@ -300,7 +301,7 @@ define(function (require, exports, module) {
                         <g id="overlay" width="100%" height="100%">
                             {policyOverlay}
                             {toolOverlay}
-                            <GuidesOverlay />
+                            {guidesOverlay}
                         </g>
                     </svg>
                 </div>

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -180,8 +180,9 @@ define(function (require, exports, module) {
                 "appearance__mixed": !uniformLayerKind && hasSomeTextLayers && hasSomeVectorLayers
             });
 
-            var copyStyleDisabled = !(this.props.document && this.props.document.layers.selected.size === 1),
-                pasteStyleDisabled = !(this.state.clipboard &&
+            var copyStyleDisabled = this.props.disabled || !(this.props.document &&
+                    this.props.document.layers.selected.size === 1),
+                pasteStyleDisabled = this.props.disabled || !(this.state.clipboard &&
                     this.props.document &&
                     this.props.document.layers.selected.size > 0),
                 copyStyleClasses = classnames({

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -200,10 +200,15 @@ define(function (require, exports, module) {
                 "section__sibling-collapsed": !this.props.visibleSibling
             });
 
-            var copyStyleDisabled = !(this.props.document && this.props.document.layers.selected.size === 1),
-                pasteStyleDisabled = !(this.state.clipboard &&
+            var addStyleDisabled = this.props.disabled,
+                copyStyleDisabled = this.props.disabled || !(this.props.document &&
+                    this.props.document.layers.selected.size === 1),
+                pasteStyleDisabled = this.props.disabled || !(this.state.clipboard &&
                     this.props.document &&
                     this.props.document.layers.selected.size > 0),
+                addStyleClasses = classnames("button-plus style-button", {
+                    "button-plus__disabled": addStyleDisabled
+                }),
                 copyStyleClasses = classnames({
                     "style-button": true,
                     "style-button__disabled": copyStyleDisabled
@@ -235,8 +240,9 @@ define(function (require, exports, module) {
                         onDoubleClick={this.props.onVisibilityToggle}>
                         <div className="style-workflow-buttons">
                             <Button
-                                className="button-plus style-button"
+                                className={addStyleClasses}
                                 title={strings.TOOLTIPS.ADD_EFFECT}
+                                disabled={addStyleDisabled}
                                 onClick={this._toggleEffectPopover}>
                                 <SVGIcon
                                     CSSID="add-new" />

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -74,7 +74,7 @@
         },
         "EXPORT_UTILITY": {
             "$action": "export.openExportPanel",
-            "$enable-rule": "export-enabled"
+            "$enable-rule": "supported-document,export-enabled"
         },
         "REVERT": {
             "$action": "history.revertCurrentDocument",
@@ -175,7 +175,7 @@
         },
         "SEARCH": {
             "$action": "search.toggleSearchBar",
-            "$enable-rule": "always-except-modal"
+            "$enable-rule": "supported-document,always-except-modal"
         }
     },
     "LAYER": {

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -133,6 +133,12 @@
             height: 1.6rem;
             fill: @item-active;
         }
+        
+        &__disabled, &__disabled:hover {
+            svg {
+                fill: @item-disabled;
+            }
+        }
     }
     &.button-iOS,
     &.button-xdpi {


### PR DESCRIPTION
This PR disabled the following features for unsupported document:

* guide creation
* copy/paste appearance/style buttons
* add effect button
* menu item: export
* menu item: search

Some files for testing unsupported document:

1 CMYK mode https://www.dropbox.com/s/z0u5nldb9fcu8aq/cmyk.psd?dl=0
2 3d https://www.dropbox.com/s/uzm4n8y6k2av5zb/3d.psd?dl=0

Related to issue #2545