### PR TITLE
Typeface datalist updates with missing font name

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -466,17 +466,22 @@ define(function (require, exports, module) {
                 styleTitle,
                 placeholderText;
 
+            var anylayerTextWarning = layers.some(function (layer) {
+                return layer.textWarningLevel > 0;
+            });
+
             if (this.props.uniformLayerKind && !postScriptNames.isEmpty() && this.state.initialized) {
-                if (postScriptFamilyName) {
+                if (postScriptFamilyName || anylayerTextWarning) {
                     familyName = this._getPostScriptFontFamily(postScriptFamilyName);
                     if (!familyName) {
-                        if (layers.size > 1) {
-                            placeholderText = strings.STYLE.TYPE.MISSING;
+                        // Font is missing
+                        var uniformValue = collection.uniformValue(postScriptNames);
+                        if (uniformValue === null) {
+                            placeholderText = "[" + strings.STYLE.TYPE.MIXED + "]";
                         } else {
                             placeholderText = "[" + postScriptFamilyName + "]";
                         }
                     }
-                    
                     if (postScriptStyleName) {
                         styleTitle = this._getPostScriptFontStyle(postScriptStyleName);
                     } else {


### PR DESCRIPTION
There were some outstanding problems after #2983 got merged, this PR addresses them. @ktaki If you can double check below that these are the expected behaviors, that would be great. References issue #2917.

Expected behavior now:


| Case  | Placeholder Text |
| ------------- | ------------- |
| 1 missing font  | [name of the font]  |
| 2+ missing fonts    |  [Mixed Fonts]  |
| 1 present font    |  name of font  |
| 2+ present fonts    |  Mixed Fonts |
| 1+ missing and present fonts   |  [Mixed Fonts] |
| 1+ missing & all the same font   |  [name of the font] |
| 1+ present & all the same font   |  name of the font |


