### PR TITLE
Artboard Sorting Issue with out-of-aligment rows

### DIFF
--- a/src/js/util/gridsort.js
+++ b/src/js/util/gridsort.js
@@ -110,6 +110,9 @@ define(function (require, exports, module) {
             .sort(function (a, b) {
                 return a.bounds.left - b.bounds.left;
             })
+            .sort(function (a, b) {
+                return a.bounds.top - b.bounds.top;
+            })
             .reduce(_.ary(_addLayerToRow, 2), []);
 
         // flatten the array of "rows" into a simple list of layers

--- a/src/js/util/gridsort.js
+++ b/src/js/util/gridsort.js
@@ -108,11 +108,20 @@ define(function (require, exports, module) {
                 return layer.bounds && !layer.bounds.empty;
             })
             .sort(function (a, b) {
-                return a.bounds.left - b.bounds.left;
+                var top = a.bounds.top - b.bounds.top >= 0 ? true : false;
+                var bottom = a.bounds.top >= b.bounds.bottom ? false : true;
+                var left = a.bounds.left - b.bounds.left <= 0 ? false : true;
+                if(bottom && left) {
+                    return 1;
+                } else  {
+                    return -1;
+                }
+                
+                //return a.bounds.left - b.bounds.left;
             })
-            .sort(function (a, b) {
+            /*.sort(function (a, b) {
                 return a.bounds.top - b.bounds.top;
-            })
+            })*/
             .reduce(_.ary(_addLayerToRow, 2), []);
 
         // flatten the array of "rows" into a simple list of layers


### PR DESCRIPTION
Artboards in a second row placed to the left of the first row would get the AB prefix ordering all messed up. This appears to fix that, but needs review. Fix is just adding an additional sort() to do first left-to-right, THEN sort() top-to-bottom.
- possible fix for #2947

Should fix this repro case shown here (and the file in the original issue):
![screen shot 2015-10-20 at 3 44 40 pm](https://cloud.githubusercontent.com/assets/3229167/10621028/bfb099c2-7743-11e5-85a8-224a0f5e80d8.png)

![screen shot 2015-10-20 at 3 45 59 pm](https://cloud.githubusercontent.com/assets/3229167/10621038/d42fe286-7743-11e5-8cdd-92ba1c5bd7a6.png)

![screen shot 2015-10-20 at 3 48 36 pm](https://cloud.githubusercontent.com/assets/3229167/10621109/524aa4bc-7744-11e5-9884-692d2686bcfe.png)


