### PR TITLE
Init 'next' doc before closing the first

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -428,6 +428,8 @@ define(function (require, exports) {
                         // needs to be initialized first
                         return this.transfer(updateDocument, nextDocumentID)
                             .return(nextDocumentID);
+                    } else {
+                        return nextDocumentID;
                     }
                 }
             })

--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -420,16 +420,28 @@ define(function (require, exports) {
     var disposeDocument = function (documentID, isDocumentSaved) {
         return _getSelectedDocumentID()
             .bind(this)
-            .then(function (currentDocumentID) {
+            .then(function (nextDocumentID) {
+                if (nextDocumentID) {
+                    var nextDocument = this.flux.store("document").getDocument(nextDocumentID);
+                    if (nextDocument && !nextDocument.layers) {
+                        // The next document which will be active upon close of the current document
+                        // needs to be initialized first
+                        return this.transfer(updateDocument, nextDocumentID)
+                            .return(nextDocumentID);
+                    }
+                }
+            })
+            .then(function (nextDocumentID) {
                 var payload = {
                     documentID: documentID,
-                    selectedDocumentID: currentDocumentID
+                    selectedDocumentID: nextDocumentID
                 };
 
                 this.dispatch(events.document.CLOSE_DOCUMENT, payload);
 
                 var newDocument = this.flux.store("application").getCurrentDocument(),
                     resetLinkedPromise = this.transfer(layerActions.resetLinkedLayers, newDocument),
+                    resetHistoryPromise = this.transfer(historyActions.queryCurrentHistory, newDocument.id),
                     recentFilesPromise = this.transfer(application.updateRecentFiles),
                     updateTransformPromise = this.transfer(ui.updateTransform),
                     deleteTempFilesPromise = this.transfer(libraryActions.deleteGraphicTempFiles,
@@ -437,6 +449,7 @@ define(function (require, exports) {
                     policyPromise = this.transfer(toolActions.resetBorderPolicies);
 
                 return Promise.join(resetLinkedPromise,
+                        resetHistoryPromise,
                         updateTransformPromise,
                         recentFilesPromise,
                         deleteTempFilesPromise,
@@ -445,8 +458,9 @@ define(function (require, exports) {
     };
     disposeDocument.reads = [];
     disposeDocument.writes = [locks.JS_DOC, locks.JS_APP];
-    disposeDocument.transfers = ["layers.resetLinkedLayers", application.updateRecentFiles, ui.updateTransform,
-        "libraries.deleteGraphicTempFiles", toolActions.resetBorderPolicies];
+    disposeDocument.transfers = [updateDocument, "layers.resetLinkedLayers", "history.queryCurrentHistory",
+        "ui.updateTransform", "application.updateRecentFiles", "libraries.deleteGraphicTempFiles",
+        "tools.resetBorderPolicies"];
     disposeDocument.lockUI = true;
 
     /**

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -165,8 +165,9 @@ define(function (require, exports) {
                             });
                         })
                         .then(function () {
-                            var borderPromise = this.transfer(toolActions.resetBorderPolicies),
-                                visibilityPromise = this.transfer(layerActions.resetLayerVisibility, document);
+                            var currentDocument = this.flux.store("application").getCurrentDocument(),
+                                borderPromise = this.transfer(toolActions.resetBorderPolicies),
+                                visibilityPromise = this.transfer(layerActions.resetLayerVisibility, currentDocument);
 
                             return Promise.join(borderPromise, visibilityPromise);
                         });

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1641,11 +1641,15 @@ define(function (require, exports, module) {
      * @return {LayerStructure}
      */
     LayerStructure.prototype.overlayVisibility = function (layerTree) {
-        var nextLayers = layerTree.layers.map(function (layer, key) {
-            if (this.layers.has(key)) {
-                return this.layers.get(key).set("visible", layer.visible);
-            }
-        }, this);
+        var nextLayers = layerTree.layers
+            .map(function (layer, key) {
+                if (this.layers.has(key)) {
+                    return this.layers.get(key).set("visible", layer.visible);
+                }
+            }, this)
+            .filter(function (layer) {
+                return layer;
+            });
 
         return this.set("layers", this.layers.merge(nextLayers));
     };


### PR DESCRIPTION
This addresses #2715 .

This also fixes an unrelated, unreported bug with history states not handling visibility correctly for newly added layers.