### PR TITLE
Increase the timeout for export ws calls to two minutes

### DIFF
--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
      * @const
      * @type {number}
      */
-    var CONNECTION_TIMEOUT_MS = 20000;
+    var CONNECTION_TIMEOUT_MS = 120000;
 
     /**
      * Maximum number of retry attempts


### PR DESCRIPTION
Previous was 20 seconds, and it was fairly easy to cause this to bonk out for large exports.  For example:

1. Open a large JPG file in DS (my test case was 7MB)
1. Unlock the background layer, and add a PNG (default) asset
1. Export it - and note that you might see a console "timeout" message

Addresses (or reduces the frequency of) #2340