### PR TITLE
During undo/redo, optimistically copy layer visibility from current state...

### DIFF
--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -165,7 +165,10 @@ define(function (require, exports) {
                             });
                         })
                         .then(function () {
-                            return this.transfer(toolActions.resetBorderPolicies);
+                            var borderPromise = this.transfer(toolActions.resetBorderPolicies),
+                                visibilityPromise = this.transfer(layerActions.resetLayerVisibility, document);
+
+                            return Promise.join(borderPromise, visibilityPromise);
                         });
                 });
         } else {
@@ -204,7 +207,8 @@ define(function (require, exports) {
     };
     incrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
     incrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];
-    incrementHistory.transfers = [toolActions.resetBorderPolicies, "documents.updateDocument"];
+    incrementHistory.transfers = [toolActions.resetBorderPolicies, "layers.resetLayerVisibility",
+        "documents.updateDocument"];
     incrementHistory.modal = true;
 
     /**
@@ -230,7 +234,8 @@ define(function (require, exports) {
     };
     decrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
     decrementHistory.writes = [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC];
-    decrementHistory.transfers = [toolActions.resetBorderPolicies, "documents.updateDocument"];
+    decrementHistory.transfers = [toolActions.resetBorderPolicies, "layers.resetLayerVisibility",
+        "documents.updateDocument"];
     decrementHistory.modal = true;
 
     /**

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -162,6 +162,20 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Overlay document with the visibility values from the provided document
+     * This is useful during undo/redo as an best-guess because visibility
+     * is usually not changed
+     *
+     * @param {Document} document
+     * @return {Document}
+     */
+    Document.prototype.overlayVisibility = function (document) {
+        var nextLayers = this.layers.overlayVisibility(document.layers);
+
+        return this.set("layers", nextLayers);
+    };
+
+    /**
      * Resize the bounds of this document model
      *
      * @param {number} x

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1113,6 +1113,17 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Merges properties into the layers based on a map of simple property maps, keyed by layer ID
+     *
+     * @param {Immutable.Map.<number, Immutable.Map>} layerMap
+     */
+    LayerStructure.prototype.setLayerPropsMap = function (layerMap) {
+        return this.mergeDeep({
+            layers: layerMap
+        });
+    };
+
+    /**
      * Update the bounds of the given layers.
      *
      * @private
@@ -1620,6 +1631,23 @@ define(function (require, exports, module) {
      */
     LayerStructure.prototype.setParagraphStyleProperties = function (layerIDs, properties) {
         return this._setTextStyleProperties("paragraphStyle", layerIDs, properties);
+    };
+
+    /**
+     * Given a set of layers representing the current state, overlay the visibility status
+     * of any matching layers
+     *
+     * @param {LayerStructure} layerTree
+     * @return {LayerStructure}
+     */
+    LayerStructure.prototype.overlayVisibility = function (layerTree) {
+        var nextLayers = layerTree.layers.map(function (layer, key) {
+            if (this.layers.has(key)) {
+                return this.layers.get(key).set("visible", layer.visible);
+            }
+        }, this);
+
+        return this.set("layers", this.layers.merge(nextLayers));
     };
 
     module.exports = LayerStructure;

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -406,7 +406,8 @@ define(function (require, exports, module) {
             if (!nextState.document) {
                 throw new Error("Could not find a valid document for the requested state");
             } else {
-                var nextDocument = nextState.document,
+                var currentDocument = this.flux.store("application").getCurrentDocument(),
+                    nextDocument = nextState.document,
                     nextDocumentExports = nextState.documentExports;
 
                 if (payload.selectedIndices) {
@@ -417,6 +418,13 @@ define(function (require, exports, module) {
                         
                     nextDocument = nextDocument.set("layers", nextLayers);
                 }
+
+                // Overlay layer visibility values from the current document.
+                // Even though we will also fetch layer visibilities separately from Photoshop,
+                // this will allow us to paint most of the UI with our best guess
+                // and only late-change the layers panel in the rare case that visibility was re-enabled
+                // by undoing to a history state that deals with an otherwise invisible layer
+                nextDocument = nextDocument.overlayVisibility(currentDocument);
 
                 // these will emit their own changes
                 this.flux.store("document").setDocument(nextDocument);


### PR DESCRIPTION
...and then also query from photoshop the visibility and update the layerstructure accordingly.

This should resolve the more serious of the two sub-bugs in #1942

@iwehrman could you please take a first pass at the performance implications of this?  The total time spent in the undo action seems to be unchanged on Vermilion.  I may be missing something.

Also please consider my design decision to allow a second re-draw of the layers panel in the rare-ish case that an otherwise hidden layer becomes visible during undo/redo because that layer was involved.  repro steps with two layers A and B (I use groups in Vermilion):

1. move layer A
1. move layer B
1. make layer A *invisible*
1. move layer B
1. undo twice: note that layer A is still invisible
1. undo again, and note that layer A become visible on canvas, and then shortly thereafter the panel reflects the visibility change