### PR TITLE
Fix panel/column visibility toggle race

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
         synchronization = require("js/util/synchronization");
 
     var PanelSet = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("application", "document")],
+        mixins: [FluxMixin, StoreWatchMixin("application", "document", "preferences")],
         
         /**
          * Get the active document from flux and add it to the state.
@@ -214,7 +214,6 @@ define(function (require, exports, module) {
             }
 
             this.getFlux().actions.preferences.setPreferences(nextState);
-            this.setState(nextState);
         },
 
         /** @ignore */
@@ -228,7 +227,6 @@ define(function (require, exports, module) {
             nextState[panelName] = !this.state[panelName];
 
             this.getFlux().actions.preferences.setPreferences(nextState);
-            this.setState(nextState);
         },
 
         render: function () {


### PR DESCRIPTION
This fixes a race condition in `PanelSet` when toggling panel and column visibility. Those functions would both call `setState` and `setPreferences`, both of which are asynchronous, without synchronization. In some interleavings, the toggled state is lost. (The details of the interleavings are complicated but boring.) This eliminates the _direct_ `setState` calls in favor of just setting the preferences, and then also having the component listen to the preferences store for updates.

Addresses #2448 again! @ktaki Please test, if you have a moment.