### PR TITLE
Instrument all external links with Headlights API

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -125,13 +125,16 @@ define(function (require, exports) {
     /**
      * Open a URL in the user's default browser.
      * 
-     * @param {{url: string}} payload
+     * @param {{url: string, category: string, subcategory: string, eventName: string}} payload
      * @return {Promise}
      */
     var openURL = function (payload) {
         if (!payload.hasOwnProperty("url")) {
             var error = new Error("Missing URL");
             return Promise.reject(error);
+        }
+        if (payload.category !== null && payload.subcategory !== null && payload.eventName !== null) {
+            headlights.logEvent(payload.category, payload.subcategory, payload.eventName);
         }
 
         return adapter.openURLInDefaultBrowser(payload.url);

--- a/src/js/jsx/help/FirstLaunch.jsx
+++ b/src/js/jsx/help/FirstLaunch.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         strings = require("i18n!nls/strings"),
         ui = require("js/util/ui"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
-        
+ 
     var FirstLaunch = React.createClass({
         mixins: [FluxMixin],
 
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
                             <ul className="carousel__slide__three__list">
                                 <li>
                                     <div
-                                        onClick={ui.openURL.bind(null, psDesignTwitterURL)}>
+                                        onClick={ui.openURL.bind(null, psDesignTwitterURL, "twitter")}>
                                         <SVGIcon
                                             CSSID="bird"/>
                                         <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_FIRST}</h2>
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
                             <ul className="carousel__slide__three__list">
                                 <li>
                                     <div
-                                        onClick={ui.openURL.bind(null, githubURL)}>
+                                        onClick={ui.openURL.bind(null, githubURL, "github")}>
                                         <SVGIcon
                                             CSSID="github"/>
                                         <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_SECOND}</h2>
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
                             <ul className="carousel__slide__three__list">
                                 <li>
                                     <div
-                                        onClick={ui.openURL.bind(null, psForumURL)}>
+                                        onClick={ui.openURL.bind(null, psForumURL, "forum")}>
                                         <SVGIcon
                                             CSSID="workspace"/>
                                         <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_THIRD}</h2>

--- a/src/js/util/ui.js
+++ b/src/js/util/ui.js
@@ -32,7 +32,8 @@ define(function (require, exports) {
         hitTestLib = require("adapter/lib/hitTest");
 
     var Bounds = require("js/models/bounds"),
-        Color = require("js/models/color");
+        Color = require("js/models/color"),
+        headlights = require("js/util/headlights");
 
     /**
      * Calculates the bounds of the name badge, used for artboards
@@ -105,10 +106,13 @@ define(function (require, exports) {
      *
      * @param {string} url
      * @param {SyntheticEvent?} event
+     * @param {string} name
      */
-    var openURL = function (url, event) {
+    var openURL = function (url, event, name) {
         adapter.openURLInDefaultBrowser(url);
-        
+
+        headlights.logEvent("UserInterface", "introduction", name);
+
         if (event && event.stopPropagation) {
             event.stopPropagation();
         }

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -480,21 +480,30 @@
         "TWITTER": {
             "$action": "menu.openURL",
             "$payload": {
-                "url": "https://www.adobe.com/go/designspace-twitter"
+                "url": "https://www.adobe.com/go/designspace-twitter",
+                "category": "help",
+                "subcategory": "external-link",
+                "eventName": "twitter"
             },
             "$enable-rule": "always-except-modal"
         },
         "HELPX": {
             "$action": "menu.openURL",
             "$payload": {
-                "url": "https://www.adobe.com/go/designspace-help"
+                "url": "https://www.adobe.com/go/designspace-help",
+                "category": "help",
+                "subcategory": "external-link",
+                "eventName": "helpX"
             },
             "$enable-rule": "always-except-modal"
         },
         "FORUM": {
             "$action": "menu.openURL",
             "$payload": {
-                "url": "https://www.adobe.com/go/designspace-forum"
+                "url": "https://www.adobe.com/go/designspace-forum",
+                "category": "help",
+                "subcategory": "external-link",
+                "eventName": "forum"
             },
             "$enable-rule": "always-except-modal"
         }


### PR DESCRIPTION
References issue #1648 

Added calls to the Headlights API for the Introduction screen (Twitter, Github, and Forum) and the menu (Twitter, HelpX, and Forum) 

If we choose to merge this as is, then we need to update this wiki with the new headlights trio that is being used: https://github.com/adobe-photoshop/spaces-design/wiki/Headlights-Categories,-Subcategories,-and-Events