### PR TITLE
added min and max for the rectangle radius

### DIFF
--- a/src/js/jsx/sections/style/Radius.jsx
+++ b/src/js/jsx/sections/style/Radius.jsx
@@ -99,6 +99,8 @@ define(function (require, exports, module) {
                 }, Immutable.List())
                 .min();
 
+            var maxRadiusInput = Math.floor(maxRadius);
+
             return (
                 <div className="formline">
                     <Label
@@ -111,6 +113,8 @@ define(function (require, exports, module) {
                         <NumberInput
                             size="column-4"
                             disabled={this.props.disabled}
+                            min={0}
+                            max={maxRadiusInput}
                             value={this.props.disabled ? "" : scalars}
                             onChange={this._handleRadiusChange.bind(this, layers)} />
                     </div>


### PR DESCRIPTION
References issue #1529 

Note: The reason I added the variable ```maxRadiusInput``` is because currently the Range slider uses ```maxRadius``` and the maximum value is an integer. If you use maxRadius as the max value for the input, it stops at either an integer or a .5 decimal value. Therefore ```maxRadiusInput``` makes sure the Range slider and Input values are the same no matter which you use. 