### PR TITLE
Enables a single column mode, where all panels appear in a single column

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -134,6 +134,23 @@ define(function (require, exports) {
     togglePinnedToolbar.transfers = [preferences.setPreference];
 
     /**
+    * Toggle small screen mode
+    *
+    * @return {Promise}
+    */
+    var toggleSingleColumnMode = function () {
+        var preferenceState = this.flux.store("preferences").getState(),
+            singleColumnModeEnabled = preferenceState.get("singleColumnModeEnabled", false);
+
+        var newsingleColumnModeEnabled = !singleColumnModeEnabled;
+
+        return this.transfer(preferences.setPreference, "singleColumnModeEnabled", newsingleColumnModeEnabled);
+    };
+    toggleSingleColumnMode.reads = [];
+    toggleSingleColumnMode.writes = [locks.JS_PREF];
+    toggleSingleColumnMode.transfers = [preferences.setPreference];
+
+    /**
      * Query Photoshop for the curent window transform and emit a
      * TRANSFORM_UPDATED event with that value.
      *
@@ -593,6 +610,7 @@ define(function (require, exports) {
     exports.enableTooltips = enableTooltips;
     exports.disableTooltips = disableTooltips;
     exports.togglePinnedToolbar = togglePinnedToolbar;
+    exports.toggleSingleColumnMode = toggleSingleColumnMode;
     exports.updateTransform = updateTransform;
     exports.setTransform = setTransform;
     exports.setOverlayCloaking = setOverlayCloaking;

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -68,14 +68,16 @@ define(function (require, exports, module) {
                 numPanels = propertiesCol + layersCol;
 
             return {
-                numberOfPanels: numPanels
+                numberOfPanels: numPanels,
+                singleColumnModeEnabled: preferences.get("singleColumnModeEnabled", false)
             };
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
             return this.state.ready !== nextState.ready ||
                 this.state.active !== nextState.active ||
-                this.state.numberOfPanels !== nextState.numberOfPanels;
+                this.state.numberOfPanels !== nextState.numberOfPanels ||
+                this.state.singleColumnModeEnabled !== nextState.singleColumnModeEnabled;
         },
 
         /**
@@ -165,11 +167,12 @@ define(function (require, exports, module) {
                         active={this.state.active} />
                     <PanelSet
                         ref="panelSet"
-                        active={this.state.active} />
+                        active={this.state.active}
+                        singleColumnModeEnabled={this.state.singleColumnModeEnabled} />
                     <Help />
                     <Search />
                     <ExportModal />
-                    
+
                     <svg style={{ display: "none" }}>
                         <defs dangerouslySetInnerHTML={{ __html: _ICO_LOADER }}/>
                     </svg>

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -169,6 +169,10 @@ define(function (require, exports, module) {
             if (this.props.active && !nextProps.active) {
                 return false;
             }
+            
+            if (this.props.singleColumnModeEnabled !== nextProps.singleColumnModeEnabled) {
+                return true;
+            }
 
             // Don't re-render until either the active document or recent files
             // are initialized.
@@ -301,51 +305,73 @@ define(function (require, exports, module) {
                     handleLayersLibraryColumnVisibilityToggle =
                         this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL);
 
-                return (
-                    <div className="panel-set__container">
-                        <div ref="panelSet"
-                             className="panel-set">
-                            <PanelColumn visible={this.state[components.PROPERTIES_COL]}
-                                         onVisibilityToggle={handlePropertiesColumnVisibilityToggle}>
-                                {documentProperties.transformPanels}
-                                {documentProperties.appearancePanels}
-                                {documentProperties.effectPanels}
-                                {documentProperties.exportPanels}
-                            </PanelColumn>
-                            <PanelColumn visible={this.state[components.LAYERS_LIBRARY_COL]}
-                                         onVisibilityToggle= {handleLayersLibraryColumnVisibilityToggle}>
-                                {documentProperties.layerPanels}
-                                <LibrariesPanel
-                                    key="libraries-panel"
-                                    className="section__active"
-                                    ref={components.LIBRARIES_PANEL}
-                                    disabled={activeDocument && activeDocument.unsupported}
-                                    document={activeDocument}
-                                    visible={this.state[components.LIBRARIES_PANEL]}
-                                    onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
-                                        components.LIBRARIES_PANEL)} />
-                            </PanelColumn>
-                        </div>
-                        <IconBar>
-                            <Button className={propertiesButtonClassNames}
-                                title={propertiesColumnTitle}
-                                disabled={false}
-                                onClick=
-                                {this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL)}>
-                                <SVGIcon
-                                    CSSID="properties" />
-                            </Button>
-                            <Button className={layersButtonClassNames}
-                                title={layerColumnTitle}
-                                disabled={false}
-                                onClick=
-                                {this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL)}>
-                                <SVGIcon
-                                    CSSID="layers" />
-                            </Button>
-                        </IconBar>
-                    </div>
+                var librariesPanel = (
+                    <LibrariesPanel
+                        key="libraries-panel"
+                        className="section__active"
+                        ref={components.LIBRARIES_PANEL}
+                        disabled={activeDocument && activeDocument.unsupported}
+                        document={activeDocument}
+                        visible={this.state[components.LIBRARIES_PANEL]}
+                        onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
+                        components.LIBRARIES_PANEL)} />
                 );
+
+                if (this.props.singleColumnModeEnabled) {
+                    return (
+                        <div className="panel-set__container panel-set__container__small-screen">
+                            <div ref="panelSet"
+                                 className="panel-set">
+                                <PanelColumn visible={true}>
+                                    {documentProperties.transformPanels}
+                                    {documentProperties.appearancePanels}
+                                    {documentProperties.effectPanels}
+                                    {documentProperties.exportPanels}
+                                    {documentProperties.layerPanels}
+                                    {librariesPanel}
+                                </PanelColumn>
+                            </div>
+                        </div>
+                    );
+                } else {
+                    return (
+                        <div className="panel-set__container">
+                            <div ref="panelSet"
+                                 className="panel-set">
+                                <PanelColumn visible={this.state[components.PROPERTIES_COL]}
+                                             onVisibilityToggle={handlePropertiesColumnVisibilityToggle}>
+                                    {documentProperties.transformPanels}
+                                    {documentProperties.appearancePanels}
+                                    {documentProperties.effectPanels}
+                                    {documentProperties.exportPanels}
+                                </PanelColumn>
+                                <PanelColumn visible={this.state[components.LAYERS_LIBRARY_COL]}
+                                             onVisibilityToggle= {handleLayersLibraryColumnVisibilityToggle}>
+                                    {documentProperties.layerPanels}
+                                    {librariesPanel}
+                                </PanelColumn>
+                            </div>
+                            <IconBar>
+                                <Button className={propertiesButtonClassNames}
+                                    title={propertiesColumnTitle}
+                                    disabled={false}
+                                    onClick=
+                                    {this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL)}>
+                                    <SVGIcon
+                                        CSSID="properties" />
+                                </Button>
+                                <Button className={layersButtonClassNames}
+                                    title={layerColumnTitle}
+                                    disabled={false}
+                                    onClick=
+                                    {this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL)}>
+                                    <SVGIcon
+                                        CSSID="layers" />
+                                </Button>
+                            </IconBar>
+                        </div>
+                    );
+                }
             } else if (this.state.recentFilesInitialized) {
                 return (
                     <div className="panel-set panel-set__active null-state">

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -56,6 +56,16 @@ define(function (require, exports, module) {
          * @type {?DOMElement}
          */
         _target: null,
+        
+        /**
+         * A unique key to append the Dialog ID. 
+         * This is a simple solution to prevent collision of dialog ID names when
+         * a component doesn't unmount before another instance mounts
+         *
+         * @private
+         * @type {Number}
+         */
+        _uniqkey: (new Date()).getTime(),
 
         propTypes: {
             id: React.PropTypes.string.isRequired,
@@ -101,12 +111,12 @@ define(function (require, exports, module) {
                 openDialogs = dialogState.openDialogs;
 
             return {
-                open: openDialogs.has(this.props.id)
+                open: openDialogs.has(this.props.id + this._uniqkey)
             };
         },
 
         componentWillMount: function () {
-            this.getFlux().store("dialog").registerDialog(this.props.id, this._getDismissalPolicy());
+            this.getFlux().store("dialog").registerDialog(this.props.id + this._uniqkey, this._getDismissalPolicy());
         },
 
         /**
@@ -129,7 +139,7 @@ define(function (require, exports, module) {
          */
         toggle: function (event) {
             var flux = this.getFlux(),
-                id = this.props.id;
+                id = this.props.id + this._uniqkey;
 
             if (this.state.open) {
                 this._target = null;
@@ -314,9 +324,10 @@ define(function (require, exports, module) {
         componentWillUnmount: function () {
             if (this.state.open) {
                 this._removeListeners();
-                this.getFlux().actions.dialog.closeDialog(this.props.id);
+                this.getFlux().actions.dialog.closeDialog(this.props.id + this._uniqkey);
             }
-            this.getFlux().store("dialog").deregisterDialog(this.props.id);
+
+            this.getFlux().store("dialog").deregisterDialog(this.props.id + this._uniqkey);
         },
 
         /** @ignore */

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -457,7 +457,8 @@ define(function (require, exports, module) {
      */
     MenuBar.prototype.updatePreferenceBasedMenuItems = function (preferences) {
         var updatedMenu = this.updateSubmenuItems("WINDOW", {
-            "TOGGLE_TOOLBAR": { "checked": (preferences.get("toolbarPinned", true) ? 1 : 0) }
+            "TOGGLE_TOOLBAR": { "checked": (preferences.get("toolbarPinned", true) ? 1 : 0) },
+            "TOGGLE_SINGLE_COLUMN_MODE": { "checked": (preferences.get("singleColumnModeEnabled", false) ? 1 : 0) }
         });
 
         if (global.debug) {

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -208,6 +208,7 @@
         "BRING_ALL_TO_FRONT": "Bring All to Front",
         "NEXT_DOCUMENT": "Next Document",
         "TOGGLE_TOOLBAR": "Pin Toolbar",
+        "TOGGLE_SINGLE_COLUMN_MODE": "Single Column Mode",
         "PREVIOUS_DOCUMENT": "Previous Document",
         "RETURN_TO_STANDARD": "Return to Standard Photoshop",
         "OPEN_DOCUMENT_ONE": "Document Name 1",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -408,6 +408,10 @@
             "$action": "ui.togglePinnedToolbar",
             "$enable-rule": "always-except-modal"
         },
+        "TOGGLE_SINGLE_COLUMN_MODE": {
+            "$action": "ui.toggleSingleColumnMode",
+            "$enable-rule": "always-except-modal"
+        },
         "RETURN_TO_STANDARD": {
             "$action": "menu.native",
             "$payload": {

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -655,6 +655,9 @@
                     "id": "TOGGLE_TOOLBAR"
                 },
                 {
+                    "id": "TOGGLE_SINGLE_COLUMN_MODE"
+                },
+                {
                     "separator": true
                 },
                 {

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -619,6 +619,9 @@
                     "id": "TOGGLE_TOOLBAR"
                 },
                 {
+                    "id": "TOGGLE_SINGLE_COLUMN_MODE"
+                },
+                {
                     "separator": true
                 },
                 {

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -414,3 +414,40 @@
         color: @focus-highlight;
     }
 }
+
+.panel-set__container__small-screen {
+    .section.section__collapsed {
+        flex-grow: 0;
+        height: auto;
+        border-bottom: 2*@hairline solid @bg-border;
+    }
+
+    .export {
+        min-height: 3.2rem;
+    }
+
+    .layers, .libraries {
+        min-height: 3rem;
+
+        &.section__collapsed {
+            min-height: 0;
+        }
+    }
+    
+    .appearance, .type {
+        height: 18rem;
+        flex-grow: 0;
+    }
+    
+    .libraries .section-container {
+        flex-basis: 10rem;
+    }
+
+    .effects.section__active {
+        min-height: 10rem;
+    }
+
+    .effects.section__collapsed {
+        min-height: 3rem;
+    }
+}

--- a/src/style/shared/title-header.less
+++ b/src/style/shared/title-header.less
@@ -84,3 +84,15 @@
     height: 2rem;
     line-height: 2rem;
 }
+
+.panel-set__container__small-screen {
+    .appearance,
+    .effects,
+    .export,
+    .layers,
+    .libraries {
+        .section-header {
+            height: 3.2rem;
+        }
+    }
+}


### PR DESCRIPTION
Another small-screen/single column option. Here, there is a menu option for Single Column Mode under the Window menu. 

With this option, all of the panels now appear in a single column, and the toggle panels toolbar disappears. I adjusted some of the sizing of both the panels and the headers in order to fit more on the screen.

Attached is the screen at approximately the resolution of a 13" Macbook Air

![vermilionartboards_psd___6_25___dropdown__rgb_8____](https://cloud.githubusercontent.com/assets/22372/10140422/5ba3ff3e-65d5-11e5-96e7-77f4e0ed8a6b.png)
