### PR TITLE
Turn off dismissOnDialogOpen for search dialog as it has a sub dialog

### DIFF
--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -86,6 +86,7 @@ define(function (require, exports, module) {
                         dismissOnCanvasClick={true}
                         dismissOnWindowClick={true}
                         dismissOnWindowResize={false}
+                        dismissOnDialogOpen={false}
                         dismissOnKeys={[{ key: os.eventKeyCode.ESCAPE, modifiers: null }]}
                         className={"search-bar__dialog"} >
                         <SearchBar


### PR DESCRIPTION
Addresses #2580, while keeping @mcilroyc's change. Problem was, `dismissOnDialogOpen` is true by default, and search dialog has a sub dialog, which mcilroy's recent fix caused this buggy behavior to show.

@iwehrman please review since it's urgent.