### PR TITLE
Place object - policy and history changes

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -43,6 +43,7 @@ define(function (require, exports) {
         preferencesActions = require("./preferences"),
         menu = require("./menu"),
         ui = require("./ui"),
+        synchronization = require("js/util/synchronization"),
         events = require("../events"),
         locks = require("js/locks"),
         pathUtil = require("js/util/path"),
@@ -912,6 +913,7 @@ define(function (require, exports) {
     handlePlaceEvent.reads = [locks.JS_APP];
     handlePlaceEvent.writes = [];
     handlePlaceEvent.transfers = [updateDocument, "layers.addLayers"];
+    handlePlaceEvent.modal = true;
 
     /**
      * Event handlers initialized in beforeStartup.
@@ -1048,10 +1050,26 @@ define(function (require, exports) {
         }.bind(this);
         descriptor.addListener("paste", _pasteHandler);
 
+        // A debounced version of the place event handler action
+        var debouncedPlaceEvent = synchronization.debounce(this.flux.actions.documents.handlePlaceEvent, this, 200);
+
         // This event is triggered when a new smart object layer is placed,
         // e.g., by dragging an image into an open document.
         _placeEventHandler = function (event) {
-            this.flux.actions.documents.handlePlaceEvent(event);
+            var layerID = event.ID;
+
+            // If an ID was not supplied, this is one of the first N-1 of N placements (probably via OS drag)
+            // we debounce so as to only call updateDocument once.
+            // This also forces the final placeEvent (which includes an ID)
+            // to occur first, which is desirable so that it won't try
+            // to add the new layer after it is already loaded via the udpateDocument.
+            // This allows effecient handling of single place events, but also tolerant of multi-object placements
+            // despite the core bug that prevents ID from being included in the first N-1 events.
+            if (!layerID) {
+                debouncedPlaceEvent(event);
+            } else {
+                this.flux.actions.documents.handlePlaceEvent(event);
+            }
         }.bind(this);
         descriptor.addListener("placeEvent", _placeEventHandler);
 

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -101,7 +101,16 @@ define(function (require, exports) {
         // FIXME: the suspend/restore policies hack is for pasting smart object from other sources (e.g. Illustrator).
         // The cause is similar to the place-object menu commands: DS is not receiving "toolModalStateChanged" events
         // until the object is committed.
-        return this.transfer(policyActions.suspendAllPolicies)
+        var policyStore = this.flux.store("policy"),
+            suspendPromise;
+
+        if (policyStore.areAllSuspended()) {
+            suspendPromise = Promise.resolve();
+        } else {
+            suspendPromise = this.transfer(policyActions.suspendAllPolicies);
+        }
+
+        return suspendPromise
             .bind(this)
             .then(function () {
                 return this.transfer(menu.nativeModal, {

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -87,7 +87,10 @@ define(function (require, exports) {
         // but would require a core change to include document ID
         var currentDocumentID = this.flux.store("application").getCurrentDocumentID();
 
-        if (currentDocumentID === null) {
+        // Ignore if either there is no current document,
+        // or if this history state is related to another document
+        if (currentDocumentID === null || currentDocumentID !== event.documentID) {
+            log.debug("Ignoring this historyState event, probably because it was for a non-current document");
             return Promise.resolve();
         }
 
@@ -102,6 +105,7 @@ define(function (require, exports) {
     };
     handleHistoryState.reads = [locks.JS_DOC, locks.JS_APP];
     handleHistoryState.writes = [locks.JS_HISTORY];
+    handleHistoryState.modal = true;
 
     /**
      * Go forward or backward in the history state by playing the appropriate photoshop action

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -79,10 +79,14 @@ define(function (require, exports) {
         
         return Promise.bind(this)
             .then(function () {
+                // This is a hack for the place linked/embedded menu commands which do not
+                // seem to promptly emit a toolModalStateChanged:enter event
                 if (isPlaceCommand) {
                     this.dispatch(events.menus.PLACE_COMMAND, { executing: true });
                     
-                    return this.transfer(policyActions.suspendAllPolicies);
+                    if (!this.flux.store("policy").areAllSuspended()) {
+                        return this.transfer(policyActions.suspendAllPolicies);
+                    }
                 }
             })
             .then(function () {
@@ -349,7 +353,7 @@ define(function (require, exports) {
         return this.dispatchAsync(events.menus.PLACE_COMMAND, { executing: false })
             .bind(this)
             .then(function () {
-                if (this.flux.store("policy").areAllSuspended) {
+                if (this.flux.store("policy").areAllSuspended()) {
                     return this.transfer(policyActions.restoreAllPolicies);
                 }
             });

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -47,7 +47,6 @@ define(function (require, exports) {
         ui = require("./ui"),
         shortcuts = require("./shortcuts"),
         strings = require("i18n!nls/strings"),
-        log = require("js/util/log"),
         system = require("js/util/system"),
         utilShortcuts = require("js/util/shortcuts"),
         EventPolicy = require("js/models/eventpolicy"),
@@ -513,7 +512,6 @@ define(function (require, exports) {
         // Except for Direct Selection Tool (ptha) because we need keyboard events in mask mode
         if (event.kind._value === "tool" && event.tool.ID !== "ptha") {
             if (modalState && !policyStore.areAllSuspended()) {
-                log.info("TEMP: suspending policies");
                 policyPromise = this.transfer(policy.suspendAllPolicies);
             } else if (!modalState && policyStore.areAllSuspended()) {
                 policyPromise = this.transfer(policy.restoreAllPolicies);

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -47,6 +47,7 @@ define(function (require, exports) {
         ui = require("./ui"),
         shortcuts = require("./shortcuts"),
         strings = require("i18n!nls/strings"),
+        log = require("js/util/log"),
         system = require("js/util/system"),
         utilShortcuts = require("js/util/shortcuts"),
         EventPolicy = require("js/models/eventpolicy"),
@@ -506,12 +507,13 @@ define(function (require, exports) {
         var modalState = (event.state._value === "enter"),
             changeStatePromise = this.transfer(changeModalState, modalState),
             policyStore = this.flux.stores.policy,
-            toolsIdsThatSuspendPolicies = ["txBx", "arwT", "Rect"],
             policyPromise;
 
         // Suspend policies during type tool modal states
-        if (event.kind._value === "tool" && toolsIdsThatSuspendPolicies.indexOf(event.tool.ID) > -1) {
+        // Except for Direct Selection Tool (ptha) because we need keyboard events in mask mode
+        if (event.kind._value === "tool" && event.tool.ID !== "ptha") {
             if (modalState && !policyStore.areAllSuspended()) {
+                log.info("TEMP: suspending policies");
                 policyPromise = this.transfer(policy.suspendAllPolicies);
             } else if (!modalState && policyStore.areAllSuspended()) {
                 policyPromise = this.transfer(policy.restoreAllPolicies);

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -505,14 +505,18 @@ define(function (require, exports) {
     var handleToolModalStateChanged = function (event) {
         var modalState = (event.state._value === "enter"),
             changeStatePromise = this.transfer(changeModalState, modalState),
+            policyStore = this.flux.stores.policy,
+            toolsIdsThatSuspendPolicies = ["txBx", "arwT", "Rect"],
             policyPromise;
 
         // Suspend policies during type tool modal states
-        if (event.kind._value === "tool" && event.tool.ID === "txBx") {
-            if (modalState) {
+        if (event.kind._value === "tool" && toolsIdsThatSuspendPolicies.indexOf(event.tool.ID) > -1) {
+            if (modalState && !policyStore.areAllSuspended()) {
                 policyPromise = this.transfer(policy.suspendAllPolicies);
-            } else {
+            } else if (!modalState && policyStore.areAllSuspended()) {
                 policyPromise = this.transfer(policy.restoreAllPolicies);
+            } else {
+                policyPromise = Promise.resolve();
             }
         } else {
             policyPromise = Promise.resolve();


### PR DESCRIPTION
This addresses #2800, but makes some fairly significant changes to the way policies are suspended in/around the place object workflows.

The main change is that when entering a tool state, we suspend policies for ALL tools (except direct select, for mask mode compatibility), not just `txBx` as before.  Is this safe?  Seems OK to me, but there may be situations I'm not aware of.  Prior to this change, the enter key was being handled by DS and causing a SS "diveIn".  This seemed to work OK for single placements, but borks for multi-object placements.

When dragging an object from the library, the above change means that we no longer need to suspend policies directly from the libraries action, so I removed that.

The place-via-native-menu-commands flow is largely unchanged, but we now validate the need to suspend/restore polices herein, because of the tool modal events which may be interspersed.

When placing objects, we get historyState events for that object itself (diff doc ID) so now we ignore those.  This change was a long time coming.

Note: When TWO or more objects are placed (by dragging from OS) we get a succession of modal tool states, and then finally a series of placeEvent notifications.  The first N-1 events will not have a layer ID.  This is an open core bug that is deferred past this release.  To deal with this, we debounce if possible, and then call updateDocument as few times as possible for these events.  It does seem that sometimes for > 2 object placements we are not able to do this perfectly.

requires pgdev mac 806 (or win equiv)