### PR TITLE
Allow shortcuts when non-input elements have focus

### DIFF
--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -36,7 +36,8 @@ define(function (require, exports) {
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
         history = require("js/actions/history"),
-        policyActions = require("js/actions/policy");
+        policyActions = require("js/actions/policy"),
+        dom = require("js/util/dom");
 
     /**
      * Native menu command IDs for Photoshop edit commands.
@@ -51,37 +52,6 @@ define(function (require, exports) {
         SELECT_ALL_NATIVE_MENU_COMMMAND_ID = 1017;
 
     var LAYER_CLIPBOARD_FORMAT = "com.adobe.photoshop.spaces.design.layers";
-
-    /**
-     * Determines whether the given element is an HTML input element.
-     * 
-     * @private
-     * @param {HTMLElement} el
-     * @return {boolean}
-     */
-    var _isInput = function (el) {
-        return el instanceof window.HTMLInputElement;
-    };
-
-    /**
-     * Determines whether the given input element is a textual element.
-     * 
-     * @private
-     * @param {HTMLInputElement} el
-     * @return {boolean}
-     */
-    var _isTextInput = function (el) {
-        switch (el.type) {
-            case "text":
-            case "search":
-            case "url":
-            case "tel":
-            case "password":
-                return true;
-            default:
-                return false;
-        }
-    };
 
     /**
      * Execute a native cut command.
@@ -186,8 +156,8 @@ define(function (require, exports) {
                 var el = window.document.activeElement,
                     data;
 
-                if (cefHasFocus && _isInput(el)) {
-                    if (_isTextInput(el)) {
+                if (cefHasFocus && dom.isInput(el)) {
+                    if (dom.isTextInput(el)) {
                         data = el.value.substring(el.selectionStart, el.selectionEnd);
                         if (cut) {
                             el.setRangeText("");
@@ -277,7 +247,7 @@ define(function (require, exports) {
             .bind(this)
             .then(function (cefHasFocus) {
                 var el = window.document.activeElement;
-                if (cefHasFocus && _isInput(el)) {
+                if (cefHasFocus && dom.isInput(el)) {
                     return os.clipboardRead()
                         .then(function (result) {
                             var data = result.data,
@@ -287,7 +257,7 @@ define(function (require, exports) {
                                 return;
                             }
 
-                            if (_isTextInput(el)) {
+                            if (dom.isTextInput(el)) {
                                 var selectionStart = el.selectionStart;
                                 el.setRangeText(data);
                                 el.setSelectionRange(selectionStart + data.length, selectionStart + data.length);
@@ -355,8 +325,8 @@ define(function (require, exports) {
             .bind(this)
             .then(function (cefHasFocus) {
                 var el = window.document.activeElement;
-                if (cefHasFocus && _isInput(el)) {
-                    if (_isTextInput(el)) {
+                if (cefHasFocus && dom.isInput(el)) {
+                    if (dom.isTextInput(el)) {
                         el.setSelectionRange(0, el.value.length);
                     }
                 } else {

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -34,7 +34,8 @@ define(function (require, exports) {
         locks = require("js/locks"),
         policy = require("js/actions/policy"),
         EventPolicy = require("js/models/eventpolicy"),
-        KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
+        KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
+        dom = require("js/util/dom");
 
     /**
      * Add a keyboard shortcut command. Registers the handler function and sets
@@ -199,18 +200,22 @@ define(function (require, exports) {
                     return;
                 }
 
-                // If an HTML element is focused, only attempt to match the shortcut
+                // If an HTML text input is focused, only attempt to match the shortcut
                 // if there are modifiers other than shift.
                 if (event.target !== window.document.body &&
+                    dom.isTextInput(event.target) &&
                     (event.detail.modifierBits === os.eventModifiers.NONE ||
                         event.detail.modifierBits === os.eventModifiers.SHIFT)) {
                     return;
                 }
 
                 var handlers = shortcutStore.matchShortcuts(event.detail, capture);
-                handlers.forEach(function (handler) {
-                    handler(event);
-                });
+                if (handlers.length > 0) {
+                    event.target.blur();
+                    handlers.forEach(function (handler) {
+                        handler(event);
+                    });
+                }
             };
         };
 

--- a/src/js/util/dom.js
+++ b/src/js/util/dom.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    /**
+     * Determines whether the given element is an HTML input element.
+     * 
+     * @param {HTMLElement} el
+     * @return {boolean}
+     */
+    var isInput = function (el) {
+        return el instanceof window.HTMLInputElement;
+    };
+
+    /**
+     * Determines whether the given input element is a textual element.
+     * 
+     * @param {HTMLInputElement} el
+     * @return {boolean}
+     */
+    var isTextInput = function (el) {
+        switch (el.type) {
+            case "text":
+            case "search":
+            case "url":
+            case "tel":
+            case "password":
+                return true;
+            default:
+                return false;
+        }
+    };
+
+    exports.isInput = isInput;
+    exports.isTextInput = isTextInput;
+});


### PR DESCRIPTION
Currently, global shortcuts are disabled when any HTML element has focus. This makes sense when the focused element is a text input (typing `v` should insert a `v` character, not activate the select tool), but makes less sense for focused non-input elements like the color swatch. This prevents you, e.g., from dismissing the color picker (which focuses the swatch) and then immediately selecting a tool without first hitting escape, which seems pedantic.

This changes the shortcut matching algorithm to only be disabled for focused input elements. Furthermore, if a non-input element is focused and there is some shortcut that matches then the focused element is blurred before executing the handlers.

I'm pretty sure there was an open issue about this, but darned if I can find it.