### PR TITLE
Enqueue initialize instead of transferring to in removeLayers

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1030,12 +1030,12 @@ define(function (require, exports) {
                 var nextDocument = this.flux.store("document").getDocument(document.id),
                     selected = nextDocument.layers.selected;
 
-                return this.transfer(initializeLayers, nextDocument, selected);
+                this.flux.actions.layers.initializeLayers(nextDocument, selected);
             });
     };
     removeLayers.reads = [locks.PS_DOC];
     removeLayers.writes = [locks.JS_DOC];
-    removeLayers.transfers = ["history.queryCurrentHistory", initializeLayers];
+    removeLayers.transfers = ["history.queryCurrentHistory"];
     removeLayers.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2156,7 +2156,7 @@ define(function (require, exports) {
                 positions: positions
             };
     
-        return this.dispatchAsync(events.document.history.optimistic.REPOSITION_LAYERS, payload);
+        return this.dispatchAsync(events.document.REPOSITION_LAYERS, payload);
     };
     handleCanvasShift.reads = [];
     handleCanvasShift.writes = [locks.JS_DOC];

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
             RESET_BOUNDS: "resetBoundsNoHistory", // slightly different than above LAYER_BOUNDS_CHANGED
             RESET_LAYERS: "resetLayers",
             RESET_LAYERS_BY_INDEX: "resetLayersByIndex",
-            TRANSLATE_LAYERS: "translateLayers",
+            REPOSITION_LAYERS: "repositionLayersNoHistory",
             GUIDES_VISIBILITY_CHANGED: "guidesVisibilityChanged",
             SELECT_DOCUMENT: "selectDocument",
             SAVE_DOCUMENT: "saveDocument",

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1191,7 +1191,8 @@ define(function (require, exports, module) {
     LayerStructure.prototype.repositionLayers = function (layerPositions) {
         var allBounds = Immutable.Map(layerPositions.reduce(function (allBounds, layerData) {
             var layer = this.byID(layerData.layer.id);
-            if (layer.bounds) {
+            // Due to handleCanvasShift, we may have non existent layers here
+            if (layer && layer.bounds) {
                 allBounds.set(layer.id, layer.bounds.updatePosition(layerData.x, layerData.y));
             }
 

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.GROUP_SELECTED, this._handleGroupLayers,
                 events.document.history.nonOptimistic.UNGROUP_SELECTED, this._handleUngroupLayers,
                 events.document.history.optimistic.REPOSITION_LAYERS, this._handleLayerRepositioned,
-                events.document.TRANSLATE_LAYERS, this._handleLayerTranslated,
+                events.document.REPOSITION_LAYERS, this._handleLayerRepositioned,
                 events.document.history.optimistic.RESIZE_LAYERS, this._handleLayerResized,
                 events.document.history.optimistic.SET_LAYERS_PROPORTIONAL, this._handleSetLayersProportional,
                 events.document.history.optimistic.RESIZE_DOCUMENT, this._handleDocumentResized,
@@ -639,23 +639,6 @@ define(function (require, exports, module) {
             var documentID = payload.documentID,
                 document = this._openDocuments[documentID],
                 nextLayers = document.layers.repositionLayers(payload.positions),
-                nextDocument = document.set("layers", nextLayers);
-
-            this.setDocument(nextDocument, true);
-        },
-
-        /**
-         * Updates the passed in translation to affected layers
-         *
-         * @private
-         * @param {{documentID: number, layerIDs: Array.<number>, change: {x: number, y: number}}} payload
-         */
-        _handleLayerTranslated: function (payload) {
-            var documentID = payload.documentID,
-                layerIDs = payload.layerIDs,
-                position = payload.position,
-                document = this._openDocuments[documentID],
-                nextLayers = document.layers.translateLayers(layerIDs, position.x, position.y),
                 nextDocument = document.set("layers", nextLayers);
 
             this.setDocument(nextDocument, true);

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
                 events.document.history.nonOptimistic.DELETE_LAYERS, this._updateMenuItems,
                 events.document.history.optimistic.GROUP_SELECTED, this._updateMenuItems,
                 events.document.history.optimistic.REPOSITION_LAYERS, this._updateMenuItems,
-                events.document.TRANSLATE_LAYERS, this._updateMenuItems,
+                events.document.REPOSITION_LAYERS, this._updateMenuItems,
                 events.document.history.optimistic.RESIZE_LAYERS, this._updateMenuItems,
                 events.document.history.optimistic.SET_LAYERS_PROPORTIONAL, this._updateMenuItems,
                 events.document.history.optimistic.RESIZE_DOCUMENT, this._updateMenuItems,


### PR DESCRIPTION
Problem:

On deleting a layer, we would transfer to  initialize the newly selected layer so it would actually get doc store to emit a change event. However, if the deleted layer caused a canvas resize shift, we would handle this by translating all the layers in the document by the shift. And we would translate the newly selected layer's shifted boundaries. So things would go to shift.

So now, instead of transferring to initializeLayers, I enqueue that action. This way, handleCanvasShift gets played first, and then init layers gets played, and the bounds are correctly shifted / initialized.

@iwehrman I don't know whether you'll agree with this fix. But I can't figure out a cleaner way. So please review and argue with me tomorrow.

Addresses #2713 