### PR TITLE
Fix proportional resize, proportional skew and angle-constrained rotation

### DIFF
--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -124,6 +124,9 @@ define(function (require, exports, module) {
                     } else if (policy.action === UI.policyAction.NEVER_PROPAGATE) {
                         policyRect.style("stroke", "#FF2200")
                             .style("stroke-opacity", "1.0");
+                    } else if (policy.action === UI.policyAction.ALPHA_PROPAGATE) {
+                        policyRect.style("stroke", "#0066FF")
+                            .style("stroke-opacity", "0.25");
                     }
                 }
             }, this);


### PR DESCRIPTION
This add additional border policies for three on-canvas interactions:

1. Proportional resize by shift-clicking and dragging a corner anchor;
2. Proportional skew by command-shift clicking (or control-shift clicking on Windows) and dragging an anchor; and
3. Angle-constrained rotation by shift-clicking and dragging outside a corner anchor.

I'm actually not sure if these ever worked, but I'd guess that they never did. (Note that shift-marquee selection is broken on master, but is FIP in #2975.)

Addresses #2998. 