### PR TITLE
Lazy document initialization

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -375,7 +375,7 @@ define(function (require, exports) {
                     historyPromise = current ?
                         this.transfer(historyActions.queryCurrentHistory, doc.documentID, true) :
                         Promise.resolve(null),
-                    guidesPromise = _getGuidesForDocument(doc);
+                    guidesPromise = current ? _getGuidesForDocument(doc) : Promise.resolve();
 
                 return Promise.join(layersPromise, historyPromise, guidesPromise,
                     function (payload, historyPayload, guidesPayload) {

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -124,17 +124,18 @@ define(function (require, exports, module) {
                 return true;
             }
 
-            return this.layers.unsupported;
+            return this.layers && this.layers.unsupported;
         }
     }));
 
     /**
      * Construct a new document model from a Photoshop document descriptor and
-     * a list of layer and guide descriptors.
+     * a list of layer and guide descriptors. The latter may be omitted if the
+     * document is being partially initialized, e.g., as an inactive document.
      * 
      * @param {object} documentDescriptor
-     * @param {Immutable.Iterator.<object>} layerDescriptors
-     * @param {Immutable.Iterator.<object>} guideDescriptors
+     * @param {Immutable.Iterator.<object>=} layerDescriptors
+     * @param {Immutable.Iterator.<object>=} guideDescriptors
      * @return {Document}
      */
     Document.fromDescriptors = function (documentDescriptor, layerDescriptors, guideDescriptors) {
@@ -149,7 +150,7 @@ define(function (require, exports, module) {
         model.guidesVisible = documentDescriptor.guidesVisibility;
         model.smartGuidesVisible = documentDescriptor.smartGuidesVisibility;
         model.bounds = Bounds.fromDocumentDescriptor(documentDescriptor);
-        model.layers = LayerStructure.fromDescriptors(documentDescriptor, layerDescriptors);
+        model.layers = layerDescriptors && LayerStructure.fromDescriptors(documentDescriptor, layerDescriptors);
         model.guides = guideDescriptors ? Guide.fromDescriptors(documentDescriptor, guideDescriptors) :
             Immutable.List();
 
@@ -180,7 +181,7 @@ define(function (require, exports, module) {
          * @type {Bounds}
          */
         "visibleBounds": function () {
-            if (this.layers.hasArtboard) {
+            if (this.layers && this.layers.hasArtboard) {
                 return this.layers.overallBounds;
             } else {
                 return this.bounds;

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
          * Construct a document model from a document and array of layer descriptors.
          *
          * @private
-         * @param {{document: object, layers: Array.<object>}} docObj
+         * @param {{document: object, layers: Array.<object>=, guides: Array.<object>=}} docObj
          * @return {Document}
          */
         _makeDocument: function (docObj) {
@@ -176,9 +176,10 @@ define(function (require, exports, module) {
 
             // If some selected layer remains uninitialized, a new document will
             // come along shortly. Wait until then to trigger the change event.
-            var initialized = nextDocument.layers.selected.every(function (layer) {
-                return layer.initialized;
-            });
+            var initialized = nextDocument.layers && nextDocument.layers.selected
+                .every(function (layer) {
+                    return layer.initialized;
+                });
 
             if (initialized) {
                 this.emit("change");


### PR DESCRIPTION
This PR is in the same spirit as #2439, which delayed loading detailed information about layers until their first selection, but for documents. It changes `documents.initInactiveDocuments` to only load a small subset of essential document properties during startup, and `documents.selectDocument` to finish loading all of the properties when the document is first selected. It does _not_ change `initActiveDocument` or `updateDocument` or anything else that might initialize a new document after startup. An uninitialized document is detected simply by having a null `layers` property.

With 7 moderately sized documents open, this reduces overall startup time from ~6.5 seconds to ~4.5 seconds, which is a ~30% reduction.

Although #2439 was a fairly simple architectural change, this is even simpler. Still, these sorts of performance optimizations always introduce some risk, so I'd appreciate some help testing this.

Partially, indirectly addresses #790.