### PR TITLE
Fully optimistic layer selection

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -171,7 +171,14 @@ define(function (require, exports, module) {
                 }
             }
 
-            this.getFlux().actions.layers.select(this.props.document, this.props.layer, modifier);
+            // The clicked layer may an have out-of-date document models due to
+            // the aggressive SCU method in LayersPanel.
+            var documentID = this.props.document.id,
+                documentStore = this.getFlux().store("document"),
+                currentDocument = documentStore.getDocument(documentID),
+                currentLayer = currentDocument.layers.byID(this.props.layer.id);
+
+            this.getFlux().actions.layers.select(currentDocument, currentLayer, modifier);
         },
 
         /**

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -54,7 +54,14 @@ define(function (require, exports, module) {
          *
          * @type {Immutable.List.<number>}
          */
-        index: null
+        index: null,
+
+        /**
+         * ID of the pivot layer, if any, for range selections.
+         *
+         * @type {?number}
+         */
+        pivotID: null
     });
 
     /**
@@ -170,6 +177,15 @@ define(function (require, exports, module) {
         },
 
         /**
+         * The pivot layer, if any, for range selections.
+         *
+         * @type {?Layer}
+         */
+        "pivot": function () {
+            return this.byID(this.pivotID);
+        },
+
+        /**
          * Indicates whether there are features in the document
          *  that are currently unsupported.
          *
@@ -218,6 +234,15 @@ define(function (require, exports, module) {
         */
         "allVisibleReversed": function () {
             return this.allVisible.reverse();
+        },
+
+        /**
+         * The subset of layers which are not hidden by a collapsed ancestor.
+         *
+         * @type {Immutable.List.<Layer>}
+         */
+        "exposed": function () {
+            return this.allVisible.filterNot(this.hasCollapsedAncestor, this);
         },
 
         /**
@@ -1219,13 +1244,16 @@ define(function (require, exports, module) {
      * @param {Immutable.Set.<number>} selectedIDs
      * @return {LayerStructure}
      */
-    LayerStructure.prototype.updateSelection = function (selectedIDs) {
+    LayerStructure.prototype.updateSelection = function (selectedIDs, pivotID) {
         var updatedLayers = this.layers.map(function (layer) {
             var selected = selectedIDs.has(layer.id);
             return layer.set("selected", selected);
         });
 
-        return this.set("layers", updatedLayers);
+        return this.merge({
+            "layers": updatedLayers,
+            "pivotID": pivotID
+        });
     };
 
     /**

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -555,9 +555,10 @@ define(function (require, exports, module) {
          * @private
          * @param {Document} document
          * @param {Immutable.Set<number>} selectedIDs
+         * @param {?number} pivotID
          */
-        _updateLayerSelection: function (document, selectedIDs) {
-            var nextLayers = document.layers.updateSelection(selectedIDs),
+        _updateLayerSelection: function (document, selectedIDs, pivotID) {
+            var nextLayers = document.layers.updateSelection(selectedIDs, pivotID),
                 nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);
@@ -575,7 +576,7 @@ define(function (require, exports, module) {
                     return document.layers.byIndex(index + 1).id;
                 });
 
-            this._updateLayerSelection(document, selectedIDs);
+            this._updateLayerSelection(document, selectedIDs, null);
         },
 
         /**
@@ -586,9 +587,10 @@ define(function (require, exports, module) {
          */
         _handleLayerSelectByID: function (payload) {
             var document = this._openDocuments[payload.documentID],
-                selectedIDs = Immutable.Set(payload.selectedIDs);
+                selectedIDs = Immutable.Set(payload.selectedIDs),
+                pivotID = payload.hasOwnProperty("pivotID") ? payload.pivotID : null;
 
-            this._updateLayerSelection(document, selectedIDs);
+            this._updateLayerSelection(document, selectedIDs, pivotID);
         },
 
         /**


### PR DESCRIPTION
The changes `layers.select` to be fully optimistic: the complete selection post-state is calculated up front in JavaScript, and the layer model is updated in parallel with the Photoshop play command instead of in sequence. Previously we only did this when no modifier was used. Even if Photoshop worked correctly this would be somewhat faster, but as is there is also a terrible bug in which the `addUpTo` modifier does not take the visibility (w.r.t. expanded/collapsed ancestors) of layers into account, such that selecting a range of collapsed groups would also select all of their descendants.

Note that the specification of `addUpTo` requires the notion of a "pivot" element, which represents the starting point of a range selection. This is tracked in `LayerStructure.prototype.pivotID` the lazy `pivot` property that refers to the pivot layer model (or null, if there is no pivot layer).

Addresses #2434, #1470 and (I do declare!) #1609. 