### PR TITLE
Fixed size of reference tool

### DIFF
--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -450,11 +450,3 @@
         flex-grow: 0;
     }
 }
-
-.control-group {
-    .reference-none {
-        width: 2.2rem;
-        height: 2.2rem;
-        fill: @icon-active;
-    }
-}


### PR DESCRIPTION
Okay, chatted with @placegraphichere and decided on keeping the icon at the 24px sizing that it natively is...which ended up being achieved by deleting some CSS. 