### PR TITLE
Center dialogs with JS calculation rather than CSS

### DIFF
--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -198,16 +198,19 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Position the dialog according to the target
+         * Position the dialog according to the position method (either target or center)
          *
          * @private
          * @param {DOMElement} dialogEl the dialog DOM element
          */
         _positionDialog: function (dialogEl) {
+            var dialogBounds;
+            
             if (this.props.position === POSITION_METHODS.TARGET) {
                 if (this._target) {
-                    var dialogBounds = dialogEl.getBoundingClientRect(),
-                        clientHeight = window.document.documentElement.clientHeight,
+                    dialogBounds = dialogEl.getBoundingClientRect();
+
+                    var clientHeight = window.document.documentElement.clientHeight,
 
                         // Need to account for element margin
                         dialogComputedStyle = window.getComputedStyle(dialogEl),
@@ -234,6 +237,17 @@ define(function (require, exports, module) {
                     dialogEl.style.top = placedDialogTop + "px";
                 } else {
                     throw new Error("Could not determine target by which to render this dialog: " + this.displayName);
+                }
+            } else if (this.props.position === POSITION_METHODS.CENTER) {
+                dialogBounds = dialogEl.getBoundingClientRect();
+
+                var cloakingRect = this.getFlux().store("ui").getCloakRect(),
+                    cloakingRectWidth = cloakingRect.right - cloakingRect.left;
+
+                if (dialogBounds.width < cloakingRectWidth) {
+                    dialogEl.style.left = (cloakingRect.left + cloakingRectWidth / 2) + "px";
+                } else {
+                    dialogEl.style.left = null;
                 }
             }
         },

--- a/src/style/help/first-launch.less
+++ b/src/style/help/first-launch.less
@@ -34,57 +34,6 @@
     overflow: hidden;
     margin-left: 0;
 }
-.main__no-panel .first-launch__dialog, .main__no-panel .keyboard-shortcut__dialog {
-    margin-left: 0;
-}
-
-.main__one-panel .first-launch__dialog, .main__one-panel .keyboard-shortcut__dialog {
-    margin-left:  -(@panel-column-width / 2);
-}
-
-.main__both-panel .first-launch__dialog, .main__both-panel .keyboard-shortcut__dialog {
-    margin-left:  -(@panel-column-width);
-}
-
-// Intro and KBSC Dialogs at 1x
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 1620px) {
-    .main__both-panel .first-launch__dialog, .main__both-panel .keyboard-shortcut__dialog {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 1300px) {
-    .main__one-panel .first-launch__dialog, .main__one-panel .keyboard-shortcut__dialog{
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 980px) {
-    .main__no-panel .first-launch__dialog, .main__no-panel .keyboard-shortcut__dialog {
-        margin-left: 0;
-    }
-}
-
-// Intro and KBSC Dialogs at 2x
-
-@media (-webkit-min-device-pixel-ratio: 2) and (max-width: 1420px) {
-    .main__both-panel .first-launch__dialog, .main__both-panel .keyboard-shortcut__dialog {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (max-width: 1100px) {
-    .main__one-panel .first-launch__dialog, .main__one-panel .keyboard-shortcut__dialog {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (max-width: 780px) {
-    .main__no-panel .first-launch__dialog, .main__no-panel .keyboard-shortcut__dialog {
-        margin-left: 0;
-    }
-}
 
 .keyboard-shortcut__content {
     display: flex;

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -44,47 +44,6 @@
     overflow: visible;
 }
 
-.main__no-panel .search-bar__dialog {
-    margin-left: 0;
-}
-
-.main__one-panel .search-bar__dialog {
-    margin-left:  -(@panel-column-width / 2);
-}
-
-.main__both-panel .search-bar__dialog {
-    margin-left: -(@panel-column-width);
-}
-
-// Search Dialog at 1x
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 1260px) {
-    .main__both-panel .search-bar__dialog {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 940px) {
-    .main__one-panel .search-bar__dialog {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 1) and (max-width: 620px) {
-    .main__no-panel .search-bar__dialog {
-        margin-left: 0;
-    }
-}
-// Search Dialog at 2x
-
-@media (-webkit-min-device-pixel-ratio: 2) and (max-width: 1125px) {
-    .main__no-panel .search-bar__dialog,
-    .main__one-panel .search-bar__dialog,
-    .main__both-panel .search-bar__dialog {
-        margin-left: 0;
-    }
-}
-
 .search-bar__dialog .drop-down {
     margin-top: 1rem;
     margin-left: 3.3rem;

--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -27,54 +27,9 @@
 
 .dialog__center {
     position: fixed;
-    margin-left: -((@panel-column-width+@toolbar-button-size)/2);
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-}
-// Plus 1rem for space
-@base-width: unit(@panel-column-width)+unit(@toolbar-button-size)+unit(@first-launch-width)+1;
-
-@media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 801px) and (max-device-width: 1440px) and (max-width: (@base-width * 8px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1441px) and (max-width: (@base-width * 10px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 801px) and (max-device-width: 1280px) and (max-width: (@base-width * 8px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1281px) and (max-device-width: 1440px) and (max-width: (@base-width * 9px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1441px) and (max-device-width: 1680px) and (max-width: (@base-width * 10px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1681px) and (max-device-width: 2560px) and (max-width: (@base-width * 11px)) {
-    .dialog__center {
-        margin-left: 0;
-    }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) and (max-width: (@base-width * 12px)){
-    .dialog__center {
-        margin-left: 0;
-    }
 }
 
 dialog {


### PR DESCRIPTION
Since the number of complicating factors for centering the dialogs keeps increasing (toolbar pinned/not pinned, 1 or 2 columns open, single column mode), we are switching to using JS to center the dialogs.

If there is enough space over the canvas for the dialog, we center it over the canvas (based on the cloaking bounds), otherwise, we center it on the screen