### PR TITLE
Fix lazy resetLayers result collation 

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -495,10 +495,11 @@ define(function (require, exports) {
 
                     return layers
                         .map(function (layer) {
-                            var list = layer.selected ? selected : unselected,
-                                index = layer.selected ? selectedIndex : unselectedIndex;
-
-                            return list[index++];
+                            if (layer.selected) {
+                                return selected[selectedIndex++];
+                            } else {
+                                return unselected[unselectedIndex++];
+                            }
                         })
                         .toArray();
                 }.bind(this));


### PR DESCRIPTION
This fixes a dumb programming error from yours truly in the new lazy path through `resetLayers` which caused it to only return the very first layer's descriptor repeatedly. Whoops!

Should address the follow-up bug reported by @ktaki in #1326.