### PR TITLE
 Improve export service startup to not lock other actions, better error handling on post-export asset updates

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -187,7 +187,7 @@ define(function (require, exports) {
                         filePath: pathArray[0],
                         status: ExportAsset.STATUS.STABLE
                     };
-                    return this.flux.actions.export.updateExportAsset(document, _layers, assetIndex, assetProps,
+                    this.flux.actions.export.updateExportAsset(document, _layers, assetIndex, assetProps,
                         true, true);
                 },
                 function (e) {
@@ -199,7 +199,7 @@ define(function (require, exports) {
                         status: ExportAsset.STATUS.ERROR
                     };
 
-                    return this.flux.actions.export.updateExportAsset(document, _layers, assetIndex, assetProps,
+                    this.flux.actions.export.updateExportAsset(document, _layers, assetIndex, assetProps,
                         true, true);
                 })
             .catch(function (e) {
@@ -878,7 +878,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     log.debug("Export: Generator plugin connection established");
-                    return this.flux.actions.export.setServiceAvailable(true);
+                    this.flux.actions.export.setServiceAvailable(true);
                 })
                 .return(true);
         }.bind(this);

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -737,7 +737,7 @@ define(function (require, exports) {
             });
     };
     exportLayerAssets.reads = [locks.JS_DOC];
-    exportLayerAssets.writes = [locks.JS_EXPORT, locks.GENERATOR];
+    exportLayerAssets.writes = [locks.JS_EXPORT];
     exportLayerAssets.transfers = [promptForFolder, addAsset, setServiceAvailable];
 
     /**
@@ -792,7 +792,7 @@ define(function (require, exports) {
             });
     };
     exportDocumentAssets.reads = [locks.JS_DOC, locks.JS_EXPORT];
-    exportDocumentAssets.writes = [locks.GENERATOR];
+    exportDocumentAssets.writes = [];
     exportDocumentAssets.transfers = [promptForFolder, addAsset, setServiceAvailable];
     
     /**
@@ -810,7 +810,7 @@ define(function (require, exports) {
         return _exportService.copyFile(sourcePath, targetPath);
     };
     copyFile.reads = [];
-    copyFile.writes = [locks.GENERATOR];
+    copyFile.writes = [];
     copyFile.transfers = [setServiceAvailable];
     
     /**
@@ -827,7 +827,7 @@ define(function (require, exports) {
         return _exportService.deleteFiles(filePaths);
     };
     deleteFiles.reads = [];
-    deleteFiles.writes = [locks.GENERATOR];
+    deleteFiles.writes = [];
     deleteFiles.transfers = [setServiceAvailable];
 
     /**
@@ -936,7 +936,7 @@ define(function (require, exports) {
             });
     };
     afterStartup.reads = [];
-    afterStartup.writes = [locks.GENERATOR];
+    afterStartup.writes = [];
 
     /**
      * Handle the standard onReset action

--- a/src/js/locks.js
+++ b/src/js/locks.js
@@ -54,8 +54,7 @@ define(function (require, exports, module) {
         JS_EXPORT: "jsExport",
         JS_SEARCH: "jsSearch",
         CC_LIBRARIES: "ccLibraries",
-        OS_CLIPBOARD: "osClipboard",
-        GENERATOR: "generator"
+        OS_CLIPBOARD: "osClipboard"
     };
 
     /**
@@ -80,7 +79,7 @@ define(function (require, exports, module) {
         LOCKS.PS_MENU
     ];
 
-    var ALL_NATIVE_LOCKS = ALL_PS_LOCKS.concat(LOCKS.CC_LIBRARIES, LOCKS.OS_CLIPBOARD, LOCKS.GENERATOR);
+    var ALL_NATIVE_LOCKS = ALL_PS_LOCKS.concat(LOCKS.CC_LIBRARIES, LOCKS.OS_CLIPBOARD);
 
     module.exports = LOCKS;
     module.exports.ALL_LOCKS = ALL_LOCKS;


### PR DESCRIPTION
There are three components to this PR, the first two of which address #2799, and the other fixes an unreported bug that I noticed while testing.

1. When export service completes its initialization, it updates the store's "available" flag via a separate flux action (instead of transfer) so that it only gets the JS_EXPORT lock when it needs it, thus not preventing other actions in the meantime.
1. Remove the GENERATOR lock entirely.  Because the plugin's websocket interface will allow concurrent calls, there is no practical need for this lock. *This* lock (held by the export's afterStartup action) was preventing the `document.close` action which uses generator to clean up old temp files.
1. Allow (only) the post-export asset update to fail silently - these updates are not strictly necessary and should not cause a reset.  See below for more info.

The unreported bug:
Changing documents during a batch export will throw a bunch of errors when trying to update the assets in the "extension data" of the now-inactive document.  So now we just swallow those errors.  This could mean that the assets don't get updated correctly with the "STABLE" status, nor the file location, but that seems like an acceptable risk.  This might be fixable on the core side in the future by allowing extension data updates of inactive documents, if it becomes important.