### PR TITLE
Multiple artboards in selection for dragging / policies

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1023,14 +1023,19 @@ define(function (require, exports) {
         _layerTransformHandler = synchronization.debounce(function (event) {
             this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
             
+            var appStore = this.flux.store("application"),
+                currentDoc = appStore.getCurrentDocument(),
+                artboardsSelected = currentDoc.layers.selected.some(function (layer) {
+                    return layer.isArtboard;
+                });
+                
             // If it was a simple click/didn't move anything, there is no need to update bounds
-            if (event.trackerEndedWithoutBreakingHysteresis) {
+            // But, if we're moving multiple artboards, we get one event with 0,0, which means
+            // we hit this and we have to update bounds
+            if (event.trackerEndedWithoutBreakingHysteresis && !artboardsSelected) {
                 return Promise.resolve();
             }
 
-            var appStore = this.flux.store("application"),
-                currentDoc = appStore.getCurrentDocument();
-                
             if (event.newDuplicateSheets) {
                 var duplicateInfo = event.newDuplicateSheets,
                     newSheetIDlist = duplicateInfo.newSheetIDlist,


### PR DESCRIPTION
This change requires CL 1044998, which will be available in pgdv.mac.688

Problem was that I was preventing both artboard tool switch AND drag operation from happening when multiple artboard selection border was clicked. So now I only prevent the tool switch in PS side.

But this presented a new problem: We would get two "move" events, where one would have "0,0", and because we were debouncing, we would handle the 0,0 event, and immediately return, eating up the other event. So now, if there are any artboards selected, "move" events all are considered legal.

I also noticed that we would draw one big policy frame all selected artboards... however, if oyu had two artboard selected that were not in a row/column, this would create a fake policy on the empty corners, and PS would still draw the handle bars around non policy areas, creating wrong behavior. So I fixed that while I was in there.

Addresses #2597