### PR TITLE
Check for alpha_propagate policies as well for highlighitng

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -439,7 +439,8 @@ define(function (require, exports, module) {
                         area.top < y && area.bottom > y;
 
                 if (intersects) {
-                    if (policy.action === UI.policyAction.ALWAYS_PROPAGATE) {
+                    if (policy.action === UI.policyAction.ALWAYS_PROPAGATE ||
+                        policy.action === UI.policyAction.ALPHA_PROPAGATE) {
                         underAlways = true;
                     } else {
                         underAlways = false;


### PR DESCRIPTION
I recently switched the border policies to alpha propagate instead of always_propagate to prevent mouse stealing over our own panels. However, this broke one of the highlighting rules, so I fixed it.

There wasn't an issue for this yet.

Noticed this while trying to fix 2515, hence the branch name.