### PR TITLE
Fix startup tool inference

### DIFF
--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -294,7 +294,7 @@ define(function (require, exports, module) {
             // current options of the native tool
             Object.keys(this._allTools).some(function (toolID) {
                 var tool = this._allTools[toolID];
-                if (tool.isMainTool && tool.nativeToolName === psToolName) {
+                if (tool.isMainTool && tool.nativeToolName() === psToolName) {
                     target = tool;
                     return true;
                 }


### PR DESCRIPTION
We now have to infer tools based on the application of `nativeToolName` because it is now a function instead of a property.

Addresses #2989.