### PR TITLE
Export panel maintains minimum height

### DIFF
--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -247,7 +247,12 @@
     min-height: 24rem;
 }
 
-.effects.section__collapsed {
+.export.section__active {
+    min-height: 18rem;
+}
+
+.effects.section__collapsed,
+.export.section__collapsed {
     min-height: 4.8rem;
 }
 


### PR DESCRIPTION
- When lots of effects are added, export panel will not get shoved down and become unusable.
- fix for #2585 
- also #2468