### PR TITLE
Initialize newly selected layers after layer deletion

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1025,11 +1025,17 @@ define(function (require, exports) {
                 if (resetHistory) {
                     this.transfer(historyActions.queryCurrentHistory, document.id);
                 }
+            })
+            .then(function () {
+                var nextDocument = this.flux.store("document").getDocument(document.id),
+                    selected = nextDocument.layers.selected;
+
+                return this.transfer(initializeLayers, nextDocument, selected);
             });
     };
     removeLayers.reads = [locks.PS_DOC];
     removeLayers.writes = [locks.JS_DOC];
-    removeLayers.transfers = ["history.queryCurrentHistory"];
+    removeLayers.transfers = ["history.queryCurrentHistory", initializeLayers];
     removeLayers.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**


### PR DESCRIPTION
Just another initialize. RemoveLayers dispatches event, event changes selection, selected layers aren't initialize, so document store doesn't emit a change event. So we have to initialize those layers to get a change event. Boy saves world.

Addresses #2601