### PR TITLE
Fix issues caused by merging on undefined/null options using `_.merge`.

### DIFF
--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -68,7 +68,7 @@ define(function (require, exports) {
             },
             types = _.isArray(type) ? type : [type];
 
-        options = _.merge(options, syncOptions);
+        options = _.merge({}, options, syncOptions);
 
         // Map the layers to a list of playable objects
         layers.forEach(function (curLayer) {

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1553,7 +1553,7 @@ define(function (require, exports) {
             return layer.isBackground;
         });
         
-        options = _.merge({ coalesce: false }, options);
+        options = _.merge({}, options);
 
         var payload = {
                 documentID: document.id,

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -473,7 +473,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setFillEnabled = function (document, layers, options) {
-        options = _.merge(options, {
+        options = _.merge({}, options, {
             coalesce: false,
             ignoreAlpha: false
         });

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -966,7 +966,7 @@ define(function (require, exports) {
      * @param {boolean=} options.coalesce Whether this history state should be coalesce with the previous one
      */
     var setRadius = function (document, layers, radius, options) {
-        options = _.merge({ coalesce: false }, options);
+        options = _.merge({}, options);
         
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.RADII_CHANGED, {
             documentID: document.id,


### PR DESCRIPTION
Instead of merging on action options, we should merge on a plain object for the following reasons:

1. the option could be `undefined`, and `_merge(options, {enabled: true})` will return `undefined`, instead of `{enabled: true}`

2. merging on the `options` directly will pollute the object, and we should avoid doing that as the `options` may be shared between multiple actions. for example: https://github.com/adobe-photoshop/spaces-design/blob/master/src/js/actions/sampler.js#L583

So a recommneded / safer pattern would be:

```
_.merge({}, options, {enabled: true})
```

addresses issue #3034