### PR TITLE
Correct the inner shadow x/y input tooltip

### DIFF
--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -268,7 +268,7 @@ define(function (require, exports) {
             } else if (this.props.type === LayerEffect.INNER_SHADOW) {
                 return innerString;
             } else {
-                return "error";
+                throw new Error("Unexpected shadow type: " + this.props.type);
             }
         },
 
@@ -280,9 +280,9 @@ define(function (require, exports) {
                 });
 
             var shadowXPositionTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_X_POSITION,
-                     strings.TOOLTIPS.SET_DROP_SHADOW_X_POSITION),
+                     strings.TOOLTIPS.SET_INNER_SHADOW_X_POSITION),
                 shadowYPositionTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_Y_POSITION,
-                     strings.TOOLTIPS.SET_DROP_SHADOW_Y_POSITION),
+                     strings.TOOLTIPS.SET_INNER_SHADOW_Y_POSITION),
                 shadowColorTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_COLOR,
                     strings.TOOLTIPS.SET_INNER_SHADOW_COLOR),
                 shadowBlurTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_BLUR,


### PR DESCRIPTION
What it says!

![image](https://cloud.githubusercontent.com/assets/1075154/10465731/4485d850-71a5-11e5-9065-51bf65796ff8.png)

Addresses #2929.

**NOTE** We might need a UIF exception for this (https://watsonexp.corp.adobe.com/#bug=4071268). So, please don't merge until I get permission from @jsbache. 