### PR TITLE
Reset UI borders when toggling single-column mode

### DIFF
--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -43,16 +43,20 @@ define(function (require, exports, module) {
          * Update the sizes of the panels.
          *
          * @private
+         * @param {boolean=} unmounting
          * @return {Promise}
          */
-        _updatePanelSizes: function () {
-            var node = React.findDOMNode(this),
-                iconBarWidth;
-
-            if (node) {
-                iconBarWidth = node.getBoundingClientRect().width;
-            } else {
+        _updatePanelSizes: function (unmounting) {
+            var iconBarWidth;
+            if (unmounting) {
                 iconBarWidth = 0;
+            } else {
+                var node = React.findDOMNode(this);
+                if (node) {
+                    iconBarWidth = node.getBoundingClientRect().width;
+                } else {
+                    iconBarWidth = 0;
+                }
             }
 
             return this.getFlux().actions.ui.updatePanelSizes({
@@ -75,6 +79,7 @@ define(function (require, exports, module) {
 
         componentWillUnmount: function () {
             os.removeListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
+            this._updatePanelSizes(true);
         },
 
         render: function () {

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -110,7 +110,8 @@ define(function (require, exports, module) {
             }
 
             var columnCount = 0;
-            if (this.state.activeDocument && this.state.activeDocumentInitialized && this.state.documentIDs.size > 0) {
+            if (this.state.activeDocument && this.state.activeDocumentInitialized &&
+                this.state.documentIDs.size > 0 && !this.props.singleColumnModeEnabled) {
                 var uiStore = this.getFlux().store("ui");
                 if (this.state[uiStore.components.LAYERS_LIBRARY_COL]) {
                     columnCount++;
@@ -158,7 +159,8 @@ define(function (require, exports, module) {
                 prevState.recentFilesInitialized !== this.state.recentFilesInitialized ||
                 hasDoc(prevState) !== hasDoc(this.state) ||
                 prevState[components.PROPERTIES_COL] !== this.state[components.PROPERTIES_COL] ||
-                prevState[components.LAYERS_LIBRARY_COL] !== this.state[components.LAYERS_LIBRARY_COL]) {
+                prevState[components.LAYERS_LIBRARY_COL] !== this.state[components.LAYERS_LIBRARY_COL] ||
+                prevProps.singleColumnModeEnabled !== this.props.singleColumnModeEnabled) {
                 this._updatePanelSizes();
             }
         },

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -280,7 +280,10 @@ define(function (require, exports, module) {
          * @return {{top: number, right: number, bottom: number, left: number}}
          */
         getCenterOffsets: function (columns) {
-            var right = this._iconBarWidth;
+            var preferences = this.flux.store("preferences").getState(),
+                singleColumn = preferences.get("singleColumnModeEnabled", false),
+                right = (columns !== undefined && singleColumn) ? 0 :
+                    this._iconBarWidth;
 
             if (columns === undefined || columns === this._columnCount) {
                 right += this._panelWidth;


### PR DESCRIPTION
This is a very narrow fix for #2731, in which toggling single-column mode fails to update the UI borders (i.e., the overlay offsets and cloaking rectangle).

After the next release, the border/panel/column management really needs some cleanup and additional structure... (CC @shaoshing, who may care to think about this during his quiet moments.)