### PR TITLE
Correctly center first document in single-column mode

### DIFF
--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -298,7 +298,9 @@ define(function (require, exports, module) {
                 right = (columns !== undefined && singleColumn) ? 0 :
                     this._iconBarWidth;
 
-            if (columns === undefined || columns === this._columnCount) {
+            if (singleColumn) {
+                right += this._panelWidth;
+            } else if (columns === undefined || columns === this._columnCount) {
                 right += this._panelWidth;
             } else if (columns > 0) {
                 if (columns === 1 && this._columnCount === 2) {

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -210,7 +210,7 @@
         "BRING_ALL_TO_FRONT": "Bring All to Front",
         "NEXT_DOCUMENT": "Next Document",
         "TOGGLE_TOOLBAR": "Pin Toolbar",
-        "TOGGLE_SINGLE_COLUMN_MODE": "Single Column Mode",
+        "TOGGLE_SINGLE_COLUMN_MODE": "Single-Column Mode",
         "PREVIOUS_DOCUMENT": "Previous Document",
         "RETURN_TO_STANDARD": "Return to Standard Photoshop",
         "OPEN_DOCUMENT_ONE": "Document Name 1",


### PR DESCRIPTION
This anticipates the single-column mode overlay offsets when opening the first document from the no-doc UI. 

Addresses #2801. 

This also fixes a grammar nit.