### PR TITLE
capitalize name correctly

### DIFF
--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -91,7 +91,7 @@
                 "ICON": "bird",
                 "HEADLINE": "Design Space",
                 "BODY_FIRST": "Twitter",
-                "BODY_SECOND": "Github",
+                "BODY_SECOND": "GitHub",
                 "BODY_THIRD": "Forum"
             }
         ]


### PR DESCRIPTION
capitalize GitHub name correctly in strings. 

#2742