### PR TITLE
Hook up missing link icons for linked and cloud smart objects

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -315,7 +315,20 @@ define(function (require, exports, module) {
                         selected={!layer.visible}
                         onClick={this._handleVisibilityToggle}>
                     </ToggleButton>
-                );
+                ),
+                iconClassModifier;
+
+            if (layer.isSmartObject()) {
+                if (layer.smartObject.linkMissing) {
+                    tooltipTitle += " : " + strings.LAYER_KIND_ALERTS.LINK_MISSING;
+                    iconClassModifier = "face__kind__error";
+                }
+
+                if (layer.smartObject.linkChanged) {
+                    tooltipTitle += " : " + strings.LAYER_KIND_ALERTS.LINK_CHANGED;
+                    iconClassModifier = "face__kind__warning";
+                }
+            }
 
             return (
                 <li className={classnames(layerClasses)}>
@@ -329,7 +342,7 @@ define(function (require, exports, module) {
                         <Button
                             title={tooltipTitle + tooltipPadding}
                             disabled={this.props.disabled}
-                            className="face__kind"
+                            className={classnames("face__kind", iconClassModifier)}
                             data-kind={layer.isArtboard ? "artboard" : layer.kind}
                             onClick={this._handleIconClick}
                             onDoubleClick={this._handleLayerEdit}>

--- a/src/js/models/smartobject.js
+++ b/src/js/models/smartobject.js
@@ -69,6 +69,16 @@ define(function (require, exports, module) {
         linked: null,
 
         /**
+         * @type {boolean}
+         */
+        linkMissing: false,
+
+        /**
+         * @type {boolean}
+         */
+        linkChanged: false,
+
+        /**
          * @type {Link}
          */
         link: null

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -41,7 +41,15 @@ define(function (require, exports) {
         } else if (layer.kind === layer.layerKinds.BACKGROUND) {
             iconID += layer.layerKinds.PIXEL;
         } else if (layer.kind === layer.layerKinds.SMARTOBJECT && layer.isLinked) {
-            iconID += layer.kind + "-linked";
+            if (layer.isCloudLinkedSmartObject()) {
+                iconID += "cloud-linked";
+            } else {
+                iconID += layer.kind + "-linked";
+            }
+
+            if (layer.smartObject.linkMissing) {
+                iconID += "-alert";
+            }
         } else {
             iconID += layer.kind;
         }

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -282,6 +282,10 @@
         "13": "Groupend Layer",
         "ARTBOARD": "Artboard"
     },
+    "LAYER_KIND_ALERTS": {
+        "LINK_MISSING": "Missing Linked Object",
+        "LINK_CHANGED": "Linked Object Updated"
+    },
     "COLOR_PICKER": {
         "FORMAT": "Format",
         "RGB_MODEL": {

--- a/src/style/shared/colors.less
+++ b/src/style/shared/colors.less
@@ -54,6 +54,7 @@
 
 @label-hidden-opacity: 0.28;
 @label-error-color: #8a3533;
+@label-warning-color: #7f6d2c;
 
 @focus-highlight: #1b8be9;
 @text-highlight: rgb(27, 139, 233);

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -319,3 +319,21 @@
         stroke: none;
     }
 }
+
+.face {
+    .face__kind {
+        &.face__kind__error,
+        &.face__kind__error:hover {
+            svg {
+                fill: @label-error-color;
+            }
+        }
+
+        &.face__kind__warning,
+        &.face__kind__warning:hover {
+            svg {
+                fill: @label-warning-color;
+            }
+        }        
+    }    
+}


### PR DESCRIPTION
Requires pgdv.679 or later.

layer.smartObject now contains `linkMissing` and `linkChanged` properties. We use `linkMissing` to change our own layer panel icons.

We currently do not get any notification from PS when this status changes, so it's up to us to later on hook up queries and model updates on our side.

Addresses #1990 and #2083