### PR TITLE
Wait to change vector mask mode until document is initialized

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -606,14 +606,16 @@ define(function (require, exports) {
                     .then(function () {
                         var initPromise = this.transfer(initActiveDocument),
                             uiPromise = this.transfer(ui.updateTransform),
-                            recentFilesPromise = this.transfer(application.updateRecentFiles),
-                            disableMaskPromise = this.transfer(toolActions.changeVectorMaskMode, false);
+                            recentFilesPromise = this.transfer(application.updateRecentFiles);
 
-                        return Promise.join(initPromise, uiPromise, recentFilesPromise, disableMaskPromise);
+                        return Promise.join(initPromise, uiPromise, recentFilesPromise);
                     }, function () {
                         // If file doesn't exist anymore, user will get an Open dialog
                         // If user cancels out of open dialog, PS will throw, so catch it here
                         this.transfer(menu.native, { commandID: _OPEN_DOCUMENT, waitForCompletion: true });
+                    })
+                    .then(function () {
+                        return this.transfer(toolActions.changeVectorMaskMode, false);
                     });
             });
     };

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -540,8 +540,13 @@ define(function (require, exports) {
         }
 
         var appStore = flux.store("application"),
-            currentDocument = appStore.getCurrentDocument(),
-            currentLayers = currentDocument.layers.selected,
+            currentDocument = appStore.getCurrentDocument();
+
+        if (!currentDocument) {
+            return Promise.resolve();
+        }
+
+        var currentLayers = currentDocument.layers.selected,
             currentLayer = currentLayers.first();
 
         // vector mask mode requires an avtive layer


### PR DESCRIPTION
1. Abort `changeVectorMaskMode` early if there is no document open.
2. Do not `changeVectorMaskMode` in `documents.open` until the document has been initialized.

Addresses #2779. 