### PR TITLE
Libraries Visual Tweak to header/footer

### DIFF
--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -91,7 +91,7 @@
             flex-direction: row;
             justify-content: space-between;
             flex: none;
-            height: 4rem;
+            height: 3.2rem;
             margin: 0 0rem;
             align-items: center;
             width: 100%;
@@ -101,7 +101,8 @@
         flex-direction: row;
         justify-content: space-between;
         flex: none;
-        height: 5rem;
+        height: 4.4rem;
+        padding-bottom: 1.2rem;
         margin: 0 1.6rem;
         align-items: center;
         
@@ -174,7 +175,7 @@
         justify-content: space-between;
         align-items: center;
         flex: none;
-        height: 3rem;
+        height: @toolbar-button-size;
         margin: 0 1.6rem;
 
         .libraries-bar__section__left {


### PR DESCRIPTION
- Footer matches Ps icon height in right toolbar
- reduce dropdown section height size but maintain gap between dropdown
section and scroll area
