### PR TITLE
Never propagate space key to PS with select tool

### DIFF
--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -145,14 +145,17 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),
             enterKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER),
+            spaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, " ");
 
         this.keyboardPolicyList = [
             escapeKeyPolicy,
             tabKeyPolicy,
             deleteKeyPolicy,
             backspaceKeyPolicy,
-            enterKeyPolicy
+            enterKeyPolicy,
+            spaceKeyPolicy
         ];
 
         var pointerPolicy = new PointerEventPolicy(UI.policyAction.NEVER_PROPAGATE,


### PR DESCRIPTION
This used to work for free because we had a `NEVER_PROPAGATE` keyboard mode, but we've changed that recently so now it doesn't!

Addresses #2984.