### PR TITLE
Do not show hidden options in datalist

### DIFF
--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -445,7 +445,9 @@ define(function (require, exports, module) {
             }
 
             if (filter.length === 0) {
-                return options;
+                return options && options.filter(function (option) {
+                    return !option.hidden;
+                });
             }
 
             return options && options.filter(function (option) {


### PR DESCRIPTION
While looking into #2465, it became apparent that we were not longer filtering hidden options from datalists. This should fix #2465 in that we shouldn't have been able to see luminosity as an option anyways