### PR TITLE
Restricts the maximum number of layer effects user can create

### DIFF
--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -432,14 +432,11 @@ define(function (require, exports) {
             var shadowCountsUnmatch = !layers.every(function (l) {
                     return l.dropShadows.size === layers.first().dropShadows.size;
                 }),
-                reachMaximumShadows = false,
                 shadowsContent;
                 
             if (!shadowCountsUnmatch) {
                 // Group into arrays of dropShadows, by position in each layer
                 var shadowGroups = collection.zip(collection.pluck(layers, "dropShadows"));
-                
-                reachMaximumShadows = shadowGroups.size >= this.props.max;
                 
                 shadowsContent = shadowGroups.map(function (dropShadows, index) {
                     return (
@@ -504,7 +501,6 @@ define(function (require, exports) {
             var shadowCountsUnmatch = !layers.every(function (l) {
                     return l.innerShadows.size === layers.first().innerShadows.size;
                 }),
-                reachMaximumShadows = false,
                 shadowsContent;
                 
             if (!shadowCountsUnmatch) {
@@ -512,8 +508,6 @@ define(function (require, exports) {
 
                 var temp = collection.pluck(layers, "innerShadows");
                 var shadowGroups = collection.zip(temp);
-                
-                reachMaximumShadows = shadowGroups.size >= this.props.max;
                 
                 shadowsContent = shadowGroups.map(function (innerShadows, index) {
                     return (

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -417,6 +417,10 @@
     &:hover {
         color: @focus-highlight;
     }
+    
+    &-disabled, &-disabled:hover {
+        color: @item-disabled;
+    }
 }
 
 .panel-set__container__small-screen {


### PR DESCRIPTION
This PR restricts the maximum number (10) of layer effects user can create. If reach maximum number, the coresponding menu item will be greyed out. for #2729

For you convenience, you can import this layer effect (http://adobe.ly/1jDyVku) to your cc library to quickly populate these effects.
