### PR TITLE
Stop propagating keyboard events to PS by default; propagate arrow key events by focus

### DIFF
--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -320,7 +320,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartup = function () {
-        var defaultKeyboardMode = adapterUI.keyboardPropagationMode.FOCUS_PROPAGATE,
+        var defaultKeyboardMode = adapterUI.keyboardPropagationMode.NEVER_PROPAGATE,
             keyboardModePromise = this.transfer(setMode, PolicyStore.eventKind.KEYBOARD,
                 defaultKeyboardMode),
             defaultPointerMode = adapterUI.pointerPropagationMode.ALPHA_PROPAGATE,

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -145,14 +145,26 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),
             enterKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ENTER),
+            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
+            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT),
+            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
+            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT);
 
         this.keyboardPolicyList = [
             escapeKeyPolicy,
             tabKeyPolicy,
             deleteKeyPolicy,
             backspaceKeyPolicy,
-            enterKeyPolicy
+            enterKeyPolicy,
+            arrowUpKeyPolicy,
+            arrowRightKeyPolicy,
+            arrowDownKeyPolicy,
+            arrowLeftKeyPolicy
         ];
 
         var pointerPolicy = new PointerEventPolicy(UI.policyAction.NEVER_PROPAGATE,


### PR DESCRIPTION
1. Revert default keyboard mode to `NEVER_PROPAGATE`.
2. Install (new from @jfitz-adobe!) `FOCUS_PROPAGATE` keyboard _policies_ in the select tool for arrow keys.

This restores the default keyboard routing behavior so that key events by default only go to CEF. If you want to send a keystroke to Photoshop from now on, you probably want to install a `FOCUS_PROPAGATE` policy for it. (The `FOCUS_PROPAGATE` policy action is new and requires at least Mac pgdev.790) In particular, you _only_ want to install an `ALWAYS_PROPAGATE` policy if you don't think CEF should get the key event _even when a text input is focused_, which is almost never because that would be a highly confusing interaction.

Addresses #2984 and #2986.  Requires Mac pgdev.790.