### PR TITLE
Mark the controller active after beforeStartup instead of after afterStartup

### DIFF
--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -691,11 +691,9 @@ define(function (require, exports, module) {
         beforeStartupPromise
             .bind(this)
             .then(function (results) {
+                this._running = true;
                 this.emit("ready");
                 return this._invokeActionMethods("afterStartup", results);
-            })
-            .then(function () {
-                this._running = true;
             });
 
         return beforeStartupPromise;


### PR DESCRIPTION
This effectively unblocks menu commands and shortcut commands from running before `afterStartup` is complete. It's possible there was some good reason for delaying this state change until after `afterStartup`, but I can't currently see what it might be.

The moral of the story is that, from now on, if the app requires some initialization to run without error, it should go in `beforeStartup`. If it's able to run without the initialization then it can go in `afterStartup`.

Addresses #2272.