### PR TITLE
Localization fixes for Japanese and German

### DIFF
--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
         Help = require("jsx!js/jsx/Help"),
         Search = require("jsx!js/jsx/Search"),
         ExportModal = require("jsx!js/jsx/sections/export/ExportModal"),
-        Guard = require("jsx!js/jsx/Guard");
+        Guard = require("jsx!js/jsx/Guard"),
+        system = require("js/util/system");
         
     /**
      * Chrome does not play animated svg loaded from external file via svg:use. 
@@ -143,9 +144,13 @@ define(function (require, exports, module) {
             this.props.controller.off("unlock", this._handleControllerUnlock);
         },
 
+        componentDidMount: function () {
+            window.document.documentElement.lang = system.language;
+        },
+
         render: function () {
             var hasDocument = this.getFlux().store("application").getCurrentDocument();
-            
+
             var className = classnames({
                 main: true,
                 "main__ready": this.state.ready,

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
                         <Label
                             title={strings.EXPORT.TITLE_SCALE}
                             size="column-4"
-                            className="label__medium__left-aligned">
+                            className="label__medium__left-aligned scale-title">
                             {strings.EXPORT.TITLE_SCALE}
                         </Label>
                         <Label

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -30,7 +30,7 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         classnames = require("classnames"),
         _ = require("lodash");
-        
+
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings");
@@ -377,6 +377,7 @@ define(function (require, exports) {
                             size="column-3" />
                         <Label
                             title={shadowBlurTooltip}
+                            className="blur-label"
                             size="column-2">
                             {shadowBlur}
                         </Label>
@@ -390,6 +391,7 @@ define(function (require, exports) {
                             size="column-3" />
                         <Label
                             title={shadowSpreadTooltip}
+                            className="spread-label"
                             size="column-4">
                             {shadowSpread}
                         </Label>

--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -38,7 +38,8 @@ define(function (require, exports, module) {
         FillVisiblity = Fill.FillVisibility,
         Label = require("jsx!js/jsx/shared/Label"),
         strings = require("i18n!nls/strings"),
-        collection = require("js/util/collection");
+        collection = require("js/util/collection"),
+        classnames = require("classnames");
 
     /**
      * VectorFill Component displays information of fills for non-type only sets of layers
@@ -117,6 +118,11 @@ define(function (require, exports, module) {
                 return null;
             }
 
+            var opacityLabelClasses = classnames({
+                "label__medium__left-aligned": true,
+                "opacity-label": true
+            });
+
             var fillVisibilityToggle = !this.props.uniformLayerKind ? null : (
                 <FillVisiblity
                     document={this.props.document}
@@ -145,7 +151,7 @@ define(function (require, exports, module) {
                     <div className="control-group__vertical">
                         <Label
                             size="column-4"
-                            className={"label__medium__left-aligned"}
+                            className={opacityLabelClasses}
                             title={strings.TOOLTIPS.SET_OPACITY}>
                             {strings.STYLE.OPACITY}
                         </Label>

--- a/src/js/util/system.js
+++ b/src/js/util/system.js
@@ -25,6 +25,27 @@ define(function (require, exports) {
     "use strict";
 
     var isMac = window.navigator.platform.indexOf("Mac") === 0;
-        
+    var locale = window.navigator.language,
+        parts = locale.match(/\w+/),
+        language = parts.length > 0 && parts[0];
+    
+    switch (language) {
+        case "en":
+            language = "en";
+            break;
+        case "de":
+            language = "de";
+            break;
+        case "fr":
+            language = "fr";
+            break;
+        case "ja":
+            language = "ja";
+            break;
+        default:
+            language = "en";
+    }
+
     exports.isMac = isMac;
+    exports.language = language;
 });

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -329,6 +329,37 @@
     .generate-columns(@n, (@i + 1));
 }
 
+/* Japanese Specific Label Sizings */
+
+:lang(ja) .label__medium.column-4.label__medium__left-aligned.opacity-label {
+   width: 5rem;
+}
+
+:lang(ja) .label__medium.column-2.blur-label {
+    width: 3.8rem;
+}
+
+:lang(ja) .label__medium.column-4.spread-label {
+    width: 7rem;
+}
+
+:lang(ja) .label__medium__left-aligned.scale-title {
+    width: 7rem;
+}
+
+:lang(ja) .effect-list__container .section-title__subtitle {
+    display: block;
+}
+
+/* German Specific Label Sizings */
+:lang(de) .label__medium.column-2.blur-label {
+    width: 5rem;
+}
+
+:lang(de) .label__medium.column-4.spread-label {
+    width: 5rem;
+}
+
 .column-full {
     width: 28.8rem;
 }

--- a/src/style/sections/style/layer-effect.less
+++ b/src/style/sections/style/layer-effect.less
@@ -47,7 +47,7 @@
 
 .effect-list__shadow {
     margin-bottom: 1rem;
-    
+
     &__disabled {
         color: @item-disabled;
     }


### PR DESCRIPTION
Fixed the input labels for overflow. 

Now we can use the :lang() pseudo selector in our CSS for localization purposes. 

references: #2571 

1.) @ktaki Please check all the labels and titles in this screenshot are correct. 
![](https://www.dropbox.com/s/sm8bonqhehqmjwe/Screenshot%202015-10-14%2010.47.07.png?raw=1)

2.) @placegraphichere Please approve the spacings between the labels. 
![](https://www.dropbox.com/s/uynh60itau6zlrb/Screenshot%202015-10-12%2018.10.28.png?raw=1)

3.) @placegraphichere Please approve the spacing between the opacity label and its input 
![](https://www.dropbox.com/s/97srcgfiny42gsu/Screenshot%202015-10-13%2011.12.35.png?raw=1)

4.) @placegraphichere Let me know if the spacing between labels and inputs is ok here 
![](https://www.dropbox.com/s/obzm2y4rz5fe81l/Screenshot%202015-10-12%2017.55.04.png?raw=1)