### PR TITLE
Assets in the export dialog end in ellipsis instead of truncation

### DIFF
--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -291,8 +291,6 @@ define(function (require, exports, module) {
                         <div className="column-4">
                         </div>
                         <div className="exports-panel__asset-list__container">
-                            
-
                             <div className="exports-panel__asset-list__quick-selection">
                                 <div className="column-2 control-group__vertical" >
                                     <CheckBox

--- a/src/style/sections/exports/exports.less
+++ b/src/style/sections/exports/exports.less
@@ -118,6 +118,9 @@
     align-items: center;
     flex-wrap: nowrap;
     margin: 0.5rem 0rem;
+    overflow: none;
+    text-overflow: ellipsis;
+    width: 100%;
 }
 
 .exports-panel__layer-icon {
@@ -133,6 +136,7 @@
 .exports-panel__layer-info {
     width: 19rem;
     overflow:hidden;
+    text-overflow: ellipsis;
 }
 
 .exports-panel__layer__name {
@@ -161,8 +165,10 @@
 .exports-panel__layer-assets {
     font-size: @text-medium;
     font-color: @item-inactive;
-    display: flex;
+    display: inline;
     width: 100%;
+    text-overflow: ellipsis;
+    overflow: hidden;
 
     & span {
         text-overflow: ellipsis;
@@ -173,6 +179,7 @@
 .exports-panel__layer-asset {
     color: @warm-gray;
     margin-right: 0.5rem;
+    display: inline;
 }
 
 .exports-panel__layer-asset__stale {


### PR DESCRIPTION
Any overflow of assets in the export dialog is hidden and ends in an ellipsis instead of truncating. 
Minor CSS change, addresses #2557.