### PR TITLE
Typeface datalist updates with missing font name 

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -470,7 +470,11 @@ define(function (require, exports, module) {
                 if (postScriptFamilyName) {
                     familyName = this._getPostScriptFontFamily(postScriptFamilyName);
                     if (!familyName) {
-                        placeholderText = "[" + postScriptFamilyName + "]";
+                        if (layers.size > 1) {
+                            placeholderText = strings.STYLE.TYPE.MISSING;
+                        } else {
+                            placeholderText = "[" + postScriptFamilyName + "]";
+                        }
                     }
                     
                     if (postScriptStyleName) {

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -137,6 +137,7 @@ define(function (require, exports, module) {
 
             return (this.props.options !== nextProps.options ||
                 this.state.filter !== nextState.filter ||
+                this.props.placeholderText !== nextState.placeholderText ||
                 this.state.active !== nextState.active ||
                 this.state.suggestTitle !== nextState.suggestTitle ||
                 this.props.value !== nextProps.value);


### PR DESCRIPTION
References #2917 

When type layer is clicked on, if the font is missing, the typeface datalist will fill with the [*name of missing font*]. If multiple missing font layers are selected, the datalist reads [Missing fonts]. 
