### PR TITLE
Re install existing fill/stroke colors on re-enable

### DIFF
--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -30,8 +30,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         _ = require("lodash");
 
-    var Color = require("js/models/color"),
-        ColorInput = require("jsx!js/jsx/shared/ColorInput"),
+    var ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
         strings = require("i18n!nls/strings"),
         collection = require("js/util/collection");
@@ -168,12 +167,9 @@ define(function (require, exports, module) {
          * @param {boolean} isChecked
          */
         _toggleFillEnabled: function (event, isChecked) {
-            var color = this.props.fill && collection.uniformValue(this.props.fill.colors) || Color.DEFAULT;
-
             this.getFlux().actions.shapes.setFillEnabled(
                 this.props.document,
                 this.props.layers,
-                color,
                 { enabled: isChecked }
             );
         },

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -108,7 +108,6 @@ define(function (require, exports, module) {
             this.getFlux().actions.shapes.setStrokeEnabled(
                 this.props.document,
                 this.state.layers,
-                this.state.stroke && this.state.stroke.colors.first() || Color.DEFAULT,
                 { enabled: isChecked }
             );
         },


### PR DESCRIPTION
This will address #2570, but more importantly, fix toggling of strokes/fills so they behave correctly.

 - Change `setFillEnabled` and `setStrokeEnabled` to pass in a `null` value for color.
 - If color being passed to `setFillColor` and `setStrokeColor` is null, and color is being enabled, we will use the last known fill/stroke colors from the layer models for each layer itself, using default fill/stroke color as fallback. This allows us to disable/enable strokes/fills of multiple layers without overwriting/losing values.

@ktaki please test this on the branch, this is a big change and I want to make sure I'm not introducing new bugs.

@mcilroyc your expertise with layerActions and fill/stroke would be very appreciated in reviewing.