### PR TITLE
Misc search improvements

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -396,6 +396,26 @@ define(function (require, exports) {
     updateDocument.lockUI = true;
 
     /**
+     * Initialize any inactive and uninitialized documents with updateDocument.
+     * If all documents are initialized, this is a fast no-op.
+     *
+     * @return {Promise}
+     */
+    var initializeDocuments = function () {
+        var appStore = this.flux.store("application"),
+            documentPromises = appStore.getUninitializedDocuments()
+                .map(function (document) {
+                    return this.transfer(updateDocument, document.id);
+                }, this)
+                .toArray();
+
+        return Promise.all(documentPromises);
+    };
+    initializeDocuments.reads = [locks.JS_APP, locks.JS_DOC];
+    initializeDocuments.writes = [];
+    initializeDocuments.transfers = [updateDocument];
+
+    /**
      * Fetch the ID of the currently selected document, or null if there is none.
      *
      * @private
@@ -1081,6 +1101,7 @@ define(function (require, exports) {
     exports.updateDocument = updateDocument;
     exports.initActiveDocument = initActiveDocument;
     exports.initInactiveDocuments = initInactiveDocuments;
+    exports.initializeDocuments = initializeDocuments;
     exports.packageDocument = packageDocument;
     exports.toggleGuidesVisibility = toggleGuidesVisibility;
     exports.toggleSmartGuidesVisibility = toggleSmartGuidesVisibility;

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -28,8 +28,7 @@ define(function (require, exports) {
 
     var dialog = require("./dialog"),
         search = require("../stores/search"),
-        locks = require("../locks"),
-        documentActions = require("./documents");
+        locks = require("../locks");
 
     /**
      * The search bar dialog ID
@@ -52,27 +51,11 @@ define(function (require, exports) {
             return this.transfer(dialog.closeDialog, ID);
         }
 
-        var allDocuments = this.flux.store("document").getAllDocuments(),
-            documentPromises = Object.keys(allDocuments)
-                .map(function (documentID) {
-                    return allDocuments[documentID];
-                })
-                .filter(function (document) {
-                    return !document.layers;
-                })
-                .map(function (document) {
-                    return this.transfer(documentActions.updateDocument, document.id);
-                }, this);
-
-        return Promise.all(documentPromises)
-            .bind(this)
-            .then(function () {
-                return this.transfer(dialog.openDialog, ID);
-            });
+        return this.transfer(dialog.openDialog, ID);
     };
     toggleSearchBar.reads = [locks.JS_DIALOG];
-    toggleSearchBar.writes = [locks.JS_DOC];
-    toggleSearchBar.transfers = [dialog.openDialog, dialog.closeDialog, documentActions.updateDocument];
+    toggleSearchBar.writes = [];
+    toggleSearchBar.transfers = [dialog.openDialog, dialog.closeDialog];
 
     var beforeStartup = function () {
         var searchStore = this.flux.store("search");

--- a/src/js/actions/search/layers.js
+++ b/src/js/actions/search/layers.js
@@ -71,8 +71,8 @@ define(function (require, exports) {
     */
     var _formatLayerAncestry = function (layer, appStore) {
         var layerTree = appStore.getCurrentDocument().layers,
-            ancestors = layerTree.ancestors(layer),
-            ancestorNames = ancestors.first().name;
+            ancestors = layerTree.strictAncestors(layer),
+            ancestorNames = ancestors.isEmpty() ? "" : ancestors.first().name;
             
         return ancestors.skip(1).reduce(function (ancestors, ancestor) {
             return ancestorNames += ("/" + ancestor.name);
@@ -204,7 +204,7 @@ define(function (require, exports) {
             "getOptions": options,
             "filters": filters,
             "handleExecute": _confirmSearch.bind(this),
-            "shortenPaths": true,
+            "shortenPaths": false,
             "haveDocument": true,
             "getSVGClass": svgUtil.getSVGClassFromLayerCategories
         };

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -67,7 +67,9 @@ define(function (require, exports, module) {
             // SVG class for an icon to show next to the Text Input
             filterIcon: React.PropTypes.string,
             // Release keyboard focus when the text input is blurred.
-            releaseOnBlur: React.PropTypes.bool
+            releaseOnBlur: React.PropTypes.bool,
+            // Emit a change event when the input blurs
+            changeOnBlur: React.PropTypes.bool
         },
 
         /**
@@ -91,7 +93,8 @@ define(function (require, exports, module) {
                 neverSelectAllInput: false,
                 dontCloseDialogIDs: [],
                 filterIcon: null,
-                autoSelect: true
+                autoSelect: true,
+                changeOnBlur: true
             };
         },
 
@@ -121,7 +124,7 @@ define(function (require, exports, module) {
 
         componentDidMount: function () {
             if (this.props.startFocused) {
-                this.refs.textInput._beginEdit();
+                this.focus();
             }
         },
 
@@ -214,11 +217,11 @@ define(function (require, exports, module) {
                 return;
             }
 
-            if (dialog.isOpen()) {
+            if (dialog.isOpen() && this.props.changeOnBlur) {
                 dialog.toggle(event);
             }
 
-            if (!this.props.live && this.state.id) {
+            if (!this.props.live && this.state.id && this.props.changeOnBlur) {
                 this.props.onChange(this.state.id);
             }
 
@@ -553,7 +556,7 @@ define(function (require, exports, module) {
             }
 
             if (this.props.startFocused && this.refs.textInput) {
-                this.refs.textInput._beginEdit();
+                this.focus();
             }
         },
 
@@ -572,7 +575,7 @@ define(function (require, exports, module) {
             }
 
             if (this.props.startFocused && this.refs.textInput) {
-                this.refs.textInput._beginEdit();
+                this.focus();
             }
         },
 
@@ -729,6 +732,13 @@ define(function (require, exports, module) {
                     {dialog}
                 </div>
             );
+        },
+
+        /**
+         * Ensure that the child text input has focus.
+         */
+        focus: function () {
+            this.refs.textInput.focus();
         }
     });
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -287,6 +287,21 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Focus the input element and begin editing if necessary.
+         */
+        focus: function () {
+            var node = React.findDOMNode(this.refs.input);
+            if (!node) {
+                return;
+            }
+
+            node.focus();
+            if (!this.editing && !this.selectDisabled) {
+                this._beginEdit();
+            }
+        },
+
+        /**
          * If the value is editable, goes into edit mode
          *
          * @private

--- a/src/js/stores/application.js
+++ b/src/js/stores/application.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
         /**
          * Get the currently active document models
          * 
-         * @return {?Immutable.List.<Document>}
+         * @return {Immutable.List.<Document>}
          */
         getOpenDocuments: function () {
             var documentStore = this.flux.store("document"),
@@ -156,6 +156,18 @@ define(function (require, exports, module) {
                 });
 
             return documents;
+        },
+
+        /**
+         * Get the list of open but uninitialized document models.
+         *
+         * @return {Immutable.List.<Document>}
+         */
+        getUninitializedDocuments: function () {
+            return this.getOpenDocuments()
+                .filterNot(function (document) {
+                    return document.layers;
+                });
         },
 
         /**

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -27,14 +27,14 @@
             "WEB_1440_900": "Web (1440 x 900)",
             "WEB_1920_1080": "Web (1920 x 1080)"
         },
-        "OPEN": "Open...",
+        "OPEN": "Open…",
         "OPEN_RECENT": {
             "$MENU": "Open Recent"
         },
         "CLOSE": "Close",
         "SAVE": "Save",
         "SAVE_AS": "Save As…",
-        "EXPORT_UTILITY": "Export...",
+        "EXPORT_UTILITY": "Export…",
         "REVERT": "Revert",
         "RENAME_DOCUMENT": "Rename…",
         "GENERATE_ASSETS": "Generate Assets…",

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -260,7 +260,7 @@
         "EXPORT_REMOVE_ASSET": "Remove asset configuration",
         "EXPORT_IOS_PRESETS": "Add 3 iOS assets + SVG",
         "EXPORT_HDPI_PRESETS": "Add 6 HDPI assets + SVG",
-        "EXPORT_DIALOG": "Export..."
+        "EXPORT_DIALOG": "Export…"
     },
     "LAYER_KIND": {
         "0": "Any Layer",
@@ -447,19 +447,20 @@
     },
     "SEARCH": {
         "PLACEHOLDER": "Search, open & select",
+        "PLACEHOLDER_INITIALIZING": "Initializing…",
         "PLACEHOLDER_FILTER": "Search ",
         "NO_OPTIONS": "No results match your search",
         "HEADERS": {
             "ALL_LAYER": "Layers",
             "CURRENT_LAYER": "Layers",
-            "CURRENT_DOC": "Current Documents",
+            "CURRENT_DOC": "Open Documents",
             "RECENT_DOC": "Recent Documents",
             "MENU_COMMAND": "Menu Commands",
             "LIBRARY": "All Libraries",
-            "FILTER": "Limit search to..."
+            "FILTER": "Limit search to…"
         },
         "CATEGORIES": {
-            "CURRENT_DOC": "Current Documents",
+            "CURRENT_DOC": "Open Documents",
             "RECENT_DOC": "Recent Documents",
             "MENU_COMMAND": "Menu Commands",
             "ALL_LAYER": "Layers",


### PR DESCRIPTION
1. Display a read-only "initializing.." message while initializing background documents instead of showing nothing for a long period of time. This improves the user experience. Partially addresses #2781.
2. Do a better job preserving search focus when tabbing away and back. The search-in-progress is no longer committed. Focus is correctly preserved when tabbing away. For some reason it still loses focus  though when you click on another application window!? Partially addresses #2759 and #2057.
3. Speed up formatting of layer name results by not reducing the layer ancestry to use the "shortest unique paths". I think this makes more sense from a UX perspective, and it's also happens to be terribly slow. Also partially addresses #2781.
4. Rename "Current Documents" to "Open Documents".
5. When formatting layer search results, do not include the layer name itself in the secondary ancestry string.
6. Bonus: fixed a couple stray instances of "..." (three periods) which should be "…" (ellipses). 
