### PR TITLE
Fix for copy/paste buttons in appearance and effects panels

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -238,26 +238,28 @@ define(function (require, exports) {
         }
 
         var firstLayer = currentLayers.last(), // currentLayers are in reversed order
-            layerFileName;
+            representationType = REP_PHOTOSHOP_TYPE;
         
         // However, if the layer is a smart object, and is owned by some other app, we need to change representation
         // we do this by matching extensions
         if (currentLayers.size === 1 && firstLayer.isSmartObject()) {
-            layerFileName = firstLayer.smartObject.fileReference;
+            var layerFileName = firstLayer.smartObject.fileReference;
 
             // layerFileName will be undefined if CC Libraries is uploading the same layer.
             if (!layerFileName) {
                 return Promise.resolve();
             }
+            
+            var fileExtension = pathUtil.extension(layerFileName);
+            
+            representationType = EXTENSION_TO_REPRESENTATION_MAP[fileExtension];
+
+            if (!representationType) {
+                throw new Error("Cannot find representation type of extension: " + fileExtension);
+            }
         }
 
-        var fileExtension = pathUtil.extension(layerFileName),
-            representationType = EXTENSION_TO_REPRESENTATION_MAP[fileExtension],
-            newElement;
-
-        if (!representationType) {
-            throw new Error("Cannot find representation type of extension: " + fileExtension);
-        }
+        var newElement;
 
         return _getTempPaths()
             .bind(this)

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -57,7 +57,7 @@ define(function (require, exports) {
             coalesce: false
         };
 
-        return _.merge(options, {
+        return _.merge({}, options, {
             paintOptions: {
                 immediateUpdate: true,
                 quality: "draft"
@@ -172,6 +172,8 @@ define(function (require, exports) {
     var setStroke = function (document, layers, stroke, options) {
         // if enabled is not provided, assume it is true
         // derive the type of event to be dispatched based on this parameter's existence
+        options = _.merge({}, options); // create a copy of the options
+        
         var eventName;
 
         if (options.enabled === undefined || options.enabled === null) {
@@ -245,6 +247,7 @@ define(function (require, exports) {
     var setStrokeColor = function (document, layers, color, options) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
+        options = _.merge({}, options); // make a copy of the options
 
         // if enabled is not provided, assume it is true
         // derive the type of event to be dispatched based on this parameter's existence
@@ -497,6 +500,7 @@ define(function (require, exports) {
         // if a color is provided, adjust the alpha to one that can be represented as a fraction of 255
         color = color ? color.normalizeAlpha() : null;
         // if enabled is not provided, assume it is true
+        options = _.merge({}, options);
         options.enabled = (options.enabled === undefined) ? true : options.enabled;
 
         // dispatch the change event    

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -148,6 +148,7 @@ define(function (require, exports, module) {
         },
         style: {
             COPY_STYLE: "copyStyle",
+            COPY_EFFECTS: "copyEffects",
             SHOW_HUD: "showStyleHUD",
             HIDE_HUD: "hideStyleHUD"
         },

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -111,10 +111,10 @@ define(function (require, exports, module) {
         getStateFromFlux: function () {
             var flux = this.getFlux(),
                 styleStore = flux.store("style"),
-                clipboardStyle = styleStore.getClipboardStyle();
+                clipboardEffects = styleStore.getClipboardEffects();
 
             return {
-                clipboard: clipboardStyle
+                clipboard: clipboardEffects
             };
         },
 
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
             var document = this.props.document,
                 source = document.layers.selected.first();
 
-            this.getFlux().actions.sampler.copyLayerStyle(document, source);
+            this.getFlux().actions.sampler.copyLayerEffects(document, source);
             event.stopPropagation();
         },
 
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
             var document = this.props.document,
                 targetLayers = this.props.document.layers.selected;
 
-            this.getFlux().actions.sampler.pasteLayerStyle(document, targetLayers);
+            this.getFlux().actions.sampler.pasteLayerEffects(document, targetLayers);
             event.stopPropagation();
         },
 

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
                 return;
             }
 
-            flux.actions.layers.setOpacityThrottled(document, layers, color.opacity, coalesce);
+            flux.actions.layers.setOpacityThrottled(document, layers, color.opacity, { coalesce: coalesce });
         },
 
         /**

--- a/src/js/stores/style.js
+++ b/src/js/stores/style.js
@@ -39,6 +39,14 @@ define(function (require, exports, module) {
          * @type {object}
          */
         _storedStyle: null,
+        
+        /**
+         * Currently stored effects object for copy/pasting
+         * 
+         * @private
+         * @type {LayerEffectsMap}
+         */
+        _storedEffects: null,
 
         /**
          * Currently active sample types based on selection / clicked point
@@ -54,6 +62,7 @@ define(function (require, exports, module) {
             this.bindActions(
                 events.RESET, this._handleReset,
                 events.style.COPY_STYLE, this._copyStyle,
+                events.style.COPY_EFFECTS, this._copyEffects,
                 events.style.SHOW_HUD, this._showHUD,
                 events.style.HIDE_HUD, this._hideHUD,
                 events.ui.TRANSFORM_UPDATED, this._hideHUD
@@ -69,6 +78,15 @@ define(function (require, exports, module) {
          */
         getClipboardStyle: function () {
             return this._storedStyle;
+        },
+        
+        /**
+         * Returns the currently copied effects object
+         *
+         * @return {LayerEffectsMap}
+         */
+        getClipboardEffects: function () {
+            return this._storedEffects;
         },
 
         /**
@@ -96,6 +114,7 @@ define(function (require, exports, module) {
          */
         _handleReset: function () {
             this._storedStyle = null;
+            this._storedEffects = null;
             this._sampleTypes = null;
         },
 
@@ -107,6 +126,18 @@ define(function (require, exports, module) {
          */
         _copyStyle: function (payload) {
             this._storedStyle = payload.style;
+
+            this.emit("change");
+        },
+        
+        /**
+         * Saves the passed in effects internally for pasting
+         *
+         * @private
+         * @param {object} payload
+         */
+        _copyEffects: function (payload) {
+            this._storedEffects = payload.effects;
 
             this.emit("change");
         },


### PR DESCRIPTION
This PR makes two changes to the copy/paste buttons:

1 copy/paste buttons in the appearances now include opacity, radius, and blend mode. This should apply for text layer, vector layer, and other layers (e.g. SO). You can checkout the video for more details of the bahaviors: https://www.dropbox.com/s/lao6v0xo6nezt0g/copy-styles.mov?dl=0. Addresses #2755 

2 copy/paste buttons in the effects panel should only apply to layer effects (used to include appearance styles). Same for the appearance panel, buttons should not copy/paste layer effects. 

###### Known issues that are not introduced from this PR (I will create separate issues later)

1 copy/paste appearance between two text layers with different opacity result in number change back and forth.

![text-styles](https://cloud.githubusercontent.com/assets/118264/10621526/34bf23ea-7736-11e5-8d10-37ed838fb837.gif)

2 undo paste-styles some times does not reset the appeanrace panel