### PR TITLE
sampler: hide sampler HUB on zoom, scroll, resize

### DIFF
--- a/src/js/stores/style.js
+++ b/src/js/stores/style.js
@@ -55,7 +55,8 @@ define(function (require, exports, module) {
                 events.RESET, this._handleReset,
                 events.style.COPY_STYLE, this._copyStyle,
                 events.style.SHOW_HUD, this._showHUD,
-                events.style.HIDE_HUD, this._hideHUD
+                events.style.HIDE_HUD, this._hideHUD,
+                events.ui.TRANSFORM_UPDATED, this._hideHUD
             );
 
             this._handleReset();
@@ -130,10 +131,12 @@ define(function (require, exports, module) {
          * @private
          */
         _hideHUD: function () {
-            this._sampleTypes = null;
-            this._samplePoint = null;
+            if (this._sampleTypes) {
+                this._sampleTypes = null;
+                this._samplePoint = null;
 
-            this.emit("change");
+                this.emit("change");
+            }
         }
     });
 

--- a/src/js/tools/sampler.js
+++ b/src/js/tools/sampler.js
@@ -116,6 +116,10 @@ define(function (require, exports, module) {
             applicationStore = flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument();
             
+        if (!currentDocument) {
+            return;
+        }
+        
         if (event.detail.keyChar === " ") {
             flux.actions.sampler.showHUD(currentDocument, _currentMouseX, _currentMouseY);
         } else if (event.detail.keyCode === OS.eventKeyCode.ESCAPE) {


### PR DESCRIPTION

This PR addresses the follwoing sampler issues:

1. should hide the sampler HUB after zoom/scroll/resize (fixe #2850)
2. with sampler tool selected, hit space will throw error in no-doc mode.