### PR TITLE
Update transform after updating panel sizes

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -241,6 +241,9 @@ define(function (require, exports) {
         return this.dispatchAsync(events.ui.PANELS_RESIZED, sizes)
             .bind(this)
             .then(function () {
+                return this.transfer(updateTransform);
+            })
+            .then(function () {
                 var centerOffsets = this.flux.store("ui").getState().centerOffsets;
                 return adapterUI.setOverlayOffsets(centerOffsets);
             })
@@ -250,7 +253,7 @@ define(function (require, exports) {
     };
     updatePanelSizes.reads = [];
     updatePanelSizes.writes = [locks.JS_UI, locks.PS_APP];
-    updatePanelSizes.transfers = [setOverlayCloaking];
+    updatePanelSizes.transfers = [setOverlayCloaking, updateTransform];
     updatePanelSizes.modal = true;
 
     /**


### PR DESCRIPTION
Addresses #2600.

Just emitting change in _handlePanelResized was not enough, as the zoom change wasn't being accounted for by the panel resizing. @iwehrman please review.