### PR TITLE
Add stroke to layers without a stroke object during setStroke command

### DIFF
--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -187,34 +187,23 @@ define(function (require, exports) {
 
         options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE);
 
-        if (_allStrokesExist(layers)) {
-            // toJS gets rid of color so we re-insert it here
-            strokeJSObj.color = stroke.color.normalizeAlpha();
-            strokeJSObj.opacity = strokeJSObj.color.a;
+        // toJS gets rid of color so we re-insert it here
+        strokeJSObj.color = stroke.color.normalizeAlpha();
+        strokeJSObj.opacity = strokeJSObj.color.a;
 
-            // optimistically dispatch the change event    
-            var dispatchPromise = _strokeChangeDispatch.call(this,
-                document,
-                layers,
-                strokeJSObj,
-                eventName);
+        // optimistically dispatch the change event    
+        var dispatchPromise = _strokeChangeDispatch.call(this,
+            document,
+            layers,
+            strokeJSObj,
+            eventName);
 
-            var strokePromise = layerActionsUtil.playSimpleLayerActions(document, layers, strokeObj, true, options);
+        var strokePromise = layerActionsUtil.playSimpleLayerActions(document, layers, strokeObj, true, options);
 
-            // after both, if enabled has potentially changed, transfer to resetBounds
-            return Promise.join(dispatchPromise,
-                    strokePromise,
-                    function () {
-                        return this.transfer(layerActions.resetBounds, document, layers);
-                    }.bind(this));
-        } else {
-            return layerActionsUtil.playSimpleLayerActions(document, layers, strokeObj, true, options)
-                .bind(this)
-                .then(function () {
-                    // upon completion, fetch the stroke info for all layers
-                    return _refreshStrokes.call(this, document, layers);
-                });
-        }
+        return Promise.join(dispatchPromise, strokePromise,
+            function () {
+                return this.transfer(layerActions.resetBounds, document, layers);
+            }.bind(this));
     };
     setStroke.reads = [];
     setStroke.writes = [locks.PS_DOC, locks.JS_DOC];

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1471,7 +1471,7 @@ define(function (require, exports, module) {
                 stroke = layer.stroke;
 
             if (!stroke) {
-                throw new Error("Unable to set stroke properties of layer: " + layer.name);
+                stroke = new Stroke();
             }
 
             var nextStroke = stroke.setStrokeProperties(strokeProperties),


### PR DESCRIPTION
Another artifact from multiple strokes age, where we checked to see if all layers had strokes and if not, we called _refreshStrokes. Problem was, with transactions, we wouldn't play the actual setStroke objects yet, so we'd be trying to grab a non existent stroke from PS, and things would burn.

I removed the check, and need to call _refreshStrokes, because we can recreate the stroke ourselves using available strokeProperties.

Addresses #2699 