### PR TITLE
Fine tune the document header resizing behavior

### DIFF
--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         exportStore = require("js/stores/export");
 
     var DocumentHeader = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("application", "document", "tool", "dialog")],
+        mixins: [FluxMixin, StoreWatchMixin("application", "document", "tool", "dialog", "preferences")],
 
         getInitialState: function () {
             return {};
@@ -61,10 +61,14 @@ define(function (require, exports, module) {
                 toolState = toolStore.getState(),
                 applicationStore = flux.store("application"),
                 applicationState = applicationStore.getState(),
+                preferencesState = flux.store("preferences").getState(),
+                components = flux.store("ui").components,
                 documentIDs = applicationState.documentIDs,
                 document = applicationStore.getCurrentDocument(),
                 count = applicationStore.getDocumentCount(),
-                inactiveDocumentsInitialized = applicationState.inactiveDocumentsInitialized;
+                inactiveDocumentsInitialized = applicationState.inactiveDocumentsInitialized,
+                panelColumnCount = (preferencesState.get(components.LAYERS_LIBRARY_COL) ? 1 : 0) +
+                    (preferencesState.get(components.PROPERTIES_COL) ? 1 : 0);
 
             return {
                 document: document,
@@ -73,7 +77,8 @@ define(function (require, exports, module) {
                 maskModeActive: toolState.vectorMaskMode,
                 searchActive: searchActive,
                 exportActive: exportActive,
-                inactiveDocumentsInitialized: inactiveDocumentsInitialized
+                inactiveDocumentsInitialized: inactiveDocumentsInitialized,
+                panelColumnCount: panelColumnCount
             };
         },
 
@@ -137,16 +142,14 @@ define(function (require, exports, module) {
                 this.state.searchActive !== nextState.searchActive ||
                 this.state.exportActive !== nextState.exportActive ||
                 this.state.maskModeActive !== nextState.maskModeActive ||
+                this.state.panelColumnCount !== nextState.panelColumnCount ||
                 !Immutable.is(this.state.documentIDs, nextState.documentIDs) ||
                 !Immutable.is(this.state.document, nextState.document);
         },
 
         componentDidMount: function () {
             this._updateTabContainerScroll();
-
-            this.setState({
-                headerWidth: React.findDOMNode(this).clientWidth
-            });
+            this._updateTabContainerWidth();
 
             this._updatePanelSizesDebounced = synchronization.debounce(this._updatePanelSizes, this, 500);
             os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
@@ -163,6 +166,19 @@ define(function (require, exports, module) {
 
         componentDidUpdate: function () {
             this._updateTabContainerScroll();
+            this._updateTabContainerWidth();
+        },
+        
+        /**
+         * Update the state with the width of the tab container. 
+         *
+         * @private
+         * @param  {function=} handler - React setState handler
+         */
+        _updateTabContainerWidth: function (handler) {
+            this.setState({
+                headerWidth: this.refs.tabContainer.getDOMNode().clientWidth
+            }, handler);
         },
 
         /**
@@ -173,9 +189,7 @@ define(function (require, exports, module) {
          */
         _handleWindowResize: function () {
             return new Promise(function (resolve) {
-                this.setState({
-                    headerWidth: React.findDOMNode(this).clientWidth
-                }, resolve);
+                this._updateTabContainerWidth(resolve);
             }.bind(this));
         },
 
@@ -219,8 +233,7 @@ define(function (require, exports, module) {
         render: function () {
             var documentStore = this.getFlux().store("document"),
                 document = this.state.document,
-                smallTab = this.state.headerWidth / this.state.documentIDs.size < 175;
-            // Above: This number tunes when tabs should be shifted to small tabs
+                smallTab = this.state.documentIDs.size > this.state.headerWidth / 90;
 
             var exportDisabled = !document || document.unsupported,
                 maskDisabled = !document || document.unsupported ||

--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -36,6 +36,10 @@
     color: @item-inactive;
 }
 
+.document-title__stub {
+    flex-grow: 1;
+}
+
 .document-title:hover {
     flex-shrink: 0;
     color: @item-hover;
@@ -61,15 +65,31 @@
     padding-right: 2rem;
 }
 
-.document-header {
+.document-header-container {
+    height: @no-border-for-canvas-height;
+    overflow: hidden;
+    flex-grow: 10;
+    display: flex;
+    width: 10px;
+    flex-wrap: wrap;
+}
+
+.document-header, .document-header__hidden {
     height: @no-border-for-canvas-height;
     line-height: @no-border-for-canvas-height;
-    flex-grow: 10;
+    
+    flex-direction: row;
     position: relative;
     overflow: hidden;
     display: flex;
-    flex-shrink: 1;
+    width: 100%;
+    flex-shrink: 0;
+    flex-grow: 1;
     overflow-x: scroll;
+}
+
+.document-header__stub {
+    margin-top: @no-border-for-canvas-height;
 }
 
 .document-controls__unsupported {


### PR DESCRIPTION
This is related to issue #2558. Taki is not happy that the document header got shrinked in the middle. He is wondering if it is possible to trigger the shrinking only when the container is out of space. I couldn't come up with a easy solution for this (it requires some extra work to detect if whether or not the header will be out of space), so I adjusted its behavior to use smaller text when reach maximum header count, where the count is dynamically calculated based on the current width of the container. This looks good to me, at least the user won't be surprised that the text is shrinked in the middle.

Here is the before and after comparision: 

#### Before

![tabs-resizing](https://cloud.githubusercontent.com/assets/118264/10399908/84512838-6e6a-11e5-89a0-db3b53b39f3d.gif)


#### After

![new-tabs-resizing](https://cloud.githubusercontent.com/assets/118264/10399920/8c4e9ac0-6e6a-11e5-8738-65277462f998.gif)
