### PR TITLE
Disable possible mouse/keyboard interaction with unsupported document.

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -340,6 +340,14 @@ define(function (require, exports) {
                                 this.dispatch(events.document.DOCUMENT_UPDATED, payload);
                                 this.dispatch(events.application.INITIALIZED, { item: "activeDocument" });
                             }.bind(this))
+                            .bind(this)
+                            .then(function () {
+                                var currentDoc = this.flux.stores.application.getCurrentDocument();
+                                
+                                if (currentDoc.unsupported) {
+                                    return this.transfer(layerActions.deselectAll, currentDoc);
+                                }
+                            })
                             .then(function () {
                                 return {
                                     currentIndex: currentDoc.itemIndex,
@@ -351,7 +359,7 @@ define(function (require, exports) {
     };
     initActiveDocument.reads = [locks.PS_DOC];
     initActiveDocument.writes = [locks.JS_DOC];
-    initActiveDocument.transfers = [historyActions.queryCurrentHistory];
+    initActiveDocument.transfers = [historyActions.queryCurrentHistory, "layers.deselectAll"];
 
     /**
      * Update the document and layer state for the given document ID. Emits a

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1076,7 +1076,7 @@ define(function (require, exports) {
         }
 
         // If document doesn't exist, or is a flat document
-        if (!document || document.unsupported || document.layers.all.size === 1 &&
+        if (!document || document.layers.all.size === 1 &&
             document.layers.all.first().isBackground) {
             return Promise.resolve();
         }

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -283,7 +283,8 @@ define(function (require, exports, module) {
             
             var classNames = classnames({
                 "scrim": true,
-                "scrim-drop": this.state.isDropTarget
+                "scrim-drop": this.state.isDropTarget,
+                "scrim__disabled": document && document.unsupported
             });
 
             // Only the mouse event handlers are attached to the scrim

--- a/src/style/scrim.less
+++ b/src/style/scrim.less
@@ -34,6 +34,12 @@
     cursor: copy;
 }
 
+.scrim__disabled {
+    cursor: not-allowed;
+    background-color: white;
+    opacity: 0.01;
+}
+
 .scrim svg {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
When the current document is unsupported (3D / non-RGB color mode):

1. all mouse interaction is disabled by blocking mouse events to the canvas.
2. document's layers are deselected by default, to prevent keyboard events (e.g. using arrow keys to change layer positon)

Hopefully will address issue #2545 completely. 