### PR TITLE
Don't update mouse over highlights while in marquee state

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -172,8 +172,9 @@ define(function (require, exports, module) {
                 this._currentMouseY = event.location[1];
                 if (this.state.marqueeEnabled) {
                     this.updateMarqueeRect();
+                } else {
+                    this.updateMouseOverHighlights();
                 }
-                this.updateMouseOverHighlights();
             }
         },
 


### PR DESCRIPTION
It was causing highlights to blink as it removed all highlights if marquee was on. Addresses #2594 