### PR TITLE
Effects panel subheader colors corrected

### DIFF
--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -256,7 +256,7 @@ define(function (require, exports, module) {
             return (
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
-                        <h3 className="section-title">
+                        <h3 className="section-title__subtitle">
                             {strings.STYLE.COLOR_OVERLAY.TITLE}
                         </h3>
                     </header>

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -330,7 +330,7 @@ define(function (require, exports, module) {
             return (
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
-                        <h3 className="section-title">
+                        <h3 className="section-title__subtitle">
                             {strings.STYLE.STROKE_EFFECT.TITLE}
                         </h3>
                     </header>

--- a/src/js/jsx/sections/style/UnsupportedEffectList.jsx
+++ b/src/js/jsx/sections/style/UnsupportedEffectList.jsx
@@ -164,7 +164,7 @@ define(function (require, exports, module) {
             return (
                 <div className="unsupported-effect-list effect-list__container">
                     <header className="section-header section-header__no-padding">
-                        <h3 className="section-title">
+                        <h3 className="section-title__subtitle">
                             {strings.STYLE.UNSUPPORTED_EFFECTS.TITLE}
                         </h3>
                     </header>

--- a/src/style/sections/style/layer-effect.less
+++ b/src/style/sections/style/layer-effect.less
@@ -65,13 +65,18 @@
         justify-content: space-between;
         align-items: center;
         padding: 0.4em 0.6em;
-        border: @hairline solid @underlines;
+        border: @hairline solid @item-disabled;
         margin: 0.4em 0;
-        border-radius: 0.6em;
+        border-radius: 0.4em;
+
+        &__title {
+            font-style: italic;
+            color: @item-inactive;
+        }
         
         &:hover {
-            border: @hairline solid @item-active;
-            color: @item-active;
+            border: @hairline solid item-disabled;
+            color: @item-inactive;
         }
         
         &__index {


### PR DESCRIPTION
References #3008 

Before: 
![](https://www.dropbox.com/s/bgt00vy4kmkc11i/Screenshot%202015-10-19%2009.57.34.png?raw=1)

After: 
![](https://www.dropbox.com/s/4pre0k4ohz1lvfw/Screenshot%202015-10-19%2009.56.27.png?raw=1)
![](https://www.dropbox.com/s/pf30j1g3zps1cx7/Screenshot%202015-10-19%2014.21.42.png?raw=1) @placegraphichere has :white_check_mark: the look of unsupported layer effects. 