### PR TITLE
add escape handlers for vector mask tools

### DIFF
--- a/src/js/tools/ellipse.js
+++ b/src/js/tools/ellipse.js
@@ -84,6 +84,8 @@ define(function (require, exports, module) {
     var EllipseTool = function () {
         var shiftUKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, { shift: true }, shortcuts.GLOBAL.TOOLS.SHAPE),
+            escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE),
             deleteKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE),
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
@@ -91,7 +93,7 @@ define(function (require, exports, module) {
         
         Tool.call(this, "ellipse", "Ellipse", "ellipseTool", _selectHandler);
 
-        this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy];
+        this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy, escapeKeyPolicy];
         this.activationKey = shortcuts.GLOBAL.TOOLS.ELLIPSE;
         this.handleVectorMaskMode = true;
     };
@@ -109,6 +111,10 @@ define(function (require, exports, module) {
 
         if (detail.keyChar === shortcuts.GLOBAL.TOOLS.SHAPE && detail.modifiers.shift) {
             flux.actions.tools.select(toolStore.getToolByID("rectangle"));
+        }
+
+        if (toolStore.getVectorMode() && detail.keyCode === OS.eventKeyCode.ESCAPE) {
+            flux.actions.tools.changeVectorMaskMode(false);
         }
 
         // we may like to iterate on what happens when a user hits delete in vector mask mode

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -84,6 +84,8 @@ define(function (require, exports, module) {
     var RectangleTool = function () {
         var shiftUKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, { shift: true }, utilShortcuts.GLOBAL.TOOLS.SHAPE),
+            escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE),
             deleteKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE),
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
@@ -91,7 +93,7 @@ define(function (require, exports, module) {
 
         Tool.call(this, "rectangle", "Rectangle", "rectangleTool", _selectHandler);
        
-        this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy];
+        this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy, escapeKeyPolicy];
         this.activationKey = utilShortcuts.GLOBAL.TOOLS.RECTANGLE;
         this.handleVectorMaskMode = true;
     };
@@ -111,6 +113,10 @@ define(function (require, exports, module) {
             flux.actions.tools.select(toolStore.getToolByID("ellipse"));
         }
         
+        if (toolStore.getVectorMode() && detail.keyCode === OS.eventKeyCode.ESCAPE) {
+            flux.actions.tools.changeVectorMaskMode(false);
+        }
+
         // we may like to iterate on what happens when a user hits delete in vector mask mode
         if (toolStore.getVectorMode() && (detail.keyCode === OS.eventKeyCode.DELETE ||
                 detail.keyCode === OS.eventKeyCode.BACKSPACE)) {

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -176,7 +176,11 @@ define(function (require, exports, module) {
 
         var detail = event.detail;
         if (detail.keyCode === 27) { // Escape
-            flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            if (toolStore.getVectorMode() && toolStore.getModalToolState()) {
+                flux.actions.tools.changeVectorMaskMode(false);
+            } else {
+                flux.actions.tools.select(toolStore.getToolByID("newSelect"));
+            }
         } else if (detail.keyCode === 13) { // Enter
             flux.actions.tools.select(toolStore.getToolByID("newSelect"));
         }


### PR DESCRIPTION
fix for issue # 2670 

there is still an issue with escaping from superselect/vector some of the time, but i think it should not block this PR, (and it have a feeling that it may be resolved by some of the other open vector mask PRs) 