### PR TITLE
Various improvements for the libraries panel

### DIFF
--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -54,7 +54,8 @@ define(function (require, exports, module) {
                 isDropTarget: isDropTarget,
                 isValidDropTarget: dndState.hasValidDropTarget,
                 selectedLibrary: libraryStore.getCurrentLibrary(),
-                lastLocallyCreatedElement: libraryStore.getLastLocallyCreatedElement()
+                lastLocallyCreatedElement: libraryStore.getLastLocallyCreatedElement(),
+                lastLocallyUpdatedGraphic: libraryStore.getLastLocallyUpdatedGraphic()
             };
         },
 
@@ -118,6 +119,7 @@ define(function (require, exports, module) {
                 <Library
                     addElement={this._handleAddElement}
                     lastLocallyCreatedElement={this.state.lastLocallyCreatedElement}
+                    lastLocallyUpdatedGraphic={this.state.lastLocallyUpdatedGraphic}
                     library={currentLibrary} />
                 );
             } else {

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -76,6 +76,15 @@ define(function (require, exports, module) {
          * @type {AdobeLibraryElement}
          */
         lastLocallyCreatedElement: null,
+        
+        /**
+         * Store the last locally updated graphic element and modified time. Used to determine whether the 
+         * library list should scroll to reveal the updated graphic.
+         * 
+         * @type {AdobeLibraryElement}
+         */
+        lastLocallyUpdatedGraphic: null,
+        lastLocallyUpdatedGraphicModified: null,
 
         getInitialState: function () {
             return {
@@ -90,15 +99,29 @@ define(function (require, exports, module) {
         },
         
         componentDidUpdate: function () {
-            if (this.lastLocallyCreatedElement !== this.props.lastLocallyCreatedElement) {
-                this.lastLocallyCreatedElement = this.props.lastLocallyCreatedElement;
-                
+            var scrollTo = function (element) {
                 // Scroll to reveal the newly created element.
-                var typeName = _ELEMENT_TYPE_TO_NAME_MAP[this.lastLocallyCreatedElement.type],
+                var typeName = _ELEMENT_TYPE_TO_NAME_MAP[element.type],
                     sectionClass = "libraries__assets__" + typeName,
                     graphicsListEle = window.document.getElementsByClassName(sectionClass)[0];
                     
                 graphicsListEle.scrollIntoView();
+            };
+            
+            if (this.lastLocallyCreatedElement !== this.props.lastLocallyCreatedElement) {
+                this.lastLocallyCreatedElement = this.props.lastLocallyCreatedElement;
+                scrollTo(this.lastLocallyCreatedElement);
+            }
+            
+            if (this.lastLocallyUpdatedGraphic &&
+                (this.lastLocallyUpdatedGraphic !== this.props.lastLocallyUpdatedGraphic ||
+                 this.lastLocallyUpdatedGraphicModified !== this.props.lastLocallyUpdatedGraphic.modified)) {
+                this.lastLocallyUpdatedGraphic = this.props.lastLocallyUpdatedGraphic;
+                this.lastLocallyUpdatedGraphicModified = this.props.lastLocallyUpdatedGraphic.modified;
+                
+                if (this.lastLocallyUpdatedGraphic.library === this.props.library) {
+                    scrollTo(this.lastLocallyUpdatedGraphic);
+                }
             }
         },
         

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -91,6 +91,12 @@ define(function (require, exports, module) {
          * @type {AdobeLibraryElement}
          */
         _lastLocallyCreatedElement: null,
+        
+        /**
+         * Store the last locally updated graphic element.
+         * @type {AdobeLibraryElement}
+         */
+        _lastLocallyUpdatedGraphic: null,
 
         initialize: function () {
             this.bindActions(
@@ -309,7 +315,7 @@ define(function (require, exports, module) {
          * @private
          * @param {object} payload
          * @param {number} payload.documentID 
-         * @param {string} payload.path - document path
+         * @param {AdobeLibraryElement} payload.element
          */
         _handleUpdatingGraphicContent: function (payload) {
             var documentID = payload.documentID,
@@ -320,6 +326,8 @@ define(function (require, exports, module) {
             }
             
             editStatus.isUpdatingContent = true;
+            this._lastLocallyUpdatedGraphic = payload.element;
+            this.emit("change");
         },
 
         /**
@@ -533,6 +541,15 @@ define(function (require, exports, module) {
          */
         getLastLocallyCreatedElement: function () {
             return this._lastLocallyCreatedElement;
+        },
+        
+        /**
+         * Return the last locally updated graphic element.
+         * 
+         * @return {?AdobeLibraryElement}
+         */
+        getLastLocallyUpdatedGraphic: function () {
+            return this._lastLocallyUpdatedGraphic;
         },
         
         /**

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -292,7 +292,6 @@
                 &:focus {
                     align-self: stretch;
                     color: @item-hover;
-                    background-color:@item-active;
                     user-select: none;
                     border-bottom: @hairline solid @focus-highlight;
                 }


### PR DESCRIPTION
1 can edit large document format (PSB, here is a sample asset for testing purpose http://adobe.ly/1LAQoVB)
2 handle error when double-click smart object while its associated element is deleted. (#2615)
3 automatically scroll to the last locally updated graphic asset in the libraries panel.
4 match asset rename input style with the layers panel. (#2621)