### PR TITLE
Icon header sizes adjusted 

### DIFF
--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -301,7 +301,7 @@ define(function (require, exports, module) {
                     <div className="icon-header">
                         <div className="icon-header-buttons">
                             <Button
-                                className="button-plus"
+                                className="button-plus search-button"
                                 title={strings.TOOLTIPS.SEARCH}
                                 onClick={this._toggleSearch}
                                 active={this.state.searchActive}>
@@ -318,7 +318,7 @@ define(function (require, exports, module) {
                                     CSSID="tool-maskmode" />
                             </Button>
                             <Button
-                                className="button-plus"
+                                className="button-plus export-button"
                                 title={strings.TOOLTIPS.EXPORT_DIALOG}
                                 disabled={exportDisabled}
                                 active={this.state.exportActive}

--- a/src/style/document-header.less
+++ b/src/style/document-header.less
@@ -141,7 +141,6 @@
             fill: @focus-highlight;
         }
     }
-
 }
 
 .document-container {

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -166,6 +166,14 @@
     }
 }
 
+.export-button {
+    height: 1.7rem;
+}
+
+.search-button {
+    height: 1.7rem;
+}
+
 .reference-mark {
     margin-right: 4.5rem;
     


### PR DESCRIPTION
References #2956  

Small changes to the icon sizes so that they don't get cut off and the search icon looks as big as the other icons. 