### PR TITLE
do not enter mask mode if layer is locked

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -549,7 +549,8 @@ define(function (require, exports) {
         }
 
         var nonVectorModeLayer = (currentLayer.kind === currentLayer.layerKinds.BACKGROUND ||
-                currentLayer.kind === currentLayer.layerKinds.VECTOR);
+                currentLayer.kind === currentLayer.layerKinds.VECTOR) ||
+                currentLayer.locked;
 
         if (vectorMaskMode && nonVectorModeLayer) {
             return Promise.resolve();


### PR DESCRIPTION
fix for #2678 
I'm not sure if the reciprocal is also true, that if you lock a layer we should exit mask mode. maybe @placegraphichere has some thoughts. but in the mean time this is a nice little low risk fix 