### PR TITLE
updateDocument should block on resetBorderPolicies

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -386,7 +386,7 @@ define(function (require, exports) {
                     }.bind(this))
                     .bind(this)
                     .then(function () {
-                        this.transfer(toolActions.resetBorderPolicies);
+                        return this.transfer(toolActions.resetBorderPolicies);
                     });
             });
     };


### PR DESCRIPTION
This delays `updateDocument` from resolving until after its call to `resetBorderPolicies` finishes. Note that it is **NEVER** OK to call `transfer` without blocking on the promise that is returned!

Along with #2790, I hypothesize that this is a very narrow fix for #2224. (@ktaki is verifying this now.)