### PR TITLE
Command Click on Column Toggles has different behavior

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -193,8 +193,19 @@ define(function (require, exports, module) {
 
         /** @ignore */
         _handleColumnVisibilityToggle: function (columnName) {
-            var nextState = {};
-            nextState[columnName] = !this.state[columnName];
+            var nextState = {},
+                uiStore = this.getFlux().store("ui"),
+                components = uiStore.components,
+                flux = this.getFlux(),
+                modifierStore = flux.store("modifier"),
+                modifierState = modifierStore.getState();
+                
+            if (modifierState.command) {
+                nextState[components.LAYERS_LIBRARY_COL] = !this.state[components.LAYERS_LIBRARY_COL];
+                nextState[components.PROPERTIES_COL] = !this.state[components.PROPERTIES_COL];
+            } else {
+                nextState[columnName] = !this.state[columnName];
+            }
 
             this.getFlux().actions.preferences.setPreferences(nextState);
             this.setState(nextState);

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -193,12 +193,12 @@ define(function (require, exports, module) {
 
         /** @ignore */
         _handleColumnVisibilityToggle: function (columnName) {
-            var nextState = {},
-                uiStore = this.getFlux().store("ui"),
-                components = uiStore.components,
-                flux = this.getFlux(),
+            var flux = this.getFlux(),
+                uiStore = flux.store("ui"),
                 modifierStore = flux.store("modifier"),
-                modifierState = modifierStore.getState();
+                components = uiStore.components,
+                modifierState = modifierStore.getState(),
+                nextState = {};
                 
             if (modifierState.command) {
                 nextState[components.LAYERS_LIBRARY_COL] = !this.state[components.LAYERS_LIBRARY_COL];


### PR DESCRIPTION
This is more an experiment than anything else, using a PR so we can have a conversation about it.

For the proposed single column mode, there are a lot of ways we could get there...this is one of them. Instead of moving all of the panels into a single column, which has some issues around space (why we moved to two column in the first place), this simply allows the user to quickly switch between Properties and Layers/Libraries. 

Behavior is:
2 columns open: Command Click on either column toggle button closes both panels
2 columns closed: Command Click on either column toggle button open both panels 
1 column open: Command Click on either column toggle button switches the open panel for the closed panel

For your consideration, @placegraphichere 
