### PR TITLE
Initialize the font list only it necessary

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -603,6 +603,14 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var initFontList = function () {
+        var fontStore = this.flux.store("font"),
+            fontState = fontStore.getState(),
+            initialized = fontState.initialized;
+
+        if (initialized) {
+            return Promise.resolve();
+        }
+
         return descriptor.getProperty("application", "fontList")
             .bind(this)
             .then(this.dispatch.bind(this, events.font.INIT_FONTS));


### PR DESCRIPTION
We're currently initializing the font list twice for no reason. The `Type` initiates before each render if it hasn't already been initialized, but `Type` apparently renders twice in succession before the first call is complete. The fix is to just have the `type.initFontList` action itself check to see if the font list has already been initialized and to bail out early if so. This saves a few hundred milliseconds on startup time.

Addresses: concerns.