### PR TITLE
Set ColorFields expected color proptype to HSVAColor

### DIFF
--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -606,7 +606,7 @@ define(function (require, exports, module) {
      */
     var ColorFields = React.createClass({
         propTypes: {
-            color: React.PropTypes.instanceOf(Color),
+            color: React.PropTypes.instanceOf(HSVAColor),
             onChange: React.PropTypes.func
         },
 


### PR DESCRIPTION
ColorPicker keeps the state.color in HSVAColor type, so ColorFields should expect that.

Addresses #2568 