### PR TITLE
Moved the dirty document indicator and changed the color to red

### DIFF
--- a/src/js/jsx/DocumentHeaderTab.jsx
+++ b/src/js/jsx/DocumentHeaderTab.jsx
@@ -82,9 +82,9 @@ define(function (require, exports, module) {
                         "document-title__mask": this.state.vectorMode && this.props.current
                     })}
                     onClick={this.props.onClick}>
+                    {warning}
                     {this.props.dirty ? "*" : ""}
                     {this.props.name}
-                    {warning}
                 </div>
             );
         }

--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -72,6 +72,11 @@
     overflow-x: scroll;
 }
 
+.document-controls__unsupported {
+    color: red;
+    padding-right: .5rem;
+}
+
 .icon-header {
     height: @no-border-for-canvas-height;
     line-height: @toolbar-button-size;


### PR DESCRIPTION
Regarding issue #2842 

Now looks like:
![](https://www.dropbox.com/s/tq3m0w9m8iwkit6/Screenshot%202015-10-07%2011.13.14.png?raw=1 "Logo Title Text 1")