### PR TITLE
Added a border around .document-container instead of shadow

### DIFF
--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -134,5 +134,7 @@
     flex-shrink: 1;
     flex-grow: 10;
     background-color: @bg-panel;
-    box-shadow: inset 0 (-2 * @hairline) 0 @bg-border-for-canvas, inset 0 (2 * @hairline) 0 @bg-border, inset (2 * @hairline) 0 0 @bg-no-border-for-canvas, inset (-2 * @hairline) 0 0 @bg-no-border-for-canvas;
+    border-left: (2 * @hairline) solid @bg-border;
+    border-right: (2 * @hairline) solid @bg-border;
+    border-top: (2 * @hairline) solid @bg-border;
 }


### PR DESCRIPTION
Regarding issue #2711 

Now looks like:
![](https://www.dropbox.com/s/3lled7gzw67ymx7/Screenshot%202015-10-07%2012.32.19.png?raw=1)

![](https://www.dropbox.com/s/xcp150jgvk4kcqp/docheaderscroll.gif?raw=1)