### PR TITLE
Addresses issue that restoring policy will set to incorrect mode

### DIFF
--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -320,29 +320,20 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartup = function () {
-        var keyboardMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
-            keyboardDescriptor = {
-                defaultMode: keyboardMode
-            },
-            keyboardModePromise = adapterUI.setKeyboardPropagationMode(keyboardDescriptor)
-                .bind(this)
-                .then(function () {
-                    this.dispatch(events.policies.MODE_CHANGED, {
-                        kind: PolicyStore.eventKind.KEYBOARD,
-                        mode: keyboardMode
-                    });
-                }),
-            pointerMode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE,
-            // Alpha is the default pointer mode, so we don't need to change it here
-            pointerModePromise = this.dispatchAsync(events.policies.MODE_CHANGED, {
-                kind: PolicyStore.eventKind.POINTER,
-                mode: pointerMode
-            });
+        var defaultKeyboardMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
+            keyboardModePromise = this.transfer(setMode, PolicyStore.eventKind.KEYBOARD,
+                defaultKeyboardMode),
+            defaultPointerMode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE,
+            // Alpha is the default pointer mode, but we set it here anyway so that we can reset 
+            // to the correct default mode when error occurs.
+            pointerModePromise = this.transfer(setMode, PolicyStore.eventKind.POINTER,
+                defaultPointerMode);
 
         return Promise.join(keyboardModePromise, pointerModePromise);
     };
     beforeStartup.reads = [];
     beforeStartup.writes = [locks.PS_APP, locks.JS_POLICY];
+    beforeStartup.transfers = ["policy.setMode"];
 
     exports.syncPolicies = syncPolicies;
     exports.setMode = setMode;

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -418,7 +418,7 @@ define(function (require, exports) {
     selectTool.reads = [];
     selectTool.writes = [locks.JS_TOOL, locks.PS_TOOL];
     selectTool.transfers = [resetBorderPolicies, policy.removePointerPolicies, installShapeDefaults,
-        policy.removeKeyboardPolicies, policy.addPointerPolicies, policy.addKeyboardPolicies,
+        policy.removeKeyboardPolicies, policy.addPointerPolicies, policy.addKeyboardPolicies, policy.setMode,
         shortcuts.addShortcut, shortcuts.removeShortcut];
     selectTool.modal = true;
 

--- a/src/js/tools/sampler.js
+++ b/src/js/tools/sampler.js
@@ -33,7 +33,9 @@ define(function (require, exports, module) {
         EventPolicy = require("js/models/eventpolicy"),
         PointerEventPolicy = EventPolicy.PointerEventPolicy,
         SamplerOverlay = require("jsx!js/jsx/tools/SamplerOverlay"),
-        shortcuts = require("js/util/shortcuts");
+        shortcuts = require("js/util/shortcuts"),
+        policyActions = require("js/actions/policy"),
+        PolicyStore = require("js/stores/policy");
 
     /**
      * Used by sampler HUD, we listen to OS notifications to update the locations
@@ -60,19 +62,18 @@ define(function (require, exports, module) {
         var selectHandler = function () {
             OS.addListener("externalMouseMove", _mouseMoveHandler);
 
-            return UI.setPointerPropagationMode({
-                defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
-            });
+            return this.transfer(policyActions.setMode, PolicyStore.eventKind.POINTER,
+                UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY);
         };
 
         var deselectHandler = function () {
             OS.removeListener("externalMouseMove", _mouseMoveHandler);
 
             return this.dispatchAsync(events.style.HIDE_HUD)
+                .bind(this)
                 .then(function () {
-                    return UI.setPointerPropagationMode({
-                        defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE
-                    });
+                    return this.transfer(policyActions.setMode, PolicyStore.eventKind.POINTER,
+                        UI.pointerPropagationMode.ALPHA_PROPAGATE);
                 });
         };
 

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
         shortcuts = require("js/util/shortcuts"),
         SuperselectOverlay = require("jsx!js/jsx/tools/SuperselectOverlay"),
         EventPolicy = require("js/models/eventpolicy"),
+        PolicyStore = require("js/stores/policy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
         PointerEventPolicy = EventPolicy.PointerEventPolicy;
 
@@ -66,10 +67,10 @@ define(function (require, exports, module) {
 
         if (!vectorMode || !currentDocument) {
             return descriptor.playObject(toolLib.setToolOptions("moveTool", toolOptions))
+                .bind(this)
                 .then(function () {
-                    UI.setPointerPropagationMode({
-                        defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY
-                    });
+                    return this.transfer(policy.setMode, PolicyStore.eventKind.POINTER,
+                        UI.pointerPropagationMode.ALPHA_PROPAGATE_WITH_NOTIFY);
                 });
         } else {
             var currentLayers = currentDocument.layers.selected,
@@ -99,9 +100,8 @@ define(function (require, exports, module) {
      * @private
      */
     var _deselectHandler = function () {
-        return UI.setPointerPropagationMode({
-            defaultMode: UI.pointerPropagationMode.ALPHA_PROPAGATE
-        });
+        return this.transfer(policy.setMode, PolicyStore.eventKind.POINTER,
+            UI.pointerPropagationMode.ALPHA_PROPAGATE);
     };
 
     /**


### PR DESCRIPTION
In some tool handlers, we are using `UI.setPointerPropagationMode` to set pointer mode directly and did not dispatch a `mode changed` event to the policy store, and thus the actual pointer mode is out of sync with the store. This will cause problem if we suspend/restore policy actions as the pointer mode might be restored to a wrong one. This PR replaces `UI.setPointerPropagationMode` calls with `policyActions.setMode` to make sure the policy store is in sync. This will address issue #2849