### PR TITLE
Replace mergeDeep with merge in Layerstructure.prototype.resetBounds

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1089,9 +1089,7 @@ define(function (require, exports, module) {
             }, this);
         }.bind(this));
 
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+        return this.set("layers", nextLayers);
     };
 
     /**


### PR DESCRIPTION
This replaces an apparently unnecessary `mergeDeep` call with a faster `merge` call in `Layerstructure.prototype.resetBounds`. Changing a font in Vermilion previously looked like this:
![image](https://cloud.githubusercontent.com/assets/1075154/10647118/44c96a18-77fc-11e5-8b89-abd0b09deff5.png)

Now it looks like this:
![image](https://cloud.githubusercontent.com/assets/1075154/10647121/4e175030-77fc-11e5-98af-9823af6f5975.png)

That is, the time is now dominated by React instead of Immutable, saving ~250ms.

Addresses #3057. 