### PR TITLE
Fix ordering of the typefaces list 

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -37,16 +37,17 @@ define(function (require, exports, module) {
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         SplitButton = require("jsx!js/jsx/shared/SplitButton"),
-        SplitButtonList = SplitButton.SplitButtonList,
-        SplitButtonItem = SplitButton.SplitButtonItem,
         LayerBlendMode = require("jsx!./LayerBlendMode"),
         Opacity = require("jsx!./Opacity"),
         Datalist = require("jsx!js/jsx/shared/Datalist"),
-        strings = require("i18n!nls/strings"),
-        collection = require("js/util/collection"),
-        Color = require("js/models/color"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
-        unit = require("js/util/unit");
+        SplitButtonList = SplitButton.SplitButtonList,
+        SplitButtonItem = SplitButton.SplitButtonItem,
+        strings = require("i18n!nls/strings"),
+        Color = require("js/models/color"),
+        collection = require("js/util/collection"),
+        unit = require("js/util/unit"),
+        mathUtil = require("js/util/math");
 
     /**
      * Minimum and maximum values for font size, leading and tracking.
@@ -142,12 +143,16 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Set the type face of the selected text layers from a font's postscript name.
+         * Set the type face of the selected text layers from a font's ID.
          * 
          * @private
-         * @param {string} postScriptName
+         * @param {string} typefaceID
          */
-        _handleTypefaceChange: function (postScriptName) {
+        _handleTypefaceChange: function (typefaceID) {
+            var typefaceIndex = mathUtil.parseNumber(typefaceID), // typefaceID is equivalent to index in typefaces
+                typeface = this.state.typefaces.get(typefaceIndex),
+                postScriptName = typeface && typeface.postScriptName;
+
             if (!postScriptName) {
                 return;
             }
@@ -459,7 +464,11 @@ define(function (require, exports, module) {
                 }.bind(this)),
                 postScriptStyleName = collection.uniformValue(postScriptNames, function (a, b) {
                     return this._getPostScriptFontStyle(a) === this._getPostScriptFontStyle(b);
-                }.bind(this));
+                }.bind(this)),
+                selectedTypeface = this.state.typefaces.find(function (typeface) {
+                    return typeface.postScriptName === postScriptFamilyName;
+                }),
+                selectedTypefaceID = selectedTypeface && selectedTypeface.id;
 
             // The typeface family name and style for display in the UI
             var familyName,
@@ -617,7 +626,7 @@ define(function (require, exports, module) {
                             disabled={locked}
                             list={typefaceListID}
                             value={familyName}
-                            defaultSelected={postScriptFamilyName}
+                            defaultSelected={selectedTypefaceID}
                             placeholderText={placeholderText}
                             options={this.state.typefaces}
                             onChange={this._handleTypefaceChange}

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -55,12 +55,20 @@ define(function (require, exports, module) {
          * @type {Immutable.Map.<string, {family: string, font: string}>}
          */
         _postScriptMap: Immutable.Map(),
+        
+        /**
+         * @typedef {object} FontTypeface
+         * @property {string} id - value of id is typeface's index in the List pad with leading zeros (e.g. 0025, 1004)
+         *                         see `_handleInitFonts`
+         * @property {string} postScriptName
+         * @property {string} title
+         */
 
         /**
          * List of typefaces for populating datalists
          *
          * @private
-         * @type {Immutable.List.<{id: string, font: string}>}
+         * @type {Immutable.List.<FontTypeface>}
          */
         _typefaces: Immutable.List(),
 
@@ -313,19 +321,25 @@ define(function (require, exports, module) {
             // The list of all selectable type faces
             this._typefaces = this._postScriptMap
                 .entrySeq()
-                .sortBy(function (entry) {
-                    return entry[0];
-                })
                 .map(function (entry) {
                     var psName = entry[0],
                         fontObj = entry[1];
 
                     return {
-                        id: psName,
+                        postScriptName: psName,
                         title: fontObj.font
                     };
                 })
-                .toList();
+                .sortBy(function (typeface) {
+                    return typeface.title.toUpperCase();
+                })
+                .toList()
+                .map(function (typeface, index) {
+                    // typeface id is equivalent to its index in this._typefaces, pad with leading zeros.
+                    typeface.id = ("000" + index).slice(-4);
+
+                    return typeface;
+                });
 
             this._initialized = true;
             this.emit("change");


### PR DESCRIPTION
This PR addresses the following issues:

1 typeface should ordered case insensitively. (#2530)

<img width="250" alt="screen shot 2015-10-18 at 10 47 39 am" src="https://github-cloud.s3.amazonaws.com/assets/118264/10565667/4f8b3af8-758b-11e5-9ca4-68c37dc7d12a.png">

2 some typefaces are not ordered by title. This is becuase we ordered typeface by postScriptName, and it turns out that `title` does not always match with `postScriptName`. For example `title: Wide Latin, postScriptName: LatinWide`, `title: Wawati SC Regular, postScriptName: DFWaWaSC-W5`.

<img width="250" alt="screen shot 2015-10-18 at 11 24 45 am" src="https://github-cloud.s3.amazonaws.com/assets/118264/10565665/47dd47e2-758b-11e5-805a-d89bdc6c8a30.png">

The fix is to sort typefaces by upper case title, instead of postScriptName. However, it breaks the binary search in `Select._findIndex`, as postScriptNames (which are the ids of of Select's options) are longer ordered. So another change I made is replacing the ID with typeface index (zero padding string). I have several solutions, and this is the one that requires least changes. Do let me know if you have better solution :D

