### PR TITLE
Preserve overlay offsets on reset

### DIFF
--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -159,6 +159,13 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.RESET_BOUNDS, this._handleLayersUpdated
             );
 
+            // HACK: Do not reset panel sizes because they should remain constant.
+            this._panelWidth = 0;
+            this._columnCount = 0;
+            this._iconBarWidth = 0;
+            this._headerHeight = 0;
+            this._toolbarWidth = 0;
+
             this._handleReset();
         },
 
@@ -175,12 +182,6 @@ define(function (require, exports, module) {
             this._zoom = null;
             this._transformMatrix = null;
             this._inverseTransformMatrix = null;
-
-            this._panelWidth = 0;
-            this._columnCount = 0;
-            this._iconBarWidth = 0;
-            this._headerHeight = 0;
-            this._toolbarWidth = 0;
         },
         
         /** @ignore */


### PR DESCRIPTION
Do not reset panel boundaries after a controller reset because:

1. The panel boundaries shouldn't have changed anyway; and
2. We don't yet have any good way to tell the individual panel components that they should reset their sizes when the controller resets.

Ideally we would have some kind of event that the components could easily listen to which would cause them to reset their sizes. And probably there should be a more general mixin for panels that contribute to the panel boundaries. But, for now, this super hack is sufficient to address #2593: