### PR TITLE
Fixed handling when a user cancels out of the folder chooser dialog

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -729,34 +729,34 @@ define(function (require, exports) {
             .then(function (baseDir) {
                 if (!baseDir) {
                     return Promise.resolve();
-                } else {
-                    _lastFolderPath = baseDir;
-
-                    var layerIdList = collection.pluck(layersList, "id");
-
-                    return _setAssetsRequested.call(this, document.id, layerIdList)
-                        .bind(this)
-                        .then(_setServiceBusy.bind(this, true))
-                        .return(quickAddPromise)
-                        .then(function () {
-                            // fetch documentExports anew, in case quick-add added any assets
-                            var documentExports = this.flux.stores.export.getDocumentExports(documentID, true);
-
-                            // Iterate over the layers, find the associated export assets, and export them
-                            var exportList = layersList.flatMap(function (layer) {
-                                var prefix = prefixMap && prefixMap.get(layer.id);
-
-                                return documentExports.getLayerExports(layer.id)
-                                    .map(function (asset, index) {
-                                        return _exportAsset.call(this, document, layer,
-                                            index, asset, _lastFolderPath, prefix);
-                                    }, this);
-                            }, this);
-
-                            _batchExports.call(this, exportList);
-                            return Promise.resolve();
-                        });
                 }
+
+                _lastFolderPath = baseDir;
+
+                var layerIdList = collection.pluck(layersList, "id");
+
+                return _setAssetsRequested.call(this, document.id, layerIdList)
+                    .bind(this)
+                    .then(_setServiceBusy.bind(this, true))
+                    .return(quickAddPromise)
+                    .then(function () {
+                        // fetch documentExports anew, in case quick-add added any assets
+                        var documentExports = this.flux.stores.export.getDocumentExports(documentID, true);
+
+                        // Iterate over the layers, find the associated export assets, and export them
+                        var exportList = layersList.flatMap(function (layer) {
+                            var prefix = prefixMap && prefixMap.get(layer.id);
+
+                            return documentExports.getLayerExports(layer.id)
+                                .map(function (asset, index) {
+                                    return _exportAsset.call(this, document, layer,
+                                        index, asset, _lastFolderPath, prefix);
+                                }, this);
+                        }, this);
+
+                        _batchExports.call(this, exportList);
+                        return Promise.resolve();
+                    });
             });
     };
     exportLayerAssets.reads = [locks.JS_DOC];
@@ -795,25 +795,25 @@ define(function (require, exports) {
             .then(function (baseDir) {
                 if (!baseDir) {
                     return Promise.resolve();
-                } else {
-                    _lastFolderPath = baseDir;
-
-                    return _setAssetsRequested.call(this, document.id)
-                        .bind(this)
-                        .then(_setServiceBusy.bind(this, true))
-                        .then(function () {
-                            // fetch documentExports anew, in case quick-add added any assets
-                            var documentExports = this.flux.stores.export.getDocumentExports(document.id, true);
-
-                            // Iterate over the root document assets, and export them
-                            var exportList = documentExports.rootExports.map(function (asset, index) {
-                                return _exportAsset.call(this, document, null, index, asset, _lastFolderPath);
-                            }, this);
-
-                            _batchExports.call(this, exportList);
-                            return Promise.resolve();
-                        });
                 }
+                
+                _lastFolderPath = baseDir;
+
+                return _setAssetsRequested.call(this, document.id)
+                    .bind(this)
+                    .then(_setServiceBusy.bind(this, true))
+                    .then(function () {
+                        // fetch documentExports anew, in case quick-add added any assets
+                        var documentExports = this.flux.stores.export.getDocumentExports(document.id, true);
+
+                        // Iterate over the root document assets, and export them
+                        var exportList = documentExports.rootExports.map(function (asset, index) {
+                            return _exportAsset.call(this, document, null, index, asset, _lastFolderPath);
+                        }, this);
+
+                        _batchExports.call(this, exportList);
+                        return Promise.resolve();
+                    });
             });
     };
     exportDocumentAssets.reads = [locks.JS_DOC, locks.JS_EXPORT];


### PR DESCRIPTION
This rotted in two remarkable ways.  So many feels.

Addresses #2958 

1. It would seem that the error returned by generator/JSX when a user cancels the dialog has changed from an object with a `message` property, to a simple string.  This is troubling, but I'm not sure how hard I want to try and figure out when/why it changed.
2. The previous approach was to throw a custom error in this case, and handle it in the export action that transferred to promptForFolder.  But, the transfer system is puking on that error now.  I'm fairly confident this used to work ... but anyway now I'm going with a simpler approach of simply resolving null in this case.  No fuss no muss.

The diff looks messier than it actually is.  The meat of the export logic got bumped in a couple of tab stops.