### PR TITLE
CC Libraries - tweaks for library creation and rename

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -545,7 +545,7 @@ define(function (require, exports) {
         
         var representation = element.getPrimaryRepresentation();
         
-        if (!EDITABLE_GRAPHIC_REPRESENTATION_TYPES.has(representation.type)) {
+        if (representation && !EDITABLE_GRAPHIC_REPRESENTATION_TYPES.has(representation.type)) {
             log.debug("[CC Lib] openGraphicForEdit: unsupported graphic type: " + representation.type);
             return Promise.resolve();
         }
@@ -895,13 +895,12 @@ define(function (require, exports) {
         var appStore = this.flux.store("application"),
             currentDocument = appStore.getCurrentDocument(),
             selectedLayers = currentDocument ? currentDocument.layers.selected : Immutable.List(),
-            selectedUnlockedLayers = selectedLayers.filter(function (l) { return !l.locked; });
+            selectedUnlockedLayers = selectedLayers.filter(function (l) { return !l.locked; }),
+            representation = element.getPrimaryRepresentation();
 
-        if (selectedUnlockedLayers.isEmpty()) {
+        if (selectedUnlockedLayers.isEmpty() || !representation) {
             return Promise.resolve();
         }
-
-        var representation = element.getPrimaryRepresentation();
 
         return Promise.fromNode(function (done) {
                 representation.getContentPath(done);

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -95,6 +95,18 @@ define(function (require, exports, module) {
         _handleLibraryRemove: function () {
             this.getFlux().actions.libraries.removeCurrentLibrary();
         },
+        
+        /**
+         * Handle create new library.
+         *
+         * @private
+         * @param {boolean} isCreating - whether or not the LibraryList is in create library mode.
+         */
+        _handleCreateLibrary: function (isCreating) {
+            this.setState({
+                isCreatingLibrary: isCreating
+            });
+        },
 
         /**
          * Return library panel content based on the connection status of CC Library.
@@ -116,6 +128,7 @@ define(function (require, exports, module) {
             if (connected) {
                 containerContents = (
                 <Library
+                    className={this.state.isCreatingLibrary && "libraries__content__hidden"}
                     addElement={this._handleAddElement}
                     lastLocallyCreatedElement={this.state.lastLocallyCreatedElement}
                     lastLocallyUpdatedGraphic={this.state.lastLocallyUpdatedGraphic}
@@ -143,6 +156,7 @@ define(function (require, exports, module) {
                         libraries={libraries}
                         selected={currentLibrary}
                         onLibraryChange={this._handleLibraryChange}
+                        onCreateLibrary={this._handleCreateLibrary}
                         disabled={!connected} />
                     {containerContents}
                     <LibraryBar

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -129,6 +129,7 @@ define(function (require, exports, module) {
             // Library's modified time reflects itself and its elements, so there is no need to check its element's 
             // modified time.
             return this.props.library !== nextProps.library ||
+                this.props.className !== nextProps.className ||
                 this._libraryLastModified !== nextProps.library.modified ||
                 !_.isEqual(this.state, nextState);
         },
@@ -256,7 +257,7 @@ define(function (require, exports, module) {
 
             if (!library || library.elements.length === 0) {
                 return (
-                    <div className="libraries__content panel__info">
+                    <div className={classnames("libraries__content panel__info", this.props.className)}>
                         <div className="panel__info__title">
                             {strings.LIBRARIES.INTRO_TITLE}
                         </div>
@@ -279,7 +280,7 @@ define(function (require, exports, module) {
                 graphicAssets = this._renderAssets("graphic", strings.LIBRARIES.GRAPHICS, Graphic),
                 brushAssets = this._renderAssets("brush", strings.LIBRARIES.BRUSHES);
             
-            var classNames = classnames("libraries__content", {
+            var classNames = classnames("libraries__content", this.props.className, {
                 "libraries__content-drag": this.state.hasDraggedItem
             });
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -138,6 +138,15 @@ define(function (require, exports, module) {
                 });
             }
         },
+        
+        /**
+         * Return the text input's current value
+         * 
+         * @return {string}
+         */
+        getValue: function () {
+            return this.state.value;
+        },
 
         /**
          * Update the value of the text input.

--- a/src/js/util/libraries.js
+++ b/src/js/util/libraries.js
@@ -139,14 +139,14 @@ define(function (require, exports) {
     var isEditableGraphic = function (element) {
         var representation = element.getPrimaryRepresentation();
         
-        return libraryActions.EDITABLE_GRAPHIC_REPRESENTATION_TYPES.has(representation.type);
+        return !!representation && libraryActions.EDITABLE_GRAPHIC_REPRESENTATION_TYPES.has(representation.type);
     };
     
     /**
      * Return the file extension of the element's primary representation.
      * 
      * @param {AdobeLibraryElement} element
-     * @return {?string}
+     * @return {string|undefined}
      */
     var getExtension = function (element) {
         if (!_REPRESENTATION_TO_EXTENSION_MAP) {
@@ -155,7 +155,7 @@ define(function (require, exports) {
         
         var representation = element.getPrimaryRepresentation();
             
-        return _REPRESENTATION_TO_EXTENSION_MAP[representation.type];
+        return representation && _REPRESENTATION_TO_EXTENSION_MAP[representation.type];
     };
 
     exports.formatCharStyle = formatCharStyle;

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -207,6 +207,10 @@
         &-drag {
             overflow-y: hidden;
         }
+        
+        &__hidden {
+            display: none;
+        }
     }
 
     &__drop-overlay {


### PR DESCRIPTION
This PR introduces the following changes:

* During library creation, the current library's content will be hidden, to reduce confusion and give user clear instruction on where to input the library name. - addresses #2197

* Hitting return / esc can confirm / cancel the current library command (creation or rename). - addresses #2864 

* Handle edge case that asset may have empty representation and will cause exception.