### PR TITLE
Handle step back/forward events that get initiated in photoshop

### DIFF
--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -366,7 +366,7 @@ define(function (require, exports) {
         } else {
             return Promise.join(
                 this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false }),
-                this.transfer(history.decrementHistory, currentDocument),
+                this.transfer(history.decrementHistory, currentDocument.id),
                 function () {
                     return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
                 }.bind(this));
@@ -390,7 +390,7 @@ define(function (require, exports) {
         } else {
             return Promise.join(
                 this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false }),
-                this.transfer(history.incrementHistory, currentDocument),
+                this.transfer(history.incrementHistory, currentDocument.id),
                 function () {
                     return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
                 }.bind(this));

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -77,51 +77,54 @@ define(function (require, exports) {
     queryCurrentHistory.modal = true;
 
     /**
-     * Given a history state event from photoshop, dispatch a flux event for the history store
+     * Helper function to load a state from history store based on a count offset
+     * and then to fix it up with the latest selection state, visibility state, and
+     * then reset border policies
      *
-     * @param {object} event a raw historyState event from photoshop
+     * @private
+     * @param {number} documentID
+     * @param {number} count
      * @return {Promise}
      */
-    var handleHistoryState = function (event) {
-        // This assumption of current document could be problematic
-        // but would require a core change to include document ID
-        var currentDocumentID = this.flux.store("application").getCurrentDocumentID();
+    var _loadHistory = function (documentID, count) {
+        return descriptor.getProperty(documentLib.referenceBy.id(documentID), "targetLayers")
+            .bind(this)
+            .catch(function () {
+                // no targetLayers property means no document is open
+                return [];
+            })
+            .then(function (targetLayers) {
+                var selectedIndices = _.pluck(targetLayers, "_index");
+                return this.dispatchAsync(events.history.LOAD_HISTORY_STATE, {
+                    documentID: documentID,
+                    count: count,
+                    selectedIndices: selectedIndices
+                });
+            })
+            .then(function () {
+                var currentDocument = this.flux.store("application").getCurrentDocument(),
+                    borderPromise = this.transfer(toolActions.resetBorderPolicies),
+                    visibilityPromise = this.transfer(layerActions.resetLayerVisibility, currentDocument);
 
-        // Ignore if either there is no current document,
-        // or if this history state is related to another document
-        if (currentDocumentID === null || currentDocumentID !== event.documentID) {
-            log.debug("Ignoring this historyState event, probably because it was for a non-current document");
-            return Promise.resolve();
-        }
-
-        var payload = {
-            source: "listener", // for human convenience
-            documentID: currentDocumentID,
-            name: event.name,
-            totalStates: event.historyStates + 1, // yes, seriously.
-            currentState: event.currentHistoryState // seems to be zero-base already (unlike get historyState)
-        };
-        return this.dispatchAsync(events.history.PS_HISTORY_EVENT, payload);
+                return Promise.join(borderPromise, visibilityPromise);
+            });
     };
-    handleHistoryState.reads = [locks.JS_DOC, locks.JS_APP];
-    handleHistoryState.writes = [locks.JS_HISTORY];
-    handleHistoryState.modal = true;
 
     /**
      * Go forward or backward in the history state by playing the appropriate photoshop action
      * and either loading a state from the history store's cache, or calling updateDocument
      *
      * @private
-     * @param {Document} document
+     * @param {number} documentID
      * @param {number} count increment history state by this number, should be either 1 or -1
      * @return {Promise}
      */
-    var _navigateHistory = function (document, count) {
-        if (document === undefined) {
-            document = this.flux.store("application").getCurrentDocument();
+    var _navigateHistory = function (documentID, count) {
+        if (documentID === undefined) {
+            documentID = this.flux.store("application").getCurrentDocumentID();
         }
 
-        if (!document) {
+        if (!documentID) {
             throw new Error("History changed without an open document");
         }
 
@@ -131,12 +134,12 @@ define(function (require, exports) {
             hasNextStateCached;
 
         if (count === 1) {
-            hasNextState = historyStore.hasNextState(document.id);
-            hasNextStateCached = historyStore.hasNextStateCached(document.id);
+            hasNextState = historyStore.hasNextState(documentID);
+            hasNextStateCached = historyStore.hasNextStateCached(documentID);
             historyPlayObject = historyLib.stepForward;
         } else if (count === -1) {
-            hasNextState = historyStore.hasPreviousState(document.id);
-            hasNextStateCached = historyStore.hasPreviousStateCached(document.id);
+            hasNextState = historyStore.hasPreviousState(documentID);
+            hasNextStateCached = historyStore.hasPreviousStateCached(documentID);
             historyPlayObject = historyLib.stepBackward;
         } else {
             throw new Error("Count must be 1 or -1");
@@ -154,27 +157,7 @@ define(function (require, exports) {
             return descriptor.playObject(historyPlayObject)
                 .bind(this)
                 .then(function () {
-                    return descriptor.getProperty(documentLib.referenceBy.id(document.id), "targetLayers")
-                        .bind(this)
-                        .catch(function () {
-                            // no targetLayers property means no document is open
-                            return [];
-                        })
-                        .then(function (targetLayers) {
-                            var selectedIndices = _.pluck(targetLayers, "_index");
-                            return this.dispatchAsync(events.history.LOAD_HISTORY_STATE, {
-                                documentID: document.id,
-                                count: count,
-                                selectedIndices: selectedIndices
-                            });
-                        })
-                        .then(function () {
-                            var currentDocument = this.flux.store("application").getCurrentDocument(),
-                                borderPromise = this.transfer(toolActions.resetBorderPolicies),
-                                visibilityPromise = this.transfer(layerActions.resetLayerVisibility, currentDocument);
-
-                            return Promise.join(borderPromise, visibilityPromise);
-                        });
+                    return _loadHistory.call(this, documentID, count);
                 });
         } else {
             // If cached state is not available, we must wait for photoshop undo/redo to be complete
@@ -184,7 +167,7 @@ define(function (require, exports) {
                 .bind(this)
                 .then(function () {
                     return this.dispatchAsync(events.history.ADJUST_HISTORY_STATE, {
-                            documentID: document.id,
+                            documentID: documentID,
                             count: count });
                 })
                 .then(function () {
@@ -196,10 +179,10 @@ define(function (require, exports) {
     /**
      * Navigate to the next (future) history state
      *
-     * @param {Document} document
+     * @param {number} documentID
      * @return {Promise}
      */
-    var incrementHistory = function (document) {
+    var incrementHistory = function (documentID) {
         var modal = this.flux.store("tool").getModalToolState();
 
         if (modal) {
@@ -207,7 +190,7 @@ define(function (require, exports) {
             // Currently we are not disabling this menu action correctly, so this is for safety
             return Promise.resolve();
         } else {
-            return _navigateHistory.call(this, document, 1);
+            return _navigateHistory.call(this, documentID, 1);
         }
     };
     incrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
@@ -221,10 +204,10 @@ define(function (require, exports) {
      * If we're in a modal text edit state, play the native UNDO command.
      * Otherwise use the history store
      *
-     * @param {Document} document
+     * @param {number} documentID
      * @return {Promise}
      */
-    var decrementHistory = function (document) {
+    var decrementHistory = function (documentID) {
         var modal = this.flux.store("tool").getModalToolState();
 
         if (modal) {
@@ -234,7 +217,7 @@ define(function (require, exports) {
             };
             return ps.performMenuCommand(payload);
         } else {
-            return _navigateHistory.call(this, document, -1);
+            return _navigateHistory.call(this, documentID, -1);
         }
     };
     decrementHistory.reads = [locks.JS_DOC, locks.JS_APP];
@@ -292,12 +275,108 @@ define(function (require, exports) {
     revertCurrentDocument.modal = true;
 
     /**
+     * Given a history state event from photoshop, dispatch a flux event for the history store
+     *
+     * @param {object} event a raw historyState event from photoshop
+     * @return {Promise}
+     */
+    var handleHistoryState = function (event) {
+        // This assumption of current document could be problematic
+        // but would require a core change to include document ID
+        var documentID = this.flux.store("application").getCurrentDocumentID();
+
+        // Ignore if either there is no current document,
+        // or if this history state is related to another document
+        if (documentID === null || documentID !== event.documentID) {
+            log.debug("Ignoring this historyState event, probably because it was for a non-current document");
+            return Promise.resolve();
+        }
+
+        var payload = {
+            source: "listener", // for human convenience
+            documentID: documentID,
+            id: event.ID,
+            name: event.name,
+            totalStates: event.historyStates + 1, // yes, seriously.
+            currentState: event.currentHistoryState // seems to be zero-base already (unlike get historyState)
+        };
+        return this.dispatchAsync(events.history.PS_HISTORY_EVENT, payload);
+    };
+    handleHistoryState.reads = [locks.JS_DOC, locks.JS_APP];
+    handleHistoryState.writes = [locks.JS_HISTORY];
+    handleHistoryState.modal = true;
+
+    /**
+     * Given a history state event from photoshop that comes directly after a "select" event,
+     * Interpret this event's index as cause to adjust/load that history state.
+     * Validate the event as "previous" or "next" and that the offset is positive or negative 1
+     *
+     * @param {object} event a raw historyState event from photoshop
+     * @param {string} recentSelectEvent either "previous" or "next"
+     * @return {Promise}
+     */
+    var handleHistoryStateAfterSelect = function (event, recentSelectEvent) {
+        // This assumption of current document could be problematic
+        // but would require a core change to include document ID
+        var documentID = this.flux.store("application").getCurrentDocumentID();
+
+        if (documentID === null) {
+            return Promise.resolve();
+        }
+
+        var historyStore = this.flux.stores.history,
+            currentIndex = historyStore.currentIndex(documentID),
+            nextIndex = event.currentHistoryState;
+
+        if (_.isFinite(currentIndex) && _.isFinite(nextIndex)) {
+            var count = nextIndex - currentIndex,
+                prev = recentSelectEvent === "previous" && count === -1,
+                next = recentSelectEvent === "next" && count === 1;
+
+            if ((prev && historyStore.hasPreviousStateCached(documentID)) ||
+                (next && historyStore.hasNextStateCached(documentID))) {
+                // either load previous, or adjust & update
+                return _loadHistory.call(this, documentID, count);
+            } else {
+                // adjust pointer, and update doc
+                var payload = {
+                    documentID: documentID,
+                    count: count
+                };
+
+                return this.dispatchAsync(events.history.ADJUST_HISTORY_STATE, payload)
+                    .then(function () {
+                        return this.transfer(documentActions.updateDocument);
+                    });
+            }
+        } else {
+            // failsafe, if things are out of whack, nuke and pave
+            return this.dispatchAsync(events.history.DELETE_DOCUMENT_HISTORY, { documentID: documentID })
+                .then(function () {
+                    return this.transfer(documentActions.updateDocument);
+                });
+        }
+    };
+    handleHistoryStateAfterSelect.reads = [locks.JS_DOC];
+    handleHistoryStateAfterSelect.writes = [locks.JS_HISTORY];
+    handleHistoryStateAfterSelect.transfers = [toolActions.resetBorderPolicies, "layers.resetLayerVisibility",
+        "documents.updateDocument"];
+
+    /**
      * Event handlers initialized in beforeStartup.
      *
      * @private
      * @type {function()}
      */
-    var _historyStateHandler;
+    var _historyStateHandler,
+        _historySelectHandler;
+
+    /**
+     * String value of the most recent "select" event from photoshop.  Null if the event "expired"
+     * @type {?string}
+     */
+    var _recentSelectEvent,
+        _recentSelectTimer;
 
     /**
      * Register event listeners for step back/forward commands
@@ -306,11 +385,43 @@ define(function (require, exports) {
     var beforeStartup = function () {
         // We get these every time there is a new history state being created
         _historyStateHandler = function (event) {
-            log.info("History state event from photoshop (raw): currentState (index) %d, total states: %d",
+            log.debug("History state event from photoshop (raw): currentState (index) %d, total states: %d",
                  event.currentHistoryState, event.historyStates);
-            this.flux.actions.history.handleHistoryState(event);
+
+            if (_recentSelectTimer) {
+                // If a "select" event (undo/redo) was recently received, handle this event specially.
+                // This will validate the event and attempt to incr/decr history
+                window.clearTimeout(_recentSelectTimer);
+                log.debug("History state event received, and there was a recent history select event: %s",
+                    _recentSelectEvent);
+
+                this.flux.actions.history.handleHistoryStateAfterSelect(event, _recentSelectEvent);
+                _recentSelectTimer = null;
+                _recentSelectEvent = null;
+            } else {
+                // Handle this historyState event conventionally
+                this.flux.actions.history.handleHistoryState(event);
+            }
         }.bind(this);
         descriptor.addListener("historyState", _historyStateHandler);
+
+        // We get these every time there is a "select" event of type historyState
+        // This indicates an out of band undo/redo event that we try to handle
+        _historySelectHandler = function (event) {
+            var eventData = event["null"];
+            if (eventData && eventData._ref === "historyState" && eventData._value) {
+                log.debug("History SELECT event from photoshop _value: %s", eventData._value);
+
+                _recentSelectEvent = eventData._value;
+                _recentSelectTimer = window.setTimeout(function () {
+                    // If we don't get a follow-up historyState event, then we just reboot the doc
+                    this.flux.actions.document.updateDocument();
+                    _recentSelectEvent = null;
+                    _recentSelectTimer = null;
+                }.bind(this), 700);
+            }
+        }.bind(this);
+        descriptor.addListener("select", _historySelectHandler);
 
         return Promise.resolve();
     };
@@ -320,6 +431,9 @@ define(function (require, exports) {
     /** @ignore */
     var onReset = function () {
         descriptor.removeListener("historyState", _historyStateHandler);
+        descriptor.removeListener("select", _historySelectHandler);
+        _recentSelectEvent = null;
+        _recentSelectTimer = null;
 
         return Promise.resolve();
     };
@@ -327,10 +441,11 @@ define(function (require, exports) {
     onReset.writes = [];
 
     exports.queryCurrentHistory = queryCurrentHistory;
-    exports.handleHistoryState = handleHistoryState;
     exports.incrementHistory = incrementHistory;
     exports.decrementHistory = decrementHistory;
     exports.revertCurrentDocument = revertCurrentDocument;
+    exports.handleHistoryState = handleHistoryState;
+    exports.handleHistoryStateAfterSelect = handleHistoryStateAfterSelect;
     exports.beforeStartup = beforeStartup;
     exports.onReset = onReset;
 });

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -110,6 +110,16 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Find the current pointer by documentID
+         *
+         * @param {number} documentID
+         * @return {?number}
+         */
+        currentIndex: function (documentID) {
+            return this._current.get(documentID);
+        },
+
+        /**
          * Is there a next state in the document's history, regardless of status of the document in our cache
          *
          * @param {number} documentID


### PR DESCRIPTION
Handle touch-initiated time travel, by ~~attempting to load the given prev/next history state.~~ nuking history and updating the document.  This attempts such a maneuver only if a history state "select" event is soon followed by a historyState event for a prev/next history state.  These actions are also debounced so that 3-finger scrubbing will result in fewer updateDocument calls, hopefully just once when the scrubbing subsides.

The diff is a bit messy because I moved `handleHistoryState` further down in the file for organizational reasons, and factored out a `_loadHistory` helper function.

The crux of this PR is a short timer on the "select" handler (history state only) that, if it times out, will update the document.  Assuming that a historyState event follows quickly thereafter (<700ms) then it will  ~~attempt to navigate ONE step forward or ONE step back~~ nuke and pave.

This is not particularly pretty, but it should be limited to touch events, as we are not aware of other times that we would get history state select events.

~~It is very possible that scrubbing quickly through history states with touch will cause DS to freak out a little~~.  On net, I think this PR at least handles the simple case by keeping our model in sync.

A "best we can do" attempt at #2004 