### PR TITLE
Don't add/remove arrow keyboard policies on focus

### DIFF
--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -320,7 +320,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartup = function () {
-        var defaultKeyboardMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
+        var defaultKeyboardMode = adapterUI.keyboardPropagationMode.FOCUS_PROPAGATE,
             keyboardModePromise = this.transfer(setMode, PolicyStore.eventKind.KEYBOARD,
                 defaultKeyboardMode),
             defaultPointerMode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE,

--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -26,47 +26,14 @@ define(function (require, exports, module) {
 
     var React = require("react");
 
-    var OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        EventPolicy = require("js/models/eventpolicy"),
-        KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
+    var OS = require("adapter/os");
 
     var log = require("js/util/log");
-
-    var arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-            OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
-        arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-            OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
-        arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-            OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT),
-        arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-            OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT);
-
-    var keyboardPolicyList = [
-        arrowUpKeyPolicy,
-        arrowDownKeyPolicy,
-        arrowLeftKeyPolicy,
-        arrowRightKeyPolicy
-    ];
-
-    var _keyboardPolicy = null;
 
     module.exports = {
         /** @ignore */
         acquireFocus: function () {
             return OS.acquireKeyboardFocus()
-                .bind(this)
-                .then(function () {
-                    if (_keyboardPolicy) {
-                        return;
-                    }
-
-                    return this.getFlux().actions.policy.addKeyboardPolicies(keyboardPolicyList)
-                        .bind(this)
-                        .then(function (policy) {
-                            _keyboardPolicy = policy;
-                        });
-                })
                 .catch(function (err) {
                     var message = err instanceof Error ? (err.stack || err.message) : err;
 
@@ -75,19 +42,8 @@ define(function (require, exports, module) {
         },
         /** @ignore */
         releaseFocus: function () {
-            var keyboardPolicy;
-            if (_keyboardPolicy) {
-                keyboardPolicy = _keyboardPolicy;
-                _keyboardPolicy = null;
-            }
-
             return OS.releaseKeyboardFocus()
                 .bind(this)
-                .then(function () {
-                    if (keyboardPolicy) {
-                        return this.getFlux().actions.policy.removeKeyboardPolicies(keyboardPolicy, true);
-                    }
-                })
                 .catch(function (err) {
                     var message = err instanceof Error ? (err.stack || err.message) : err;
 

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -145,26 +145,14 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),
             enterKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER),
-            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
-            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
-            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT),
-            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER);
 
         this.keyboardPolicyList = [
             escapeKeyPolicy,
             tabKeyPolicy,
             deleteKeyPolicy,
             backspaceKeyPolicy,
-            enterKeyPolicy,
-            arrowUpKeyPolicy,
-            arrowDownKeyPolicy,
-            arrowLeftKeyPolicy,
-            arrowRightKeyPolicy
+            enterKeyPolicy
         ];
 
         var pointerPolicy = new PointerEventPolicy(UI.policyAction.NEVER_PROPAGATE,

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -138,25 +138,13 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),
             deleteKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE),
-            arrowLeftPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT),
-            arrowUpPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
-            arrowRightPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT),
-            arrowDownPolicy = new KeyboardEventPolicy(UI.policyAction.ALWAYS_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE);
             
         this.keyboardPolicyList = [
             escapeKeyPolicy, // Switch back to newSelect
             enterKeyPolicy, // Switch back to newSelect
             backspaceKeyPolicy, // Delete selected vertices
-            deleteKeyPolicy, // Delete selected vertices
-            arrowLeftPolicy, // We want all arrow keys to go into Photoshop in vector edit mode
-            arrowDownPolicy,
-            arrowRightPolicy,
-            arrowUpPolicy
+            deleteKeyPolicy // Delete selected vertices
         ];
 
         this.selectHandler = _selectHandler;


### PR DESCRIPTION
This removes a fertile source of errors with keyboard policies. Many moons ago @pineapplespatula had to add these so that arrow keys worked correctly in CEF text inputs while in the type modal tool state. This creates a bit of a concurrency nightmare, however, which was never fully addressed. See, e.g., #2650. However, @jfitz-adobe has recently relieved us of the need to install these arrow keyboard policies. This removes the `Focusable` keyboard policies entirely, and thus reduces the number of places where we can hurt ourselves with policy manipulation.

Should fully address #2650. Requires >= Mac pgdev.734, or whatever the latest Windows build was when this PR was filed.

(Also, it would be great to verify this on Windows too.)