### PR TITLE
Fix updating position of locked layers

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -423,12 +423,7 @@ define(function (require, exports) {
                 historyStateInfo: {
                     name: strings.ACTIONS.SET_LAYER_POSITION,
                     target: documentLib.referenceBy.id(document.id)
-                },
-                // Setting this to false allows PS to send us
-                // notifications that happen as a result of this
-                // action, in conjunction with `suppresPlayLevelIncrease`
-                // flag in the descriptor
-                synchronous: false
+                }
             };
 
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.REPOSITION_LAYERS, payload)


### PR DESCRIPTION
Updating position from the transform panel is broken for a locked layer (#3019). I traced down our commits and found the cause: we set to run the descriptor asynchronously for `transforms.setPosition`, and it might break the lock overwrite mechanism (position is set before the layer is unlocked). The change was introduced from #2626, however, I am not familiar with transform enough to figure out the purpose of this change. I marked this for discussion, and let me know if you know the purpose of the `synchronous: false` setting, or the way to work around this in lock overwrite mode.

