### PR TITLE
Suspend/Restore event policies around menu's place commands.

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -160,15 +160,6 @@ define(function (require, exports) {
      * @type {LibrarySyncStatus}
      */
     var _librarySyncStatus;
-    
-    /**
-     * Event handlers initialized in beforeStartup.
-     *
-     * @private
-     * @type {function()}
-     */
-    var _placeEventHandler,
-        _toolModalStateChangedHandler;
 
     /**
      * Finds a usable representation for the image element that PS will accept
@@ -1186,6 +1177,14 @@ define(function (require, exports) {
         
         this.flux.actions.preferences.setPreference(_LAST_SELECTED_LIBRARY_ID_PREF, libraryState.currentLibraryID);
     };
+    
+    /**
+     * Event handlers initialized in beforeStartup.
+     *
+     * @private
+     * @type {function()}
+     */
+    var _toolModalStateChangedHandler;
 
     var beforeStartup = function () {
         var dependencies = {
@@ -1212,19 +1211,12 @@ define(function (require, exports) {
                 ELEMENT_COLORTHEME_TYPE
             ]
         });
-        
-        _placeEventHandler = function () {
-            if (this.flux.store("library").getState().isPlacingGraphic) {
-                this.flux.actions.libraries.handleCompletePlacingGraphic();
-            }
-        }.bind(this);
-        descriptor.addListener("placeEvent", _placeEventHandler);
 
         _toolModalStateChangedHandler = function (event) {
             var isPlacingGraphic = this.flux.store("library").getState().isPlacingGraphic,
-                modalStateCancelled = event.reason && event.reason._value === "cancel";
+                modalStateEnded = event.state && event.state._value === "exit";
 
-            if (isPlacingGraphic && modalStateCancelled) {
+            if (isPlacingGraphic && modalStateEnded) {
                 this.flux.actions.libraries.handleCompletePlacingGraphic();
             }
         }.bind(this);
@@ -1259,7 +1251,6 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var onReset = function () {
-        descriptor.removeListener("placeEvent", _placeEventHandler);
         descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
 
         return Promise.resolve();

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -160,7 +160,8 @@ define(function (require, exports, module) {
         },
         menus: {
             INIT_MENUS: "initMenus",
-            UPDATE_MENUS: "updateMenus"
+            UPDATE_MENUS: "updateMenus",
+            PLACE_COMMAND: "placeCommand"
         },
         preferences: {
             SET_PREFERENCE: "setPreference",

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -45,6 +45,12 @@ define(function (require, exports, module) {
          * @type {MenuBar}
          */
         _applicationMenu: null,
+        
+        /**
+         * @private
+         * @type {boolean}
+         */
+        _isExecutingPlaceCommand: null,
 
         /**
          * Initialize the policy sets
@@ -56,6 +62,7 @@ define(function (require, exports, module) {
                 events.application.UPDATE_RECENT_FILES, this._updateRecentFiles,
                 events.menus.INIT_MENUS, this._handleMenuInitialize,
                 events.menus.UPDATE_MENUS, this._updateMenuItems,
+                events.menus.PLACE_COMMAND, this._handlePlaceCommand,
 
                 events.document.SELECT_DOCUMENT, this._updateMenuItems,
                 events.document.DOCUMENT_UPDATED, this._updateMenuItems,
@@ -124,6 +131,13 @@ define(function (require, exports, module) {
          */
         _handleReset: function () {
             this._applicationMenu = new MenuBar();
+            this._isExecutingPlaceCommand = false;
+        },
+        
+        getState: function () {
+            return {
+                isExecutingPlaceCommand: this._isExecutingPlaceCommand
+            };
         },
 
         /**
@@ -206,6 +220,17 @@ define(function (require, exports, module) {
         _updateMenuItems: function () {
             this.waitFor(["document", "application", "dialog", "preferences", "history", "export"],
                 this._updateMenuItemsHelper);
+        },
+        
+        /**
+         * Handle status update of place command.
+         *
+         * @private
+         * @param {object} payload
+         * @param {boolean} payload.executing
+         */
+        _handlePlaceCommand: function (payload) {
+            this._isExecutingPlaceCommand = payload.executing;
         },
 
         /**


### PR DESCRIPTION
This is similar to libraries drag-n-drop, the event policies have to be suspended before executing place commands via the menu item, and then restored afterward; otherwise, DS will be freezed. Addresses issue #2770 