### PR TITLE
DocumentExports.getLayerExports will always return an Immutable List

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -94,7 +94,7 @@ define(function (require, exports) {
         // helper to build play object for  individual layers
         var _buildPlayObject = function (layerID) {
             var layerExports = documentExports.getLayerExports(layerID),
-                layerExportsArray = layerExports && layerExports.toJS() || [],
+                layerExportsArray = layerExports.toJS(),
                 layer = document.layers.byID(layerID);
 
             if (!document || !layer) {

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -501,6 +501,8 @@ define(function (require, exports, module) {
      */
     Layer.fromDescriptor = function (document, layerDescriptor, selected, initialized) {
         var id = layerDescriptor.layerID,
+            artboardEnabled = layerDescriptor.artboardEnabled,
+            exportEnabled = artboardEnabled && layerDescriptor.exportEnabled !== false || layerDescriptor.exportEnabled,
             documentID,
             resolution;
 
@@ -534,7 +536,7 @@ define(function (require, exports, module) {
             proportionalScaling: layerDescriptor.proportionalScaling,
             isArtboard: layerDescriptor.artboardEnabled,
             vectorMaskEnabled: layerDescriptor.vectorMaskEnabled,
-            exportEnabled: layerDescriptor.exportEnabled,
+            exportEnabled: exportEnabled,
             isLinked: _extractIsLinked(layerDescriptor),
             initialized: initialized || selected
             // if not explicitly marked as initialized, then it is initialized iff it is selected
@@ -556,6 +558,8 @@ define(function (require, exports, module) {
      */
     Layer.prototype.resetFromDescriptor = function (layerDescriptor, previousDocument) {
         var resolution = previousDocument.resolution,
+            artboardEnabled = layerDescriptor.artboardEnabled,
+            exportEnabled = artboardEnabled && layerDescriptor.exportEnabled !== false || layerDescriptor.exportEnabled,
             model = {
                 name: layerDescriptor.name,
                 kind: layerDescriptor.layerKind,
@@ -573,7 +577,7 @@ define(function (require, exports, module) {
                 proportionalScaling: layerDescriptor.proportionalScaling,
                 isArtboard: layerDescriptor.artboardEnabled,
                 vectorMaskEnabled: layerDescriptor.vectorMaskEnabled,
-                exportEnabled: layerDescriptor.exportEnabled,
+                exportEnabled: exportEnabled,
                 isLinked: _extractIsLinked(layerDescriptor),
                 initialized: true
             };


### PR DESCRIPTION
This was really the practical use of this method anyway, which allowed some cleanup.

Addresses #2641.  In some cases, new layers did not have layer-level exports defined properly in the `ExportDocuments` model.

This PR also tries harder to safely default artboards to "exportEnabled" and having one default asset.  When opening a document that has undefined export-related `extension` values, we assume this is a fresh document (never opened in DS, or at least the exports were not monkeyed with), so we default the values accordingly.  This is a request by @davealonzo.