### PR TITLE
Narrow fix for another resetBorderPolicies race

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -882,10 +882,7 @@ define(function (require, exports) {
         var dispatchPromise = this.dispatchAsync(events.document.SELECT_LAYERS_BY_ID, payload)
                 .bind(this)
                 .then(function () {
-                    var policiesPromise = this.transfer(tools.resetBorderPolicies),
-                        initializePromise = this.transfer(initializeLayers, document, nextSelected);
-
-                    return Promise.join(policiesPromise, initializePromise);
+                    return this.transfer(initializeLayers, document, nextSelected);
                 }),
             revealPromise = this.transfer(revealLayers, document, nextSelected);
 
@@ -907,8 +904,7 @@ define(function (require, exports) {
     };
     select.reads = [];
     select.writes = [locks.PS_DOC, locks.JS_DOC];
-    select.transfers = [revealLayers, resetSelection, tools.resetBorderPolicies,
-        initializeLayers, tools.changeVectorMaskMode];
+    select.transfers = [revealLayers, resetSelection, initializeLayers, tools.changeVectorMaskMode];
     select.post = [_verifyLayerSelection];
 
     /**


### PR DESCRIPTION
This is another very narrow fix for another `resetBorderPolicies` race that results in ghostly border policies. In this case, it's between the `layers.select` action and its transfer to `layers.initializeLayers`. Their calls to `resetBorderPolicies` interleave in a bad way, and the border polices are never cleaned up, which causes issues like in #2224. See for yourself:

![Nightmare fuel](https://s3.amazonaws.com/f.cl.ly/items/2a2n1J1n3R2M2P0P1w0z/Screen%20Recording%202015-10-06%20at%2003.49%20PM.gif "Nightmare fuel")

Fixing this one was easy (`initializeLayers` always calls `resetBorderPolicies` anyway, so I just removed the other, redundant call), but these sure are fun to find! Recall that #2794 intends to make this entire class of bugs go away forever.