### PR TITLE
Fix incorrect layer index after placing file and calm React warning

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -671,28 +671,30 @@ define(function (require, exports) {
                 return Promise.resolve();
             }
         }
-        
+
         var document = this.flux.stores.document.getDocument(documentID),
             updateGraphicPromise = Promise.resolve();
-        
+
         if (!document.unsupported) {
             this.dispatch(events.libraries.UPDATING_GRAPHIC_CONTENT, { documentID: documentID, element: element });
-            
+
             updateGraphicPromise = Promise
                 .fromNode(function (done) {
                     library.beginOperation();
-                    
-                    // If the element we're editing was deleted, we recreate it as a new element, so the changes 
+
+                    // If the element we're editing was deleted, we recreate it as a new element, so the changes
                     // aren't lost. Otherwise, we just remove the existing representations so we can add the new ones
                     if (element.deletedLocally) {
                         element = library.createElement(element.name, element.type);
                     } else {
-                        // TODO should keep representation's stock data
+                        // TODO should keep representation's Adobe Stock info. However, Adobe Stocks are in photo,
+                        // illustrator, and video formats currently, and none of them is editable in DS, so we can
+                        // safely skip this step for now.
                         element.removeAllRepresentations();
                     }
-                    
+
                     var newRepresentation = element.createRepresentation(REP_PHOTOSHOP_TYPE, "primary");
-                        
+
                     // TODO should check and limit file size to 1024MB
                     newRepresentation.updateContentFromPath(editStatus.documentPath, done);
                 })
@@ -707,7 +709,7 @@ define(function (require, exports) {
                     this.dispatch(events.libraries.UPDATED_GRAPHIC_CONTENT, { documentID: documentID });
                 });
         }
-        
+
         return updateGraphicPromise
             .bind(this)
             .then(function () {

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -588,8 +588,11 @@ define(function (require, exports, module) {
 
                     var postPromises = post.map(function (conjunct, index) {
                         return conjunct.apply(this)
-                            .catch(function () {
-                                log.error("Verification of postcondition " + index + " failed for " + actionTitle);
+                            .catch(function (err) {
+                                var errMessage = err && err.message || "no error message";
+                                
+                                log.error("Verification of postcondition %s failed for %s - %s",
+                                    index, actionTitle, errMessage);
                             });
                     }, this);
 

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -440,6 +440,10 @@ define(function (require, exports) {
                 // Group into arrays of dropShadows, by position in each layer
                 var shadowGroups = collection.zip(collection.pluck(layers, "dropShadows"));
                 
+                if (shadowGroups.isEmpty()) {
+                    return null;
+                }
+                
                 shadowsContent = shadowGroups.map(function (dropShadows, index) {
                     return (
                         <Shadow
@@ -454,15 +458,11 @@ define(function (require, exports) {
                     );
                 }, this).toList();
             } else {
-                shadowsContent = Immutable.List.of((
+                shadowsContent = (
                     <div className="effect-list__list-container__mixed">
                         <i>{strings.STYLE.DROP_SHADOW.MIXED}</i>
                     </div>
-                ));
-            }
-
-            if (shadowsContent.isEmpty()) {
-                return null;
+                );
             }
 
             return (
@@ -511,6 +511,10 @@ define(function (require, exports) {
                 var temp = collection.pluck(layers, "innerShadows");
                 var shadowGroups = collection.zip(temp);
                 
+                if (shadowGroups.isEmpty()) {
+                    return null;
+                }
+                
                 shadowsContent = shadowGroups.map(function (innerShadows, index) {
                     return (
                         <Shadow {...this.props}
@@ -523,15 +527,11 @@ define(function (require, exports) {
                     );
                 }, this).toList();
             } else {
-                shadowsContent = Immutable.List.of((
+                shadowsContent = (
                     <div className="effect-list__list-container__mixed">
                         <i>{strings.STYLE.INNER_SHADOW.MIXED}</i>
                     </div>
-                ));
-            }
-
-            if (shadowsContent.isEmpty()) {
-                return null;
+                );
             }
 
             return (


### PR DESCRIPTION
This PR fixes:

1 selected empty layer is not replaced after placing file. addresses issue #2819. I checked the three difference way of placing file and here is the summary:

1. place file via menu item (place linked or embedded): empty layer will be replaced.
2. drag-n-drop local file: empty layer will be replaced.
3. drag-n-drop CC libraries graphic: empty layer will not be replaced.

**Require dev > 743 to receive the replaced layer id in `placeEvent` attributes**

<img width="293" alt="screen shot 2015-10-14 at 11 27 42 am" src="https://cloud.githubusercontent.com/assets/118264/10493561/b0290fb6-7266-11e5-8461-f559a1356fae.png">


2 React warn about missing unique key in children. #2651