### PR TITLE
 deselect paths when pen tool is not in vector mask mode

### DIFF
--- a/src/js/tools/pen.js
+++ b/src/js/tools/pen.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
         if (vectorMode) {
             selectVectorMask = descriptor.playObject(vectorMaskLib.activateVectorMaskEditing());
         } else {
-            selectVectorMask = Promise.resolve();
+            selectVectorMask = descriptor.playObject(vectorMaskLib.dropPathSelection());
         }
         return Promise.join(setPromise, selectVectorMask, disableSuppressionPromise,
             backspacePromise, deletePromise);


### PR DESCRIPTION
fix for issue #3029 
requires https://github.com/adobe-photoshop/spaces-adapter/pull/159