### PR TITLE
Dismiss the export dialog on wheel events

### DIFF
--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -169,6 +169,23 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Dismiss the dialog on mouse wheel events.
+         *
+         * @private
+         */
+        _handleMouseWheel: function () {
+            if (!this.state.open) {
+                return;
+            }
+
+            var id = this.props.id,
+                flux = this.getFlux();
+
+            this._target = null;
+            flux.actions.dialog.closeDialogThrottled(id);
+        },
+
+        /**
          * Handle window resize events, closing the open dialog.
          *
          * @param {Event} event
@@ -227,8 +244,11 @@ define(function (require, exports, module) {
         _addListeners: function () {
             if (this.props.dismissOnWindowClick) {
                 window.addEventListener("click", this._handleWindowClick);
-            } else if (this.props.dismissOnCanvasClick) {
+            }
+
+            if (this.props.dismissOnCanvasClick) {
                 os.once(os.eventKind.EXTERNAL_MOUSE_DOWN, this.toggle);
+                os.once("externalMouseWheel", this._handleMouseWheel);
             }
 
             if (this.props.dismissOnWindowResize) {
@@ -250,6 +270,11 @@ define(function (require, exports, module) {
         _removeListeners: function () {
             if (this.props.dismissOnWindowClick) {
                 window.removeEventListener("click", this._handleWindowClick);
+            }
+
+            if (this.props.dismissOnCanvasClick) {
+                os.removeListener(os.eventKind.EXTERNAL_MOUSE_DOWN, this.toggle);
+                os.removeListener("externalMouseWheel", this._handleMouseWheel);
             }
 
             if (this.props.dismissOnWindowResize) {


### PR DESCRIPTION
Addresses #2424. 

Ideally I think these would just be suppressed, but I'm not sure how to do that and I _am_ sure how to do this! All dialogs with a `dismissOnCanvasClick` policy will have the same behavior. 

PS: actually, I do know how to suppress these events: by using a policy over the canvas region. But, that seems fairly risky compared to this simple change.

Also note: this does _not_ address a similar problem with pinch-to-zoom. To handle that, we would need to do something at a very different level because there are no adapter os events for the pinch gesture. For example, the cloaking mechanism would have to know whether or not there is a dialog open that is on top of the canvas. So, this is definitely still an issue, but one that I think will have to be addressed separately!