### PR TITLE
Add missing onChange prop to ColorPicker

### DIFF
--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -142,10 +142,10 @@ define(function (require, exports, module) {
                     React.PropTypes.instanceOf(Color),
                     React.PropTypes.instanceOf(Immutable.Iterable)
                 ]),
-            onChange: React.PropTypes.func,
             onFocus: React.PropTypes.func,
-            onColorChange: React.PropTypes.func,
-            onAlphaChange: React.PropTypes.func,
+            onChange: React.PropTypes.func.isRequired,
+            onColorChange: React.PropTypes.func.isRequired,
+            onAlphaChange: React.PropTypes.func.isRequired,
             editable: React.PropTypes.bool,
             swatchOverlay: React.PropTypes.func
         },
@@ -153,10 +153,7 @@ define(function (require, exports, module) {
         getDefaultProps: function () {
             return {
                 defaultColor: Color.DEFAULT,
-                onChange: _.identity,
-                onFocus: _.identity,
-                onAlphaChange: _.identity,
-                onColorChange: _.identity
+                onFocus: _.identity
             };
         },
 
@@ -395,6 +392,7 @@ define(function (require, exports, module) {
                             editable={this.props.editable}
                             opaque={this.props.opaque}
                             color={color}
+                            onChange={this.props.onChange}
                             onAlphaChange={this.props.onAlphaChange}
                             onColorChange={this.props.onColorChange} />
                     </Dialog>

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -814,17 +814,14 @@ define(function (require, exports, module) {
 
         propTypes: {
             color: React.PropTypes.instanceOf(Color),
-            onChange: React.PropTypes.func,
-            onColorChange: React.PropTypes.func,
-            onAlphaChange: React.PropTypes.func
+            onChange: React.PropTypes.func.isRequired,
+            onColorChange: React.PropTypes.func.isRequired,
+            onAlphaChange: React.PropTypes.func.isRequired
         },
 
         getDefaultProps: function () {
             return {
-                color: Color.DEFAULT,
-                onChange: _.identity,
-                onAlphaChange: _.identity,
-                onColorChange: _.identity
+                color: Color.DEFAULT
             };
         },
 
@@ -949,8 +946,6 @@ define(function (require, exports, module) {
                         currentRgbaColor.b !== nextRgbaColor.b) {
                         this._changeColor(nextRgbaColor);
                     }
-
-                    this.props.onChange(nextRgbaColor);
                 }
             }
         },
@@ -993,7 +988,7 @@ define(function (require, exports, module) {
          */
         _changeColor: function (color) {
             var coalesce = this.shouldCoalesce();
-            this.props.onColorChange(color, coalesce);
+            this.props.onChange(color, coalesce);
             if (!coalesce) {
                 headlights.logEvent("edit", "color-input", "palette-click");
             }


### PR DESCRIPTION
The `ColorInput` has three change event handlers:

1. `onColorChange` for changes to the opaque (RGB) color;
2. `onAlphaChange` for changes to the alpha (and not RGB) value;
3. `onChange` for arbitrary color changes.

The latter wasn't correctly percolating from the `ColorInput` to the internal `ColorPicker` component, which prevented color changes in the picker's text input to not correctly propagate changes to the opacity. This fixes that.

One reason why this problem wasn't caught earlier is that the three handlers were not marked as required for either component, and the default value for `onChange` was the identity. To avoid this in teh future, all three handlers are now marked as required for both components.

These components have become fairly convoluted since moving the text input inside the picker itself. We should look into smoothing them out a bit after M3.

Addresses #3003. 