### PR TITLE
Menu stores now listens for UNGROUP_SELECTED

### DIFF
--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.DELETE_LAYERS, this._updateMenuItems,
                 events.document.history.nonOptimistic.DELETE_LAYERS, this._updateMenuItems,
                 events.document.history.optimistic.GROUP_SELECTED, this._updateMenuItems,
+                events.document.history.nonOptimistic.UNGROUP_SELECTED, this._updateMenuItems,
                 events.document.history.optimistic.REPOSITION_LAYERS, this._updateMenuItems,
                 events.document.REPOSITION_LAYERS, this._updateMenuItems,
                 events.document.history.optimistic.RESIZE_LAYERS, this._updateMenuItems,


### PR DESCRIPTION
This addresses #2652 
When ungrouping layers, the menu was not recognizing this change, and so in some cases the "undo" menu item was left inactive.