### PR TITLE
Fix the 'revert' history store handler

### DIFF
--- a/src/js/models/historystate.js
+++ b/src/js/models/historystate.js
@@ -71,17 +71,5 @@ define(function (require, exports, module) {
             (this.documentExports && this.documentExports !== documentExports);
     };
 
-    /**
-     * Make a copy of this state that is suitable for generating a new "revert" state
-     *
-     * @return {HistoryState}
-     */
-    HistoryState.prototype.cloneForRevert = function () {
-        return new HistoryState({
-            document: this.document,
-            documentExports: this.documentExports
-        });
-    };
-
     module.exports = HistoryState;
 });

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -441,7 +441,10 @@ define(function (require, exports, module) {
                 throw new Error("Could not revert using cached history state, document model not found");
             }
 
-            var newState = lastHistoryState.cloneFoRevert();
+            var newState = new HistoryState({
+                document: lastHistoryState.document,
+                documentExports: lastHistoryState.documentExports
+            });
 
             // push a new history on top of current
             this._pushHistoryState.call(this, newState, false, true);


### PR DESCRIPTION
This should address #2646.

Look you guys, I don't know why this is necessary.  I also do not know when it broke, other than that it was at least several sprints ago, before the major plugin version change.  

Prior to this commit, if I stick a breakpoint at stores/history.js line 444, I could execute that same code in the console.  If I tried to step in to it, it exploded.  I was stumped.  I moved the logic out of that low-value abstraction (as a method of the historystate model) and just did tha business directly in to the history store.  It worked.  Is that obvious to anyone why?