### PR TITLE
move layer history fix

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2288,6 +2288,7 @@ define(function (require, exports) {
     handleCanvasShift.reads = [locks.JS_DOC];
     handleCanvasShift.writes = [];
     handleCanvasShift.transfers = [resetBounds];
+    handleCanvasShift.modal = true;
 
     /**
      * Reveal and select the vector mask of the selected layer. 

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -597,7 +597,7 @@ define(function (require, exports, module) {
                 var documentID = this._getDocumentID(payload),
                     document = documentStore.getDocument(documentID),
                     documentExports = exportStore.getDocumentExports(documentID),
-                    nextState = new HistoryState({ document: document, documentExports: documentExports });
+                    nextState = { document: document, documentExports: documentExports };
 
                 if (!document) {
                     throw new Error("Could not amend history state, document not found: " + documentID);


### PR DESCRIPTION
This is a follow-up fix for #2831

1. Allow handleCanvasShift action during modal state.  When dragging a layer, a canvas shift may occur during the drag.  It seems safe to me to allow that action to get queued up without breaking modal state.
1. A narrow fix of the history amendment process which should *not* overwrite the "rogue" flag (set when we get a history state event for an action that photoshop initiates).  The bug here is that if that rogue flag gets reset, then our follow-up action won't know it is safe to amend the roguely-created history state.