### PR TITLE
Fixed SVGIcon require in CheckBox

### DIFF
--- a/src/js/jsx/shared/CheckBox.jsx
+++ b/src/js/jsx/shared/CheckBox.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var SVGIcon = require("./SVGIcon"),
+    var SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         collection = require("js/util/collection");
 
     /**


### PR DESCRIPTION
uses !jsx prefix now.  This was causing the minified sources to bork.