### PR TITLE
Number input for text values made larger

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -683,6 +683,7 @@ define(function (require, exports, module) {
                                 disabled={locked}
                                 min={MIN_TRACKING}
                                 max={MAX_TRACKING}
+                                size="column-5"
                                 onChange={this._handleTrackingChange}
                                 valueType="size" />
                         </div>
@@ -696,6 +697,7 @@ define(function (require, exports, module) {
                             <NumberInput
                                 value={locked ? null : leadings}
                                 precision={2}
+                                size="column-5"
                                 min={toPixels(MIN_LEADING_PTS)}
                                 max={toPixels(MAX_LEADING_PTS)}
                                 disabled={locked}


### PR DESCRIPTION
Regarding issue #2821 

Before: 
![](https://www.dropbox.com/s/t6kg5m656e4h1i8/Screenshot%202015-10-08%2011.17.27.png?raw=1)

After:
![](https://www.dropbox.com/s/xgjdka8zmxe6ibt/Screenshot%202015-10-08%2011.17.01.png?raw=1)
