### PR TITLE
menu store now listens for the new finalize_history event

### DIFF
--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -113,6 +113,7 @@ define(function (require, exports, module) {
                 events.document.TYPE_ALIGNMENT_CHANGED, this._updateMenuItems,
                 events.dialog.OPEN_DIALOG, this._updateMenuItems,
                 events.dialog.CLOSE_DIALOG, this._updateMenuItems,
+                events.history.FINALIZE_HISTORY_STATE, this._updateMenuItems,
                 events.history.LOAD_HISTORY_STATE, this._updateMenuItems,
                 events.history.LOAD_HISTORY_STATE_REVERT, this._updateMenuItems,
                 events.export.SERVICE_STATUS_CHANGED, this._updateMenuItems,


### PR DESCRIPTION
This addresses #2949.  I recently added a new event that allows history state to be wrapped up and finalized after a complex transaction.  It is currently used only by the move handler.  The menu wasn't listening for this new event, so the menu was not showing "undo" as valid option after the first layer move with a clean doc.