### PR TITLE
Fix lost click after drag

### DIFF
--- a/src/js/jsx/shared/Draggable.jsx
+++ b/src/js/jsx/shared/Draggable.jsx
@@ -309,6 +309,12 @@ define(function (require, exports, module) {
                 // click event.
                 if (event.target === window.document.documentElement) {
                     window.removeEventListener("click", this._handleDragClick, true);
+                } else {
+                    // The following click event sometimes never arrives, so just
+                    // remove the handler after a short timeout.
+                    window.setTimeout(function () {
+                        window.removeEventListener("click", this._handleDragClick, true);
+                    }.bind(this), 100);
                 }
 
                 if (this.props.onDragStop) {


### PR DESCRIPTION
We currently add a click handler when a drag operation starts which stops propagation of the click event. This is because in some cases the drag-ending mouseup is followed by a click event that causes weird things to happen (e.g., entering layer rename mode at the end of a drag). But, we don't _always_ get the click event, so this just removes the post-drag click handler after a short timeout in case the spurious click never arrives.

Addresses #2964.