### PR TITLE
Add relativeChildBounds, and use it for position inputs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,11 +106,13 @@ module.exports = function (grunt) {
         },
         lintspaces: {
             src: [
-                "*.js",
-                "*.json",
+                "*",
                 "src/**/*.json",
                 "src/**/*.jsx",
-                "src/**/*.js"
+                "src/**/*.js",
+                "src/**/*.svg",
+                "src/**/*.less",
+                "!src/**/*.gif"
             ],
             options: {
                 newline: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,12 +106,10 @@ module.exports = function (grunt) {
         },
         lintspaces: {
             src: [
-                "*",
-                "src/**/*",
-                "test/**/*",
-                "!**/*.ogg",
-                "!**/*.otf",
-                "!**/*.png"
+                "*.js",
+                "*.json",
+                "src/**/*.jsx",
+                "src/**/*.js"
             ],
             options: {
                 newline: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,6 +108,7 @@ module.exports = function (grunt) {
             src: [
                 "*.js",
                 "*.json",
+                "src/**/*.json",
                 "src/**/*.jsx",
                 "src/**/*.js"
             ],

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1412,12 +1412,20 @@ define(function (require, exports) {
      * Reset the layer z-index. Assumes that all layers are already in the model,
      * though possibly out of order w.r.t. Photoshop's model.
      *
-     * @param {Document} document Document for which layers should be reordered
+     * @param {Document=} document Document for which layers should be reordered, if undefined, use current document
      * @param {boolean=} suppressHistory if truthy, dispatch a non-history-changing event.
      * @param {boolean=} amendHistory if truthy, update the current state (requires suppressHistory)
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
      **/
     var resetIndex = function (document, suppressHistory, amendHistory) {
+        if (typeof document === "undefined") {
+            document = this.flux.store("application").getCurrentDocument();
+
+            if (!document) {
+                return Promise.resolve();
+            }
+        }
+        
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
                 return _getSelectedLayerIndices(document).then(function (selectedIndices) {

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -25,8 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var Promise = require("bluebird"),
-        Immutable = require("immutable"),
-        _ = require("lodash");
+        Immutable = require("immutable");
 
     var descriptor = require("adapter/ps/descriptor"),
         adapterOS = require("adapter/os"),
@@ -597,17 +596,6 @@ define(function (require, exports) {
     diveIn.transfers = [layerActions.select, editLayer];
 
     /**
-     * Stores the move listener that was installed by the last drag command
-     * so we can remove it if it hasn't been hit
-     * Certain drag operations (like space+drag to move canvas) still hit
-     * dragCommand method, so we gotta make sure there is only one move listener installed
-     * for this function at any point
-     *
-     * @type {function(event)}
-     */
-    var _moveToArtboardListener = null;
-
-    /**
      * Selects and starts dragging the layer around
      *
      * @param {Document} doc
@@ -622,8 +610,7 @@ define(function (require, exports) {
             coordinates = [x, y],
             dragModifiers = keyUtil.modifiersToBits(modifiers),
             diveIn = system.isMac ? modifiers.command : modifiers.control,
-            dontDeselect = modifiers.shift,
-            copyDrag = modifiers.option;
+            dontDeselect = modifiers.shift;
 
         if (panning) {
             var dragEvent = {
@@ -650,18 +637,6 @@ define(function (require, exports) {
                     .bind(this)
                     .then(function (anySelected) {
                         if (anySelected) {
-                            if (_moveToArtboardListener) {
-                                descriptor.removeListener("moveToArtboard", _moveToArtboardListener);
-                            }
-
-                            if (!copyDrag) {
-                                _moveToArtboardListener = _.once(function () {
-                                    this.flux.actions.layers.resetIndex(doc, true, true);
-                                }.bind(this));
-
-                                descriptor.addListener("moveToArtboard", _moveToArtboardListener);
-                            }
-
                             var dragEvent = {
                                 eventKind: eventKind,
                                 location: coordinates,

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -334,6 +334,10 @@ define(function (require, exports) {
                     name: strings.ACTIONS.SET_LAYER_POSITION,
                     target: documentLib.referenceBy.id(document.id)
                 },
+                // Setting this to false allows PS to send us
+                // notifications that happen as a result of this
+                // action, in conjunction with `suppresPlayLevelIncrease`
+                // flag in the descriptor
                 synchronous: false
             };
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -337,7 +337,8 @@ define(function (require, exports) {
                 historyStateInfo: {
                     name: strings.ACTIONS.SET_LAYER_POSITION,
                     target: documentLib.referenceBy.id(document.id)
-                }
+                },
+                synchronous: false
             };
 
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.REPOSITION_LAYERS, payload)
@@ -991,6 +992,7 @@ define(function (require, exports) {
      * @type {function()}
      */
     var _artboardTransformHandler,
+        _moveToArtboardHandler,
         _layerTransformHandler;
 
     var beforeStartup = function () {
@@ -1048,10 +1050,18 @@ define(function (require, exports) {
             }
         }, this);
 
+        _moveToArtboardHandler = function () {
+            var appStore = this.flux.store("application"),
+                nextDoc = appStore.getCurrentDocument();
+
+            this.flux.actions.layers.resetIndex(nextDoc, true, true);
+        }.bind(this);
+
         descriptor.addListener("transform", _layerTransformHandler);
         descriptor.addListener("move", _layerTransformHandler);
         descriptor.addListener("nudge", _layerTransformHandler);
         descriptor.addListener("editArtboardEvent", _artboardTransformHandler);
+        descriptor.addListener("moveToArtboard", _moveToArtboardHandler);
         return Promise.resolve();
     };
     beforeStartup.reads = [];
@@ -1065,6 +1075,7 @@ define(function (require, exports) {
         descriptor.removeListener("move", _layerTransformHandler);
         descriptor.removeListener("nudge", _layerTransformHandler);
         descriptor.removeListener("editArtboardEvent", _artboardTransformHandler);
+        descriptor.removeListener("moveToArtboard", _moveToArtboardHandler);
 
         return Promise.resolve();
     };

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -60,54 +60,47 @@ define(function (require, exports) {
 
     /**
      * Helper function that will break down a given layer to all it's children
-     * and return layerActionsUtil compatible layer actions to move all the kids
-     * so the overall selection ends at given position
+     * and calculate the move action for the layer and new bounds of all the children.
      *
      * @param {Document} document
      * @param {Layer} targetLayer
-     * @param {{x: number, y: number}} position
+     * @param {{relative: boolean=, x: number, y: number}} position
+     * @param {boolean=} position.relative If true, will calculate new position relative to
+     *                                     parent artboard of the layer
      * @param {Array.<{layer: Layer, x: number, y: number}>} moveResults payload for updating each layer's bounds
-     * @param {boolean} relative If true, will use teh artboard relative bounds of the layer
      *
      * @return {Immutable.List<{layer: Layer, playObject: PlayObject}>}
      */
-    var _getMoveLayerActions = function (document, targetLayer, position, moveResults, relative) {
-        var overallBounds = relative ?
+    var _getMoveLayerActions = function (document, targetLayer, position, moveResults) {
+        var overallBounds = position.relative ?
                 document.layers.relativeChildBounds(targetLayer) :
                 document.layers.childBounds(targetLayer),
             deltaX = position.hasOwnProperty("x") ? position.x - overallBounds.left : 0,
             deltaY = position.hasOwnProperty("y") ? position.y - overallBounds.top : 0,
             documentRef = documentLib.referenceBy.id(document.id),
-            movingLayers = document.layers.descendants(targetLayer);
+            movingLayers = document.layers.descendants(targetLayer),
+            layerRef = [documentRef, layerLib.referenceBy.id(targetLayer.id)];
 
         moveResults = moveResults || [];
 
-        return movingLayers.reduce(function (playObjects, layer) {
+        // We only send the move command for the main layer, but we
+        // calculate the new bounds for all child layers
+        movingLayers.forEach(function (layer) {
             if (!layer.bounds || layer.bounds.empty) {
-                return playObjects;
+                return;
             }
-            var layerRef = [documentRef, layerLib.referenceBy.id(layer.id)],
-                translateObj;
-
+            
             moveResults.push({
                 layer: layer,
                 x: layer.bounds.left + deltaX,
                 y: layer.bounds.top + deltaY
             });
+        });
 
-            // If the targetlayer is an artboard, we want the move action played only for it
-            // But we still want to reposition the child layers in our models so we stop here
-            if (targetLayer.isArtboard && layer !== targetLayer) {
-                return playObjects;
-            }
-                
-            translateObj = layerLib.translate(layerRef, deltaX, deltaY);
-
-            return playObjects.push({
-                layer: layer,
-                playObject: translateObj
-            });
-        }, Immutable.List(), this);
+        return Immutable.List.of({
+            layer: targetLayer,
+            playObject: layerLib.translate(layerRef, deltaX, deltaY)
+        });
     };
          
     /**
@@ -176,8 +169,8 @@ define(function (require, exports) {
         }
         
         return Immutable.List.of(
-            { x: l1Left, y: l1Top },
-            { x: l2Left, y: l2Top }
+            { x: l1Left, y: l1Top, relative: false },
+            { x: l2Left, y: l2Top, relative: false }
         );
     };
 
@@ -320,11 +313,14 @@ define(function (require, exports) {
      * @private
      * @param {Document} document Owner document
      * @param {Layer|Immutable.Iterable.<Layer>} layerSpec Either a Layer reference or array of Layers
-     * @param {{x: number, y: number}} position New top and left values for each layer
+     * @param {object} position Object describing the position to move layers to
+     * @param {number} position.x Target horizontal location of top left corner of layer
+     * @param {number} position.y Target vertical location of top left corner of the layer
+     * @param {boolean} position.relative If true, x and y will be relative to the owner artboard of layer
      *
      * @return {Promise}
      */
-    var setPosition = function (document, layerSpec, position, relative) {
+    var setPosition = function (document, layerSpec, position) {
         layerSpec = layerSpec.filterNot(function (layer) {
             return layer.kind === layer.layerKinds.GROUPEND;
         });
@@ -347,17 +343,21 @@ define(function (require, exports) {
             }),
             translateLayerActions = layerSpec.reduce(function (actions, layer) {
                 var layerActions = _getMoveLayerActions.call(this,
-                        document, layer, position, payload.positions, relative);
+                        document, layer, position, payload.positions);
                 return actions.concat(layerActions);
             }, Immutable.List(), this);
 
-        var positionPromise = layerActionsUtil.playLayerActions(document, translateLayerActions, true, options);
+        var positionPromise = layerActionsUtil.playLayerActions(document, translateLayerActions, true, options)
+            .bind(this)
+            .then(function () {
+                return this.transfer(layerActions.resetIndex, undefined, true, true);
+            });
 
         return Promise.join(dispatchPromise, positionPromise);
     };
     setPosition.reads = [];
     setPosition.writes = [locks.PS_DOC, locks.JS_DOC];
-    setPosition.transfers = [toolActions.resetBorderPolicies];
+    setPosition.transfers = [toolActions.resetBorderPolicies, layerActions.resetIndex];
 
     /**
      * Swaps the two given layers top-left positions
@@ -386,9 +386,9 @@ define(function (require, exports) {
                 positions: []
             },
             layerOneActions = _getMoveLayerActions
-                .call(this, document, layers.get(0), newPositions.get(0), payload.positions, false),
+                .call(this, document, layers.get(0), newPositions.get(0), payload.positions),
             layerTwoActions = _getMoveLayerActions
-                .call(this, document, layers.get(1), newPositions.get(1), payload.positions, false),
+                .call(this, document, layers.get(1), newPositions.get(1), payload.positions),
             translateActions = layerOneActions.concat(layerTwoActions);
                 
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.REPOSITION_LAYERS, payload)
@@ -434,13 +434,16 @@ define(function (require, exports) {
 
                     return descriptor.playObject(setObj);
                 }
+            })
+            .then(function () {
+                return this.transfer(layerActions.resetIndex, document, true, true);
             });
 
         return Promise.join(dispatchPromise, swapPromise);
     };
     swapLayers.reads = [];
     swapLayers.writes = [locks.PS_DOC, locks.JS_DOC];
-    swapLayers.transfers = [toolActions.resetBorderPolicies];
+    swapLayers.transfers = [toolActions.resetBorderPolicies, layerActions.resetIndex];
 
     /**
      * Sets the given layers' sizes
@@ -1050,12 +1053,10 @@ define(function (require, exports) {
             }
         }, this);
 
-        _moveToArtboardHandler = function () {
-            var appStore = this.flux.store("application"),
-                nextDoc = appStore.getCurrentDocument();
-
-            this.flux.actions.layers.resetIndex(nextDoc, true, true);
-        }.bind(this);
+        _moveToArtboardHandler = synchronization.debounce(function () {
+            // Undefined makes it use the most recent document model
+            return this.flux.actions.layers.resetIndex(undefined, true, true);
+        }, this);
 
         descriptor.addListener("transform", _layerTransformHandler);
         descriptor.addListener("move", _layerTransformHandler);

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -64,10 +64,13 @@ define(function (require, exports, module) {
          * @param {number} newX
          */
         _handleLeftChange: function (event, newX) {
-            var document = this.props.document;
+            var document = this.props.document,
+                positionObj = {
+                    x: newX,
+                    relative: true
+                };
             
-            this.getFlux().actions.transform
-                .setPositionThrottled(document, document.layers.selected, { x: newX }, true);
+            this.getFlux().actions.transform.setPositionThrottled(document, document.layers.selected, positionObj);
         },
 
         /**
@@ -78,10 +81,14 @@ define(function (require, exports, module) {
          * @param {number} newY
          */
         _handleTopChange: function (event, newY) {
-            var document = this.props.document;
+            var document = this.props.document,
+                positionObj = {
+                    y: newY,
+                    relative: true
+                };
             
             this.getFlux().actions.transform
-                .setPositionThrottled(document, document.layers.selected, { y: newY }, true);
+                .setPositionThrottled(document, document.layers.selected, positionObj);
         },
 
         /**

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
             var document = this.props.document;
             
             this.getFlux().actions.transform
-                .setPositionThrottled(document, document.layers.selected, { x: newX });
+                .setPositionThrottled(document, document.layers.selected, { x: newX }, true);
         },
 
         /**
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
             var document = this.props.document;
             
             this.getFlux().actions.transform
-                .setPositionThrottled(document, document.layers.selected, { y: newY });
+                .setPositionThrottled(document, document.layers.selected, { y: newY }, true);
         },
 
         /**
@@ -118,7 +118,7 @@ define(function (require, exports, module) {
         render: function () {
             var document = this.props.document,
                 layers = document.layers.selected,
-                bounds = document.layers.selectedChildBounds;
+                bounds = document.layers.selectedRelativeChildBounds;
 
             var disabled = this._disabled(document, layers),
                 tops = collection.pluck(bounds, "top"),

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps) {
             var getSelectedChildBounds = function (props) {
-                return props.document.layers.selectedChildBounds;
+                return props.document.layers.selectedRelativeChildBounds;
             };
 
             var getRelevantProps = function (props) {

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -382,5 +382,25 @@ define(function (require, exports, module) {
             this.top < otherBounds.bottom && this.bottom > otherBounds.top;
     };
 
+    /**
+     * Clones this bounds object returning it relative to the position 
+     * of the given bounds' top left value
+     *
+     * @param {Bounds} otherBounds Comparison bounds
+     * @return {Bounds} Updated bounds where location is in relation to otherBounds
+     */
+    Bounds.prototype.relativeTo = function (otherBounds) {
+        var x = otherBounds.left,
+            y = otherBounds.top,
+            model = {
+                left: this.left - x,
+                top: this.top - y,
+                right: this.right - x,
+                bottom: this.bottom - y
+            };
+
+        return this.merge(model);
+    };
+
     module.exports = Bounds;
 });


### PR DESCRIPTION
Will address #2613, and show layer position in relation to it's owner artboard.

 - Added `Bounds.prototype.relativeTo` method which returns a new bounds object with updated position in relation to the given bounds object.
 - Added `relativeChildBounds` cached property that calculates the bounds of a layer relative to it's owner artboard.
 - Added `selectedRelativeChildBounds` cached property that grabs all the selected layer's relativeChildBounds.
 - Add `relative` flag to `actions.transform.setPosition` to use relative child bounds during transform calculations, subsequently added it to `_getMoveLayerActions` as well.

