### PR TITLE
Disable stepping on 0 step for number input, and limit zoom UI

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -326,6 +326,7 @@ define(function (require, exports) {
             x: zoom * bounds.xCenter / factor + (offset.right - offset.left) / 2,
             y: zoom * bounds.yCenter / factor + (offset.bottom - offset.top) / 2,
             z: zoom,
+            resize: true,
             animate: false
         };
     };
@@ -427,12 +428,7 @@ define(function (require, exports) {
             uiState = uiStore.getState(),
             document = this.flux.store("application").getCurrentDocument(),
             zoom = payload.zoom,
-            bounds = document.layers.selectedAreaBounds,
-            panZoomDescriptor = {
-                animate: false,
-                resize: true,
-                z: zoom
-            };
+            bounds = document.layers.selectedAreaBounds;
 
         this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
 
@@ -452,11 +448,8 @@ define(function (require, exports) {
 
         var factor = window.devicePixelRatio,
             offsets = uiState.centerOffsets,
-            panDescriptor = _calculatePanZoom(bounds, offsets, zoom, factor);
+            panZoomDescriptor = _calculatePanZoom(bounds, offsets, zoom, factor);
 
-        panZoomDescriptor.x = panDescriptor.x;
-        panZoomDescriptor.y = panDescriptor.y;
-    
         return descriptor.play("setPanZoom", panZoomDescriptor)
             .bind(this)
             .then(function () {

--- a/src/js/jsx/Zoom.jsx
+++ b/src/js/jsx/Zoom.jsx
@@ -85,11 +85,14 @@ define(function (require, exports, module) {
                 <div className="zoom">
                     <NumberInput
                         tabIndex="-1"
+                        min={5}
+                        max={3200}
                         ref="input"
                         suffix="%"
                         value={this.state.zoom}
                         onChange={this._handleZoomChange}
                         onKeyDown={this._handleKeyDown}
+                        step={0}
                     />
                 </div>
             );

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -311,6 +311,11 @@ define(function (require, exports, module) {
                 break;
             case "ArrowUp":
             case "ArrowDown":
+                if (this.props.step === 0) {
+                    event.preventDefault();
+                    break;
+                }
+                
                 nextValue = this._extractValue(event.target.value);
                 if (nextValue === null) {
                     this._reset(event);


### PR DESCRIPTION
Addresses #2592 

On NumberInput, if step is provided as 0, we disable stepping. Default is 1, so this shouldn't affect other NumberInputs.

Also, set the min/max of Zoom UI to 5,3200 so it is within the acceptable realm of zoom values, and disabled stepping for it.