### PR TITLE
Visual changes to the Libraries panel

### DIFF
--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -213,9 +213,11 @@ define(function (require, exports, module) {
 
             return (
                 <div className={classNames}>
-                    <div className="libraries__assets__title">
-                        {title}
-                    </div>
+                    <header className="section-header section-header__no-padding">
+                        <h3 className="section-title__subtitle">
+                            {title}
+                        </h3>
+                    </header>
                     {components}
                 </div>
             );

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -466,7 +466,7 @@ define(function (require, exports) {
             return (
                 <div className="effect-list__container ">
                     <header className="section-header section-header__no-padding">
-                        <h3 className="section-title">
+                        <h3 className="section-title__subtitle">
                             {strings.STYLE.DROP_SHADOW.TITLE}
                         </h3>
                     </header>
@@ -535,7 +535,7 @@ define(function (require, exports) {
             return (
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
-                        <h3 className="section-title">
+                        <h3 className="section-title__subtitle">
                             {strings.STYLE.INNER_SHADOW.TITLE}
                         </h3>
                     </header>

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -203,6 +203,7 @@
         flex-grow: 1;
         overflow-y: auto;
         overflow-x: hidden;
+        padding-left: 1.6rem;
         
         &-drag {
             overflow-y: hidden;
@@ -243,7 +244,9 @@
         display: flex;
         flex-direction: row;
         align-items: center;
-        padding: .3rem 1.6rem;
+        padding-top: .3rem;
+        padding-bottom: .3rem;
+        padding-left: 0rem;
         -webkit-user-select: none;
         cursor: pointer;
         

--- a/src/style/shared/title-header.less
+++ b/src/style/shared/title-header.less
@@ -75,6 +75,15 @@
     opacity: .8;
 }
 
+.section-title__subtitle {
+    color: @item-inactive;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    opacity: .8;
+}
+
 .recent-files .section-title {
     border-top: none;
 }


### PR DESCRIPTION
* Used the Layers panel to compare the Libraries panel against

- Added a new class with styles for different colors for subtitles
- Restructured the DOM for the Libraries panel to match the Effects panel 
- Due to the restructuring, changed the CSS for the Libraries panel a bit to match its previous alignments. 

Pictures of before and after are in the issue this references: #2629.