### PR TITLE
Add shortcuts.addShortcuts to add shortcuts

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -140,6 +140,7 @@ define(function (require, exports, module) {
         },
         shortcut: {
             ADD_SHORTCUT: "addShortcut",
+            ADD_SHORTCUTS: "addShortcuts",
             REMOVE_SHORTCUT: "removeShortcut"
         },
         style: {

--- a/src/js/stores/shortcut.js
+++ b/src/js/stores/shortcut.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
             this.bindActions(
                 events.RESET, this._handleReset,
                 events.shortcut.ADD_SHORTCUT, this._handleAddShortcut,
+                events.shortcut.ADD_SHORTCUTS, this._handleAddShortcuts,
                 events.shortcut.REMOVE_SHORTCUT, this._handleRemoveShortcut
             );
 
@@ -68,7 +69,8 @@ define(function (require, exports, module) {
          *    key: number|string,
          *    modifiers: object,
          *    fn: function,
-         *    capture: boolean: policy: number }
+         *    capture: boolean,
+         *    policy: number }
          */
         _handleAddShortcut: function (payload) {
             if (!payload.id) {
@@ -76,6 +78,16 @@ define(function (require, exports, module) {
             }
 
             this._shortcuts.push(payload);
+        },
+
+        /**
+         * Handler for the ADD_SHORTCUTS event.
+         * 
+         * @private
+         * @param {{specs: Array.<Shortcut>}} payload 
+         */
+        _handleAddShortcuts: function (payload) {
+            payload.specs.forEach(this._handleAddShortcut, this);
         },
 
         /**


### PR DESCRIPTION
1. Add a new `shortcuts.addShortcuts` action to add shortcuts in bulk.
2. Use one call to `shortcuts.addShortcuts` in `tools.beforeStartup`. Previously, we were doing separate transfers for each call to `shortcuts.addShortcut` (singular) which was both bad for performance (N redundant policy calls in the adapter instead of one) and a concurrency-safety problem waiting to happen. 

Addresses: concerns.