### PR TITLE
Change Libraries panel to hide on collapse with CSS

### DIFF
--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
          * @return {?ReactComponent}
          */
         _renderLibrariesContent: function () {
-            if (!this.props.visible || this.props.disabled) {
+            if (this.props.disabled) {
                 return null;
             }
 

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -81,7 +81,6 @@
     }
 
     &__container {
-        display: flex;
         justify-content: space-between;
         flex-direction: column;
     }

--- a/src/style/sections/style/style-section.less
+++ b/src/style/sections/style/style-section.less
@@ -24,13 +24,8 @@
 @style-button-size: 1.6rem;
 
 .effects,
-.appearance,
-.type, {
+.appearance {
     min-height: 3rem;
-    
-    .section-container__collapsed {
-        display: none;
-    }    
 }
 
 .effects {


### PR DESCRIPTION
Before, the panel content for Libraries was removed if the library was collapsed, now it is just hidden with CSS (same as the other panels).