### PR TITLE
Delay rendering document header until inactive documents are loaded

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -293,7 +293,11 @@ define(function (require, exports) {
                     });
             }, this);
 
-        return Promise.all(otherDocPromises);
+        return Promise.all(otherDocPromises)
+            .bind(this)
+            .then(function () {
+                this.dispatch(events.application.INITIALIZED, { item: "inactiveDocuments" });
+            });
     };
     initInactiveDocuments.reads = [locks.PS_DOC];
     initInactiveDocuments.writes = [locks.JS_DOC];

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -63,7 +63,8 @@ define(function (require, exports, module) {
                 applicationState = applicationStore.getState(),
                 documentIDs = applicationState.documentIDs,
                 document = applicationStore.getCurrentDocument(),
-                count = applicationStore.getDocumentCount();
+                count = applicationStore.getDocumentCount(),
+                inactiveDocumentsInitialized = applicationState.inactiveDocumentsInitialized;
 
             return {
                 document: document,
@@ -71,7 +72,8 @@ define(function (require, exports, module) {
                 count: count,
                 maskModeActive: toolState.vectorMaskMode,
                 searchActive: searchActive,
-                exportActive: exportActive
+                exportActive: exportActive,
+                inactiveDocumentsInitialized: inactiveDocumentsInitialized
             };
         },
 
@@ -119,7 +121,18 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            return this.state.count !== nextState.count ||
+            // Don't re-render if we're just going temporarily inactive so that
+            // the UI doesn't blink unnecessarily.
+            if (this.props.active && !nextProps.active) {
+                return false;
+            }
+
+            if (!nextState.inactiveDocumentsInitialized) {
+                return false;
+            }
+
+            return this.state.inactiveDocumentsInitialized !== nextState.inactiveDocumentsInitialized ||
+                this.state.count !== nextState.count ||
                 this.state.headerWidth !== nextState.headerWidth ||
                 this.state.searchActive !== nextState.searchActive ||
                 this.state.exportActive !== nextState.exportActive ||

--- a/src/js/stores/application.js
+++ b/src/js/stores/application.js
@@ -99,6 +99,7 @@ define(function (require, exports, module) {
             return {
                 hostVersion: this._hostVersion,
                 activeDocumentInitialized: this._initialized.get("activeDocument"),
+                inactiveDocumentsInitialized: this._initialized.get("inactiveDocuments"),
                 recentFilesInitialized: this._initialized.get("recentFiles"),
                 documentIDs: this._documentIDs,
                 selectedDocumentIndex: this._selectedDocumentIndex,


### PR DESCRIPTION
This prevents the document tabs from mounting one at a time, which is distracting. Yes, it delays the render somewhat, but since we initialize documents lazily now, it shouldn't slow things down too much. This also prevents a re-render from happening when the controller resets.

Addresses #2843.
