### PR TITLE
Do not dirty the document when changing the selection.

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -442,7 +442,8 @@ define(function (require, exports) {
      *
      * @param {Document} document
      * @param {Layer|Immutable.Iterable.<Layer>} layers
-     * @param {boolean=} amendHistory If truthy, update the current history state with latest document
+     * @param {boolean=} amendHistory If truthy, update the current history state
+     *  with latest document, and also do NOT dirty the document.
      * @return {Promise}
      */
     var resetLayers = function (document, layers, amendHistory) {
@@ -474,6 +475,7 @@ define(function (require, exports) {
                     };
                 });
                 if (amendHistory) {
+                    payload.suppressDirty = true;
                     this.dispatch(events.document.history.amendment.RESET_LAYERS, payload);
                 } else {
                     this.dispatch(events.document.RESET_LAYERS, payload);

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -306,16 +306,20 @@ define(function (require, exports, module) {
          * Reset the given layer models.
          *
          * @private
-         * @param {{documentID: number, layers: Immutable.Iterable.<{layerID: number, descriptor: object}>}} payload
+         * @param {object} payload
+         * @param {number} payload.documentID
+         * @param {Immutable.Iterable.<{layerID: number, descriptor: object}>} payload.layers
+         * @param {boolean=} payload.suppressDirty
          */
         _handleLayerReset: function (payload) {
             var documentID = payload.documentID,
                 layerObjs = payload.layers,
                 document = this._openDocuments[documentID],
                 nextLayers = document.layers.resetLayers(layerObjs, document),
-                nextDocument = document.set("layers", nextLayers);
+                nextDocument = document.set("layers", nextLayers),
+                suppressDirty = payload.suppressDirty;
 
-            this.setDocument(nextDocument, true);
+            this.setDocument(nextDocument, !suppressDirty);
         },
 
         /**
@@ -585,7 +589,8 @@ define(function (require, exports, module) {
             var nextLayers = document.layers.updateSelection(selectedIDs, pivotID),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, true);
+            // layer selection should NOT dirty the document
+            this.setDocument(nextDocument, false);
         },
 
         /**


### PR DESCRIPTION
What it says! Requires Mac pgdev.761 or later. Over to @mcilroyc again because of a possibly controversial history state change: when `resetLayers` is called with `amendHistory`, I now suppress setting the dirty bit. This seems reasonable to me because in theory there was some previous change which _also_ set the dirty bit (hence the amendment), but I could use a second opinion.

Addresses #1903.