### PR TITLE
"move" event bug fixes

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -408,11 +408,15 @@ define(function (require, exports) {
                     naiveLayerCount = document.layers.all.size + layerSpec.length;
 
                 return nextLayerCount !== naiveLayerCount;
+            })
+            .tap(function () {
+                return this.transfer(tools.resetBorderPolicies);
             });
     };
     addLayers.modal = true;
     addLayers.reads = [locks.PS_DOC];
     addLayers.writes = [locks.JS_DOC];
+    addLayers.transfers = [tools.resetBorderPolicies];
     addLayers.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1103,9 +1103,22 @@ define(function (require, exports) {
                         otherLayers = currentDoc.layers.allSelected.filterNot(function (layer) {
                             return layer.kind === layer.layerKinds.TEXT;
                         }),
+
+                        // note that in this case, the debouncing is critical even for just one "move" event
+                        // because the historyState event must be processed first for the following
+                        // "amend history" workflow to function correctly
                         textLayersPromise = this.flux.actions.layers.resetLayers(currentDoc, textLayers),
-                        otherLayersPromise = this.flux.actions.layers.resetBounds(currentDoc, otherLayers);
-                    return Promise.join(textLayersPromise, otherLayersPromise);
+                        otherLayersPromise = this.flux.actions.layers.resetBounds(currentDoc, otherLayers, true);
+
+                    // When moving a mixture of both text and non-text layers, the individual actions do not
+                    // affect history.  Instead, a single, separate event is dispatched to provide a unified
+                    // finalization of this history transaction with the updated model.
+                    return Promise.join(textLayersPromise, otherLayersPromise)
+                        .bind(this)
+                        .then(function () {
+                            return this.dispatchAsync(events.history.FINALIZE_HISTORY_STATE,
+                                { documentID: currentDoc.id });
+                        });
                 }
             }, this, 200);
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1092,14 +1092,8 @@ define(function (require, exports) {
 
             // Handle the normal move events with a debounced function
             var debouncedMoveHandler = synchronization.debounce(function () {
-                var artboardsSelected = currentDoc.layers.selected.some(function (layer) {
-                    return layer.isArtboard;
-                });
-
-                // If it was a simple click/didn't move anything, there is no need to update bounds
-                // But, if we're moving multiple artboards, we get one event with 0,0, which means
-                // we hit this and we have to update bounds
-                if (event.trackerEndedWithoutBreakingHysteresis && !artboardsSelected) {
+                // short circuit based on this trackerEndedWithoutBreakingHysteresis event flag
+                if (event.trackerEndedWithoutBreakingHysteresis) {
                     return Promise.resolve();
                 } else {
                     var textLayers = currentDoc.layers.allSelected.filter(function (layer) {

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -175,6 +175,7 @@ define(function (require, exports, module) {
             LOAD_HISTORY_STATE: "loadHistoryState",
             LOAD_HISTORY_STATE_REVERT: "loadHistoryStateRevert",
             ADJUST_HISTORY_STATE: "adjustHistoryState",
+            FINALIZE_HISTORY_STATE: "finalizeHistoryState",
             DELETE_DOCUMENT_HISTORY: "deleteDocumentHistory"
         },
         libraries: {

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -84,6 +84,7 @@ define(function (require, exports, module) {
                 events.history.LOAD_HISTORY_STATE, this._loadHistoryState,
                 events.history.LOAD_HISTORY_STATE_REVERT, this._loadLastSavedHistoryState,
                 events.history.ADJUST_HISTORY_STATE, this._adjustHistoryState,
+                events.history.FINALIZE_HISTORY_STATE, this._handlePostHistoryEvent,
                 events.history.DELETE_DOCUMENT_HISTORY, this._deleteHistory,
                 events.document.CLOSE_DOCUMENT, this._deleteHistory,
                 events.document.DOCUMENT_RENAMED, this._deleteHistory,
@@ -544,7 +545,7 @@ define(function (require, exports, module) {
 
         /**
          * A tracked-change has occurred, so we push the current state onto our history stack
-         * ad update the current pointer.  This allows for the possibility of a rogue state
+         * and update the current pointer.  This allows for the possibility of a rogue state
          * having been pushed prior, in which case this will merge instead of push.
          *
          * @param {object} payload


### PR DESCRIPTION
The primary bug this addresses is #1613, but there are a few other possibly-unreported bugs that are fixed.

## 1
When we option-dragging multiple artboards, we get two move events.  The debouncing of the event handler was causing us to NOT process the fancy event that notifies us of the duplication.  So, we weren't adding the layers to the model...and then things blew up downstream.  I rearranged the handler to only debounce the "regular" move events.  I'll be honest, I don't know why this needs to be debounced at all, but I wanted to make the most narrow change I could.

## 2
I essentially undid commit 529eb5e34a667ad3aa043a18bfc5ebae02ba309f from barkin (via PR #2672) which I can only assume means that the underlying core (events) behavior has changed.  "move" events were being ignored if it includes a truthy `trackerEndedWithoutBreakingHysteresis` AND if there are no artboards selected.  This resulted in "double counting" events when artboards were selected... which was causing a phantom history state (bad!).  I removed the latter requirement, and I feel like it is doing the right thing now.

## 3a
Fixed a bug that was causing improper model caching in our history store when moving text layers.  I fixed that, AND made it safe for moving mixture of txt and non-txt layers.  After both the resetLayers and resetBounds action complete, we dispatch a single history "finalization" event.  I think this is a step in the right direction towards a future of clearly specified history transactions (ie, not burying them inside resetLayers or resetBounds).

## 3b
Added a call to resetBorderPolicies at the end of addLayers action.  This fixed  a bug with option-drag not updating bounds around the newly created duplicate layer(s)