### PR TITLE
Redraw on-canvas UI when display configuration changes

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -526,6 +526,9 @@ define(function (require, exports) {
     zoomInOut.writes = [];
     zoomInOut.transfers = [zoom];
 
+    /**
+     * Emit a DISPLAY_CHANGED event.
+     */
     var handleDisplayConfigurationChanged = function () {
         return this.dispatchAsync(events.ui.DISPLAY_CHANGED);
     };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -135,7 +135,8 @@ define(function (require, exports, module) {
             PANELS_RESIZED: "panelsResized",
             TOGGLE_OVERLAYS: "toggleOverlays",
             SUPERSELECT_MARQUEE: "superselectMarquee",
-            REFERENCE_POINT_CHANGED: "referencePointChanged"
+            REFERENCE_POINT_CHANGED: "referencePointChanged",
+            DISPLAY_CHANGED: "displayChanged"
         },
         modifiers: {
             MODIFIERS_CHANGED: "modifiersChanged"

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -269,18 +269,18 @@ define(function (require, exports, module) {
             var samples = _.filter(this.state.sampleTypes, "value"),
                 mouseX = this.state.samplePoint.x,
                 mouseY = this.state.samplePoint.y,
-                pxToRem = this.getFlux().store("ui").pxToRem;
+                remToPx = this.getFlux().store("ui").remToPx;
             
             if (samples.length === 0) {
                 return;
             }
 
             // Constants
-            var sampleSize = pxToRem(40),
+            var sampleSize = remToPx(2.5),
                 rectWidth = (sampleSize * samples.length) + (sampleSize / 3),
                 rectHeight = Math.round(sampleSize * 1.25),
                 rectTLXOffset = -rectWidth / 2,
-                rectTLYOffset = -sampleSize - pxToRem(26),
+                rectTLYOffset = -sampleSize - remToPx(1.625),
                 rectRound = sampleSize / 6;
 
             var rectTLX = Math.round(mouseX + rectTLXOffset),
@@ -292,7 +292,7 @@ define(function (require, exports, module) {
                 { x: mouseX - sampleSize * 0.20833, y: mouseY - sampleSize * 0.5 },
                 { x: mouseX + sampleSize * 0.20833, y: mouseY - sampleSize * 0.5 },
                 { x: mouseX + sampleSize * 0.20833, y: mouseY - sampleSize * 0.4166666667 },
-                { x: mouseX, y: mouseY - pxToRem(5) }
+                { x: mouseX, y: mouseY - remToPx(0.3125) }
             ];
 
             var lineFunction = d3.svg.line()

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -648,7 +648,7 @@ define(function (require, exports, module) {
         _checkAndDrawArtboardAdder: function (svg, artboard, otherArtboards, direction) {
             var bounds = artboard.bounds,
                 scale = this._scale,
-                pxToRem = this.getFlux().store("ui").pxToRem,
+                remToPx = this.getFlux().store("ui").remToPx,
                 checkBounds = this._getNewArtboardBounds(bounds, direction),
                 intersects = otherArtboards.some(function (artboard) {
                     return checkBounds.intersects(artboard.bounds);
@@ -659,9 +659,9 @@ define(function (require, exports, module) {
             }
 
             var adderXCenter, adderYCenter,
-                padding = pxToRem(50) * scale,
-                crosshairLength = pxToRem(7) * scale,
-                circleRadius = pxToRem(26) * scale;
+                padding = remToPx(3.125) * scale,
+                crosshairLength = remToPx(0.4375) * scale,
+                circleRadius = remToPx(1.625) * scale;
 
             switch (direction) {
                 case "n":

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -403,15 +403,15 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Converts a pixel value to a rem value based on
+         * Converts a rem value to a pixel value based on
          * root font size
          * 16 px is 1 rem, so if our font-size is 62.5% (10px)
          * all our UI should be shrunk to that as well
          * 
          * @return {number}
          */
-        pxToRem: function (px) {
-            return px * this._rootSize / 16;
+        remToPx: function (rem) {
+            return rem * this._rootSize;
         },
 
         /**

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -163,6 +163,7 @@ define(function (require, exports, module) {
                 events.ui.SUPERSELECT_MARQUEE, this._handleMarqueeStart,
                 events.ui.TOGGLE_OVERLAYS, this._handleOverlayToggle,
                 events.ui.REFERENCE_POINT_CHANGED, this._handleReferencePointChanged,
+                events.ui.DISPLAY_CHANGED, this._handleDisplayChanged,
                 events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
                 events.document.RESET_LAYERS, this._handleLayersUpdated,
                 events.document.RESET_BOUNDS, this._handleLayersUpdated,
@@ -539,7 +540,16 @@ define(function (require, exports, module) {
          */
         _handleReferencePointChanged: function (payload) {
             this._referencePoint = payload.referencePoint;
+            this.emit("change");
+        },
 
+        /**
+         * Re-set the root font size when the display changes.
+         *
+         * @private
+         */
+        _handleDisplayChanged: function () {
+            this._setRootSize();
             this.emit("change");
         }
     });


### PR DESCRIPTION
This causes the on-canvas UI (i.e., the `SamplerOverlay` and `SuperselectOverlay`) to be redrawn upon receiving a `displayConfigurationChanged` event using pixel values that are current for the new browser root-size (i.e., with the same rem value but with updated pixel value). These events are emitted when the screen resolution changes or the when the window is moved between displays. Note for testing: Chromium doesn't seem to update it's CSS breakpoints when you just change the screen resolution on a single display. But it should do so, and hence is testable, when dragging the window between displays.

This also fixes the erroneously named and defined `pxToRem` function. In fact, we're converting a rems to pixels. The function was also off by a factor of 1/16, which forced the callers to use rem values inflated by a factor of 16 in order to get reasonable-looking pixel values out. This fixes the function by renaming it, eliminating the 1/16 error factor, and factoring out 1/16 from all the call sites. _dusts hands off_

Addresses #2196.