### PR TITLE
Suspend/Restore all policy around the placeEvent of graphic asset.

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -179,6 +179,7 @@ define(function (require, exports, module) {
             ASSET_REMOVED: "libraryAssetRemoved",
             ASSET_RENAMED: "libraryAssetRenamed",
             OPEN_GRAPHIC_FOR_EDIT: "libraryOpenGraphicForEdit",
+            PLACE_GRAPHIC_UPDATED: "libraryPlaceGraphicUpdated",
             UPDATING_GRAPHIC_CONTENT: "libraryUpdatingGraphicContent",
             UPDATED_GRAPHIC_CONTENT: "libraryUpdatedGraphicContent",
             DELETED_GRAPHIC_TEMP_FILES: "libraryDeletedGraphicTempFiles",

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -97,6 +97,11 @@ define(function (require, exports, module) {
          * @type {AdobeLibraryElement}
          */
         _lastLocallyUpdatedGraphic: null,
+        
+        /**
+         * @type {boolean}
+         */
+        _isPlacingGraphic: null,
 
         initialize: function () {
             this.bindActions(
@@ -113,8 +118,9 @@ define(function (require, exports, module) {
                 events.libraries.ASSET_CREATED, this._handleElementCreated,
                 events.libraries.ASSET_RENAMED, this._handleElementRenamed,
                 events.libraries.ASSET_REMOVED, this._handleElementRemoved,
-                
+
                 events.libraries.OPEN_GRAPHIC_FOR_EDIT, this._handleOpenGraphicForEdit,
+                events.libraries.PLACE_GRAPHIC_UPDATED, this._handlePlaceGraphicUpdate,
                 events.libraries.UPDATING_GRAPHIC_CONTENT, this._handleUpdatingGraphicContent,
                 events.libraries.UPDATED_GRAPHIC_CONTENT, this._handleUpdatedGraphicContent,
                 events.document.CLOSE_DOCUMENT, this._handleClosedGraphicDocument,
@@ -135,6 +141,7 @@ define(function (require, exports, module) {
             this._selectedLibraryID = null;
             this._serviceConnected = false;
             this._isSyncing = false;
+            this._isPlacingGraphic = false;
             this._editStatusByDocumentID = new Immutable.Map();
             this._createdNewGraphicLocally = false;
         },
@@ -291,6 +298,16 @@ define(function (require, exports, module) {
                 isUpdatingContent: false,
                 isDocumentClosed: false
             });
+        },
+        
+        /**
+         * Handle update of place graphic event. 
+         *
+         * @param {object} payload
+         * @param {boolean} payload.isPlacing
+         */
+        _handlePlaceGraphicUpdate: function (payload) {
+            this._isPlacingGraphic = payload.isPlacing;
         },
         
         /**
@@ -501,6 +518,15 @@ define(function (require, exports, module) {
         /** @ignore */
         isSyncing: function () {
             return this._isSyncing;
+        },
+        
+        /**
+         * Ture if DS is in placing graphic mode.
+         * 
+         * @return {boolean}
+         */
+        isPlacingGraphic: function () {
+            return this._isPlacingGraphic;
         },
         
         /**

--- a/src/js/stores/policy.js
+++ b/src/js/stores/policy.js
@@ -150,7 +150,17 @@ define(function (require, exports, module) {
          * @return {boolean}
          */
         isSuspended: function (kind) {
-            return this._suspendedPolicySets[kind];
+            return !!this._suspendedPolicySets[kind];
+        },
+        
+        /**
+         * Return true if all policies (mouse and keyboard) are suspended.
+         * 
+         * @return {boolean}
+         */
+        areAllSuspended: function () {
+            return !!this._suspendedPolicySets[_eventKind.KEYBOARD] &&
+                !!this._suspendedPolicySets[_eventKind.KEYBOARD];
         },
 
         /**


### PR DESCRIPTION
This PR fix the issue that PS is not responding to mouse click in the transform mode after a graphic asset is dopped on the canvas. This is related to #2719 and requires latest Jenkin build (>= 703) to fully work.

Since this is related to the event policy, @mcilroyc can you reivew my PR? Thank you.