### PR TITLE
Deal with smart objects with broken links

### DIFF
--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -656,7 +656,7 @@ define(function (require, exports, module) {
 
         if (!this.smartObject.linked) {
             return smartObjectTypes.EMBEDDED;
-        } else if (this.smartObject.link._obj === "ccLibrariesElement") {
+        } else if (this.smartObject.link && this.smartObject.link._obj === "ccLibrariesElement") {
             return smartObjectTypes.CLOUD_LINKED;
         } else {
             return smartObjectTypes.LOCAL_LINKED;

--- a/src/js/models/smartobject.js
+++ b/src/js/models/smartobject.js
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
     SmartObject.fromDescriptor = function (descriptor) {
         var nextSmartObject = new SmartObject(_.omit(descriptor, "link"));
 
-        if (descriptor.link) {
+        if (descriptor.link && _.isObject(descriptor.link)) {
             return nextSmartObject.set("link", new Link(descriptor.link));
         } else {
             return nextSmartObject;


### PR DESCRIPTION
It seems that if a linked smart object has a broken link, the descriptor's `linked` property is still *true* and its `link` contains a *string* instead of the fully formed *object*.

This PR contains a very narrow fix for this scenario, and I'm sure it could probably use some further clean-up.  It feels like there's a better way to model the smart object properties.  But, that would take some digging, and this is a :red_circle: Fix Now bug.  Addresses #2887 