### PR TITLE
Update panel sizes on display configuration change

### DIFF
--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        d3 = require("d3");
+        d3 = require("d3"),
+        _ = require("lodash");
 
     var OS = require("adapter/os");
 
@@ -77,7 +78,7 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            return !Immutable.is(this.state.uiState, nextState.uiState) ||
+            return !_.isEqual(this.state.uiState, nextState.uiState) ||
                 !Immutable.is(this.state.document, nextState.document) ||
                 this.state.tool !== nextState.tool ||
                 this.state.modalState !== nextState.modalState;


### PR DESCRIPTION
We currently call `ui.updatePanelSizes` when we receive a `displayConfigurationChanged` event from the adapter, but this may arrive before the browser has redrawn the UI with the new UI sizes. This changes the panels to call debounced helper function to update the panel sizes only after 500ms have passed without a new `displayConfigurationChanged` event.

With this change, it's possible to have drag the Design Space application window from one display to another and have the on-canvas UI (e.g., guides overlays) continue to work correctly.