### PR TITLE
ExportList now uses autoSelect=false and changeOnBlur=false datalist params

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -445,6 +445,9 @@ define(function (require, exports, module) {
                     }
                     break;
                 }
+                case "Escape":
+                    this.props.dismissDialog();
+                    return;
                 case "Backspace": {
                     if (this.refs.datalist.cursorAtBeginning() && this.state.filter.length > 0) {
                         // Clear filter and icon

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -156,6 +156,8 @@ define(function (require, exports, module) {
                             defaultSelected={scaleOption.id}
                             onChange={this._handleUpdateScale}
                             live={false}
+                            autoSelect={false}
+                            changeOnBlur={false}
                             size="column-4" />
                     </div>
                     <div className="control-group__vertical">
@@ -176,6 +178,8 @@ define(function (require, exports, module) {
                             defaultSelected={exportAsset.format}
                             onChange={this._handleUpdateFormat}
                             live={false}
+                            autoSelect={false}
+                            changeOnBlur={false}
                             size="column-8" />
                     </div>
                     <Button

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -246,8 +246,8 @@ define(function (require, exports, module) {
             if (!select) {
                 switch (event.key) {
                 case "Escape":
-                    if (!this.props.live) {
-                        this.props.onChange(null);
+                    if (this.props.onKeyDown) {
+                        this.props.onKeyDown(event);
                     }
                     return;
                 case "Tab":


### PR DESCRIPTION
This addresses #2807, #2808, and an unreported issue: extra history state when committing a change to the "format" datalist of export asset configurations.

The default value of the `DataList` parameter `autoSelect` was `true`, and this was triggering a bug when hitting ESC.  Interestingly, even with that parameter defaulting to true, the datalist did not behave autoSelecty... so by setting this false, we aren't losing any functionality.  YES, I do believe there may still be a bug lurking deep inside DataList, but I wanted to keep this PR out of it, if at all possible.

FWIW, there is still one annoying issue with these export inputs right now: after making a new selection in the datalist, the input losing focus.  This means that hitting tab will change layer selection, not tab to the next export input.

Update: This PR also changes the way ESC key is handled in the case when the TextInput is focussed, but the Select List is closed (like when you first tab into the datalist, or after you've selected with a click).  There WAS a call to `onChange(null)` which seems to have been necessary for the SearchBar, which used that to trigger a close of the search dialog, but was otherwise dangerous.  I modified that specific codepath to just pass the key event to SearchBar (via the onKeyDown prop of DataList), which allows for NOT calling the aforementioned `onChange(null)`.