### PR TITLE
Fix for layer reordering

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1650,7 +1650,7 @@ define(function (require, exports) {
                 return Promise.resolve();
             }
         }
-        
+
         return _getLayerIDsForDocumentID.call(this, document.id)
             .then(function (payload) {
                 return _getSelectedLayerIndices(document).then(function (selectedIndices) {
@@ -1668,10 +1668,17 @@ define(function (require, exports) {
                 } else {
                     return this.dispatchAsync(events.document.history.optimistic.REORDER_LAYERS, payload);
                 }
+            })
+            .then(function () {
+                // get the document with latest selected layers, after layer reordering.
+                var document = this.flux.store("application").getCurrentDocument();
+
+                return this.transfer(initializeLayers, document, document.layers.selected);
             });
     };
     resetIndex.reads = [locks.PS_DOC];
     resetIndex.writes = [locks.JS_DOC];
+    resetIndex.transfers = [initializeLayers];
     resetIndex.post = [_verifyLayerIndex, _verifyLayerSelection];
 
     /**

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -26,6 +26,8 @@ define(function (require, exports, module) {
 
     var Fluxxor = require("fluxxor");
 
+    var events = require("../events");
+
     /**
      * Holds global state needed by view components to implement drag-and-drop.
      *
@@ -79,7 +81,7 @@ define(function (require, exports, module) {
          * @private
          * @type {boolean}
          */
-        _hasValidDropTarget: false,
+        _hasValidDropTarget: null,
 
         /**
          * Past drag target (for maintaining position during render)
@@ -105,8 +107,34 @@ define(function (require, exports, module) {
          * Initializes the by-zone maps.
          */
         initialize: function () {
+            this.bindActions(
+                events.RESET, this._handleReset
+            );
+            
+            // These setting attributes should be initialized once.
             this._dropTargetsByZone = new Map();
             this._dropTargetOrderingsByZone = new Map();
+
+            this._handleReset();
+        },
+        
+        /**
+         * Reset or initialize store state.
+         *
+         * @private
+         */
+        _handleReset: function () {
+            var hasDragTargets = !!this._dragTargets;
+            
+            this._pastDragTargets = null;
+            this._dragTargets = null;
+            this._dropTarget = null;
+            this._hasValidDropTarget = false;
+            this._dragPosition = null;
+            
+            if (hasDragTargets) {
+                this.emit("change");
+            }
         },
 
         /**

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -91,14 +91,14 @@
             "$payload": {
                 "commandID": 3090
             },
-            "$enable-rule": "supported-document"
+            "$enable-rule": "supported-document,always-except-modal"
         },
         "PLACE_EMBEDDED": {
             "$action": "menu.native",
             "$payload": {
                 "commandID": 1032
             },
-            "$enable-rule": "supported-document"
+            "$enable-rule": "supported-document,always-except-modal"
         },
         "PACKAGE": {
             "$action": "documents.packageDocument",


### PR DESCRIPTION
We have lazy loading for layer attributes on startup (`layer.initialized === false`) until they are selected. When a layer is uninitialized and you reorder it without selecting it, DS will play the descriptor command but skip emmiting a change event because it thinks the layer is not initlaized and trying to avoid UI redraw (https://github.com/adobe-photoshop/spaces-design/blob/master/src/js/stores/document.js#L180). Now, what you have in the layer panel, are layers remain unchanged but inside Photoshop the reorder command is completed. Then, if you try to reorder again, it will fail and throw error. 

I made a simple fix by selecting the dragged layer (if it haven't) before reordering; this will:

1. make sure the layer is selected and initialized
2. the dragged layer is shown as selected after reordering (before it is unselected). This matches behavior in classic PS.

Addresses issue #2941