### PR TITLE
Fix search after reset

### DIFF
--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -24,7 +24,11 @@
 define(function (require, exports) {
     "use strict";
 
-    var dialog = require("./dialog");
+    var Promise = require("bluebird");
+
+    var dialog = require("./dialog"),
+        search = require("../stores/search"),
+        locks = require("../locks");
 
     /**
      * The search bar dialog ID
@@ -32,7 +36,7 @@ define(function (require, exports) {
      * @const
      * @type {string} 
      */
-    var ID = "search-bar-dialog";
+    var ID = search.SEARCH_BAR_DIALOG_ID;
 
     /**
      * Open the Search dialog
@@ -48,9 +52,22 @@ define(function (require, exports) {
         }
         return this.transfer(dialog.openDialog, ID);
     };
-    toggleSearchBar.reads = [];
+    toggleSearchBar.reads = [locks.JS_DIALOG];
     toggleSearchBar.writes = [];
     toggleSearchBar.transfers = [dialog.openDialog, dialog.closeDialog];
 
+    var beforeStartup = function () {
+        var searchStore = this.flux.store("search");
+
+        searchStore.registerSearch(ID,
+            ["LIBRARY", "ALL_LAYER", "CURRENT_DOC", "RECENT_DOC", "MENU_COMMAND"]);
+
+        return Promise.resolve();
+    };
+    beforeStartup.reads = [];
+    beforeStartup.writes = [locks.JS_SEARCH];
+    beforeStartup.transfers = [];
+
     exports.toggleSearchBar = toggleSearchBar;
+    exports.beforeStartup = beforeStartup;
 });

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -30,24 +30,11 @@ define(function (require, exports, module) {
 
     var os = require("adapter/os"),
         Dialog = require("jsx!./shared/Dialog"),
-        SearchBar = require("jsx!./search/SearchBar");
-
-    /**
-     * Unique identifier for the Search Dialog
-     *
-     * @const
-     * @type {string}
-     */
-    var SEARCH_BAR_DIALOG_ID = "search-bar-dialog";
+        SearchBar = require("jsx!./search/SearchBar"),
+        search = require("js/stores/search");
 
     var Search = React.createClass({
         mixins: [FluxMixin],
-
-        componentWillMount: function () {
-            var searchStore = this.getFlux().store("search");
-            searchStore.registerSearch(SEARCH_BAR_DIALOG_ID,
-                ["LIBRARY", "ALL_LAYER", "CURRENT_DOC", "RECENT_DOC", "MENU_COMMAND"]);
-        },
 
         /**
          * Dismiss the Search Bar Dialog.
@@ -57,7 +44,7 @@ define(function (require, exports, module) {
          * @return {Promise}
          */
         _closeSearchBar: function () {
-            return this.getFlux().actions.dialog.closeDialog(SEARCH_BAR_DIALOG_ID);
+            return this.getFlux().actions.dialog.closeDialog(search.SEARCH_BAR_DIALOG_ID);
         },
 
         /**
@@ -80,7 +67,7 @@ define(function (require, exports, module) {
             return (
                 <div>
                     <Dialog
-                        id={SEARCH_BAR_DIALOG_ID}
+                        id={search.SEARCH_BAR_DIALOG_ID}
                         modal
                         position={Dialog.POSITION_METHODS.CENTER}
                         dismissOnCanvasClick={true}
@@ -91,7 +78,7 @@ define(function (require, exports, module) {
                         className={"search-bar__dialog"} >
                         <SearchBar
                             ref="searchBar"
-                            searchID={SEARCH_BAR_DIALOG_ID}
+                            searchID={search.SEARCH_BAR_DIALOG_ID}
                             dismissDialog={this._closeSearchBar}
                             executeOption={this._handleOption}
                             />

--- a/src/js/locks.js
+++ b/src/js/locks.js
@@ -52,6 +52,7 @@ define(function (require, exports, module) {
         JS_STYLE: "jsStyle",
         JS_LIBRARIES: "jsLibraries",
         JS_EXPORT: "jsExport",
+        JS_SEARCH: "jsSearch",
         CC_LIBRARIES: "ccLibraries",
         OS_CLIPBOARD: "osClipboard",
         GENERATOR: "generator"

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -154,6 +154,9 @@ define(function (require, exports, module) {
             "supported-document":
                 (document !== null) &&
                 !document.unsupported,
+            "not-unsupported-document":
+                !document ||
+                !document.unsupported,
             "have-guides":
                 (document !== null) &&
                 !document.guides.isEmpty(),

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -60,6 +60,14 @@ define(function (require, exports, module) {
     var CATEGORIES = strings.SEARCH.CATEGORIES,
         HEADERS = strings.SEARCH.HEADERS;
 
+    /**
+     * Unique identifier for the Search Dialog
+     *
+     * @const
+     * @type {string}
+     */
+    var SEARCH_BAR_DIALOG_ID = "search-bar-dialog";
+
     /*
      * Properties used to make complete search options objects for SearchBar.jsx
      *
@@ -386,6 +394,8 @@ define(function (require, exports, module) {
             return allFilters;
         }
     });
-        
+
+    SearchStore.SEARCH_BAR_DIALOG_ID = SEARCH_BAR_DIALOG_ID;
+
     module.exports = SearchStore;
 });

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -175,7 +175,7 @@
         },
         "SEARCH": {
             "$action": "search.toggleSearchBar",
-            "$enable-rule": "supported-document,always-except-modal"
+            "$enable-rule": "not-unsupported-document,always-except-modal"
         }
     },
     "LAYER": {


### PR DESCRIPTION
1. Register search providers in `search.beforeStartup` instead of in `Search`'s `componentWillMount` method so that search providers are re-registered after a controller reset.
2. Ensure that the search command is enabled either if there is no open document or if there is a supported document open.

Addresses #2505 and #1888.

@shaoshing: 2) above tweaks your recent unsupported document change in 1e52903c3095d859496750784ecaa926fc8b42d6.