### PR TITLE
Misc border policy fixes

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -445,15 +445,17 @@ define(function (require, exports) {
                     recentFilesPromise = this.transfer(application.updateRecentFiles),
                     updateTransformPromise = this.transfer(ui.updateTransform),
                     deleteTempFilesPromise = this.transfer(libraryActions.deleteGraphicTempFiles,
-                        documentID, isDocumentSaved),
-                    policyPromise = this.transfer(toolActions.resetBorderPolicies);
+                        documentID, isDocumentSaved);
 
                 return Promise.join(resetLinkedPromise,
                         resetHistoryPromise,
                         updateTransformPromise,
                         recentFilesPromise,
-                        deleteTempFilesPromise,
-                        policyPromise);
+                        deleteTempFilesPromise);
+            })
+            .then(function () {
+                // This must run after the above transfers. See #2785.
+                return this.transfer(toolActions.resetBorderPolicies);
             });
     };
     disposeDocument.reads = [];
@@ -636,7 +638,7 @@ define(function (require, exports) {
         }
 
         if (!document) {
-            return Promise.resolve();
+            return this.transfer(toolActions.resetBorderPolicies);
         }
 
         this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
@@ -661,7 +663,7 @@ define(function (require, exports) {
     };
     close.reads = [locks.JS_APP, locks.JS_DOC];
     close.writes = [locks.JS_UI, locks.PS_APP, locks.PS_DOC];
-    close.transfers = [ui.cloak, disposeDocument];
+    close.transfers = [ui.cloak, disposeDocument, toolActions.resetBorderPolicies];
     close.lockUI = true;
     close.post = [_verifyActiveDocument, _verifyOpenDocuments];
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -472,10 +472,14 @@ define(function (require, exports) {
                 } else {
                     this.dispatch(events.document.RESET_LAYERS, payload);
                 }
+            })
+            .then(function () {
+                return this.transfer(tools.resetBorderPolicies);
             });
     };
     resetLayers.reads = [locks.PS_DOC];
     resetLayers.writes = [locks.JS_DOC];
+    resetLayers.transfers = [tools.resetBorderPolicies];
 
     /**
      * Emit a RESET_BOUNDS with bounds descriptors for the given layers.

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -276,7 +276,8 @@ define(function (require, exports) {
             .bind(this)
             .then(function () {
                 return this.transfer(policy.addPointerPolicies, pointerPolicyList);
-            }).then(function (policyID) {
+            })
+            .then(function (policyID) {
                 _currentTransformPolicyID = policyID;
             
                 return this.transfer(guides.resetGuidePolicies);


### PR DESCRIPTION
1. Call `resetBorderPolicies` after `resetLayers` because bounds may have changed.
2. Call `resetBorderPolicies` at the _end_ of `disposeDocument` to avoid an atomicity violation due to lack of concurrency control among non-sequential invocations of `this.transfer`. This is a SuperHack :tm:.

The latter bug is quite nasty. I realized that it existed in theory a few weeks ago, but I verified that it's causing the second problem above. In particular: `disposeDocument` transfers `resetBorderPolicies` and another action which itself transfers to `resetBorderPolicies`, but does not serialize the two transfers. The executions of the two instances of `resetBorderPolicies` interleave in a _very bad way_. This is exactly the sort of concurrency controller that the controller should be providing for us, but in this case is not. I'll file a separate issue...

Addresses #2785. Also addresses, I hypothesize, #2224.