### PR TITLE
Render icon bar and empty column on startup

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -358,7 +358,13 @@ define(function (require, exports, module) {
                 );
             } else {
                 return (
-                    <div ref="panelSet"></div>
+                    <div className="panel-set__container">
+                        <div ref="panelSet"
+                             className="panel-set">
+                            <PanelColumn visible={true} />
+                        </div>
+                        <IconBar />
+                    </div>
                 );
             }
         }


### PR DESCRIPTION
This changes the initial render of `PanelSet` to draw the icon bar and a single empty column instead of nothing to improve the experience of the initial UI load. It's not perfect, but I think it's better.

Addresses: concerns.