### PR TITLE
Don't pass a modifier to layers.select through marquee in normal case

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -673,7 +673,7 @@ define(function (require, exports) {
         }
         
         var layers = Immutable.List(ids.map(doc.layers.byID.bind(doc.layers))),
-            modifier = add ? "add" : "select";
+            modifier = add ? "add" : undefined;
 
         if (layers.isEmpty() && !add) {
             _logSuperselect("marqueeDeselect");


### PR DESCRIPTION
Layers.select doesn't like it when you pass it "select" as the modifier (even tho that's the default modifier) and multiple layers... Well guess who did that until now? Marquee select.

@mcilroyc please review as this is a FIXNOW bug. #2735 