### PR TITLE
Disable overlays before setting the transform

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -246,9 +246,12 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setTransform = function (transformObject) {
-        return descriptor.getProperty("document", "zoom")
-            .get("_value")
+        return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
             .bind(this)
+            .then(function () {
+                return descriptor.getProperty("document", "zoom");
+            })
+            .get("_value")
             .catch(function () {
                 return null;
             })


### PR DESCRIPTION
Disable overlays before setting the transform to prevent artboard buttons from flashing in the previous location at the end of a pan when the cloak ends. 

Addresses #2714.