### PR TITLE
Updates to color swatches

### DIFF
--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -115,8 +115,6 @@ define(function (require, exports, module) {
 
             var fillOverlay = function (colorTiny) {
                 var fillStyle = {
-                    height: "100%",
-                    width: "100%",
                     backgroundColor: colorTiny ? colorTiny.toRgbString() : "transparent"
                 };
                 

--- a/src/js/jsx/sections/style/Shadow.jsx
+++ b/src/js/jsx/sections/style/Shadow.jsx
@@ -321,7 +321,7 @@ define(function (require, exports) {
             return (
                 <div className={shadowClasses}>
                     <div className="formline formline__no-padding">
-                        <div className="control-group column-3">
+                        <div className="control-group control-group__vertical">
                             <ColorInput
                                 id={colorInputID}
                                 className={"shadow"}
@@ -336,13 +336,13 @@ define(function (require, exports) {
                                 swatchOverlay={shadowOverlay}>
                             </ColorInput>
                         </div>
-                        <div className="control-group column-23">
+                        <div className="column-21 control-group__horizontal__left">
                             <BlendMode
                                 listID={blendModelistID}
                                 modes={downsample.blendModes}
                                 handleChange={this._blendModeChanged}
                                 disabled={this.props.disabled}
-                                size="column-20"
+                                size="column-19"
                                 onChange={this._blendModeChanged} />
                         </div>
                         <ToggleButton

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -87,9 +87,7 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            // HACK for border radius bleed issue
             var swatchBackgroundSet = classnames("color-input__swatch__background", {
-                "color-input__swatch__background-hide": this.props.hideSwatchBackground,
                 "color-input__disabled": !this.props.editable
             });
             
@@ -305,7 +303,6 @@ define(function (require, exports, module) {
                 valueArray = !Immutable.Iterable.isIterable(defaultValue) ?
                     Immutable.List.of(defaultValue) : defaultValue,
                 value = collection.uniformValue(valueArray),
-                hideSwatchBackground = false,
                 label,
                 color,
                 colorTiny;
@@ -319,12 +316,6 @@ define(function (require, exports, module) {
                 } else {
                     if (this.props.opaque) {
                         value = value.opaque();
-                    }
-                    
-                    // HACK: Due to a Chrome rendering error, the swatches have little white bleeds 
-                    // on the corners. This hides the background for opaque colors, which helps a little
-                    if (value.a === 1) {
-                        hideSwatchBackground = true;
                     }
 
                     // naive tinycolor toString
@@ -368,7 +359,6 @@ define(function (require, exports, module) {
                         title={this.props.title}
                         overlay={overlay}
                         editable={this.props.editable}
-                        hideSwatchBackground={hideSwatchBackground}
                         onFocus={this._handleSwatchFocus}
                         onKeyDown={this._handleKeyDown}
                         onClick={this._handleSwatchClick} />

--- a/src/style/shared/color-input.less
+++ b/src/style/shared/color-input.less
@@ -25,22 +25,27 @@
     display: flex;
     justify-content: flex-start;
     align-content: center;
-    margin-right: 1rem;
+    margin-right: 0.8rem;
     margin-top: 0.7rem;
 }
 
 .color-input {    
-    .stroke__preview,
-    .type__preview,
-    .fill__preview {
-        z-index: 10;
+    .fill__preview,
+    .stroke__preview {
+        height: 100%;
+        width: 100%;
     }
 
-    .stroke__preview {
+    .stroke__preview:after {
+        position: absolute;
+        content: " ";
         width: 50%;
         height: 50%;
+        left: 25%;
+        top: 25%;
         background-color: @bg-panel;
         border-radius: 0.2rem;
+        z-index: 10;
     }
         
     .type__preview {
@@ -49,10 +54,6 @@
         font-size: 2rem;        
     }
     
-}
-
-.vector-fill .color-input__swatch__background-hide {
-    background: none;
 }
 
 .color-input__swatch__background,


### PR DESCRIPTION
1) Fix alignment of Effects color swatch, which should have lined up with the Appearance color swatches
2) Correct the stroke swatch, which I had done wrong and @davealonzo nicely pointed out to me (and happily made some of the code cleaner)
3) Attacked that corner radius issue #2564 some more: This issue is largely to blame on Chrome, and can be seen in normal desktop Chrome as well. It seems to have several compounding issues
* Flexbox + z-index create it for any color
* Any color with alpha < 1 also creates it

I had written a hack for the opacity issue previously, which was actually not necessary as I was able to remove the z-index instead. So for opaque colors, it looks good. Anything less than opaque still shows white corners, though it only looks really bad in the range 0.85 < alpha < 1
   