### PR TITLE
Sampler - addresses 2777 & 2826

### DIFF
--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -393,7 +393,7 @@ define(function (require, exports) {
      *
      * @param {Document} document
      * @param {?Immutable.Iterable.<Layer>} targetLayers Default is selected in the document
-     * @param {Layer} source
+     * @param {LayerEffectsMap} source
      * @param {object} options
      * @return {Promise}
      */

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -326,7 +326,7 @@ define(function (require, exports) {
             return Promise.resolve();
         }
         
-        return this.transfer(layerFXActions.duplicateLayerEffects, doc, selectedLayers, sourceLayer);
+        return this.transfer(layerFXActions.duplicateLayerEffects, doc, selectedLayers, sourceLayer.effects);
     };
 
     /**

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -407,6 +407,25 @@ define(function (require, exports, module) {
                             d3.event.stopPropagation();
                         }.bind(this));
                 } else if (sample.type === "typeStyle") {
+                    var applyTypeStyleFunc = function () {
+                        if (sample.value) {
+                            // Apply the type style to selected layers
+                            fluxActions.type.applyTextStyle(this.state.document, null, sample.value);
+                        }
+                        d3.event.stopPropagation();
+                    }.bind(this);
+                    
+                    // background rectangle for the icon so it's clickable easier
+                    this._hudGroup
+                        .append("rect")
+                        .attr("x", iconLeft)
+                        .attr("y", iconTop)
+                        .attr("width", iconSize)
+                        .attr("height", iconSize)
+                        .classed("sampler-hud-background", true)
+                        .classed("sampler-hud-icon-disabled", !sample.value)
+                        .on("click", applyTypeStyleFunc);
+                        
                     this._hudGroup
                         .append("use")
                         .attr("xlink:href", "img/ico-sampler-charStyle.svg#sampler-charStyle")
@@ -416,13 +435,7 @@ define(function (require, exports, module) {
                         .attr("height", iconSize)
                         .classed("sampler-hud", true)
                         .classed("sampler-hud-icon-disabled", !sample.value)
-                        .on("click", function () {
-                            if (sample.value) {
-                                // Apply the type style to selected layers
-                                fluxActions.type.applyTextStyle(this.state.document, null, sample.value);
-                            }
-                            d3.event.stopPropagation();
-                        }.bind(this));
+                        .on("click", applyTypeStyleFunc);
                 } else if (sample.type === "layerEffects") {
                     // background rectangle for the icon so it's clickable easier
                     this._hudGroup

--- a/src/js/models/effects/layereffect.js
+++ b/src/js/models/effects/layereffect.js
@@ -30,6 +30,13 @@ define(function (require, exports, module) {
     var Shadow = require("./shadow"),
         Stroke = require("./stroke"),
         ColorOverlay = require("./coloroverlay");
+
+    /**
+     * Map of layer effects map by effect types. A complete list of all types is defined in LayerEffect.TYPES. 
+     * Empty effect types will have an empty immutable list as default value. 
+     * 
+     * @typedef {Immutable.Map.< string, Immutable.List<?(Shadow|ColorOverlay|Stroke|LayerEffect)> >} LayerEffectsMap
+     */
     
     /**
      * Model for a layer's unsupported effects.
@@ -153,7 +160,7 @@ define(function (require, exports, module) {
      * Layer effect types to empty immutable list. This is the default value for LayerEffect.fromLayerDescriptor
      *
      * @const
-     * @type { Immutable.Map.<string, Immutable.List>}
+     * @type {LayerEffectsMap}
      */
     LayerEffect.EMPTY_EFFECTS = new Immutable.Map(LayerEffect.TYPES.toJS().reduce(function (result, type) {
         result[type] = new Immutable.List();
@@ -177,7 +184,7 @@ define(function (require, exports, module) {
      * For those layer effects that a layer does not have, they will assign with an empty immutable list.
      *
      * @param {object} layerDescriptor
-     * @return {Immutable.Map.<string, Immutable.List<LayerEffect|Shadow>>}
+     * @return {LayerEffectsMap}
      */
     LayerEffect.fromLayerDescriptor = function (layerDescriptor) {
         var layerEffects = layerDescriptor.layerEffects;

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -165,7 +165,7 @@ define(function (require, exports, module) {
          * For effect types that the layer does not have, they will assign with an 
          * empty immutable list as default value.
          * 
-         * @type {Immutable.Map.< string, Immutable.List<LayerEffect|Shadow> >}
+         * @type {LayerEffectsMap}
          */
         effects: null,
 


### PR DESCRIPTION
This PR addresses the following sampler issues:

#2777 Sampling Text via HUD sometimes fails on first click, takes 2nd or double-clicks

#2826 Sampler: Shift + click to sample Typeface fails. This is fixed by increasing the clickable area of the type button in the HUB.