### PR TITLE
Delay drag start until a distance threshold is crossed

### DIFF
--- a/src/js/util/math.js
+++ b/src/js/util/math.js
@@ -138,10 +138,27 @@ define(function (require, exports) {
         return (value < min) ? min : (value > max ? max : value);
     };
 
+    /**
+     * Measure the planar distance between two points.
+     *
+     * @param {number} x1
+     * @param {number} y1
+     * @param {number} x2
+     * @param {number} y2
+     * @return {number}
+     */
+    var distance = function (x1, y1, x2, y2) {
+        var xdiff = x2 - x1,
+            ydiff = y2 - y1;
+
+        return Math.sqrt((xdiff * xdiff) + (ydiff * ydiff));
+    };
+
     exports.parseNumber = parseNumber;
     exports.formatNumber = formatNumber;
     exports.pixelDimensionToNumber = pixelDimensionToNumber;
     exports.normalize = normalize;
     exports.isRotation = isRotation;
     exports.clamp = clamp;
+    exports.distance = distance;
 });


### PR DESCRIPTION
On Windows (and very occasionally on Mac) mouse clicks can cause a mousedown as well as a mousemove event, even when the mouse is not actually moved during the click. This causes our drag logic to kick in, which also suppresses the following click event to prevent interference. In the case of false drags, this click suppression causes problems, e.g. failing to select layers in the layers panel, and probably other cases we haven't noticed.

@jsbache suggested that the drag operations should not start until the distance between the mousemove events and the original mousedown position exceeds some modest threshold. That's exactly what this PR does, and @chadrolfs' preliminary testing suggests that this addresses #1781. Concretely, the `Draggable` component waits to set the `dragging` bit until the distance between the mousemove and the original mousedown exceeds 5 pixels. 

Addresses #1781. :tada:  