### PR TITLE
Sync font list changes

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -682,8 +682,8 @@ define(function (require, exports) {
                     return;
                 }
 
-                var selected = document.layers.selected,
-                    typeLayers = selected.filter(function (layer) {
+                var exposed = document.layers.exposed,
+                    typeLayers = exposed.filter(function (layer) {
                         return layer.isTextLayer();
                     });
 

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -580,9 +580,10 @@ define(function (require, exports, module) {
      *
      * @param {object} layerDescriptor
      * @param {Document} previousDocument
+     * @param {boolean=} lazy If true, layer will be marked as initialized iff it is selected
      * @return {Layer}
      */
-    Layer.prototype.resetFromDescriptor = function (layerDescriptor, previousDocument) {
+    Layer.prototype.resetFromDescriptor = function (layerDescriptor, previousDocument, lazy) {
         var resolution = previousDocument.resolution,
             artboardEnabled = layerDescriptor.artboardEnabled,
             exportEnabled = artboardEnabled && layerDescriptor.exportEnabled !== false || layerDescriptor.exportEnabled,
@@ -607,7 +608,7 @@ define(function (require, exports, module) {
                 vectorMaskEmpty: layerDescriptor.vectorMaskEmpty,
                 textWarningLevel: layerDescriptor.textWarningLevel,
                 isLinked: _extractIsLinked(layerDescriptor),
-                initialized: true
+                initialized: lazy ? this.selected : true
             };
 
         object.assignIf(model, "blendMode", _extractBlendMode(layerDescriptor));

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1007,15 +1007,16 @@ define(function (require, exports, module) {
      *
      * @param {Immutable.Iterable.<{layerID: number, descriptor: object}>} layerObjs
      * @param {Document} previousDocument
+     * @param {boolean=} lazy If true, layer will be marked as initialized iff it is selected
      * @return {LayerStructure}
      */
-    LayerStructure.prototype.resetLayers = function (layerObjs, previousDocument) {
+    LayerStructure.prototype.resetLayers = function (layerObjs, previousDocument, lazy) {
         var nextLayers = this.layers.withMutations(function (layers) {
             layerObjs.forEach(function (layerObj) {
                 var layerID = layerObj.layerID,
                     descriptor = layerObj.descriptor,
                     layer = this.byID(layerID),
-                    nextLayer = layer.resetFromDescriptor(descriptor, previousDocument);
+                    nextLayer = layer.resetFromDescriptor(descriptor, previousDocument, lazy);
 
                 layers.set(layerID, nextLayer);
             }, this);

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -310,12 +310,14 @@ define(function (require, exports, module) {
          * @param {number} payload.documentID
          * @param {Immutable.Iterable.<{layerID: number, descriptor: object}>} payload.layers
          * @param {boolean=} payload.suppressDirty
+         * @param {boolean=} payload.lazy
          */
         _handleLayerReset: function (payload) {
             var documentID = payload.documentID,
                 layerObjs = payload.layers,
                 document = this._openDocuments[documentID],
-                nextLayers = document.layers.resetLayers(layerObjs, document),
+                lazy = payload.lazy,
+                nextLayers = document.layers.resetLayers(layerObjs, document, lazy),
                 nextDocument = document.set("layers", nextLayers),
                 suppressDirty = payload.suppressDirty;
 


### PR DESCRIPTION
With this change, we now listen for the new `fontListChanged` event, which happens when the system font list changes, handles it by updating the font list (if it is already initialized) when the font list changes. The selected text layers are also reset when this happens so that the layers panel reflects the change immediately. Note that sometimes it is necessary for the tool to be changed before Photoshop will send this event the first time.

Assigning this to @mcilroyc because I could use a second opinion on the `resetLayers` call. Which is to say, I don't think this should create a new history state, but also I'm updating the document model, so... ?

Addresses #1326. 