### PR TITLE
Fix a typo in Datalist's shouldComponentUpdate method

### DIFF
--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
 
             return (this.props.options !== nextProps.options ||
                 this.state.filter !== nextState.filter ||
-                this.props.placeholderText !== nextState.placeholderText ||
+                this.props.placeholderText !== nextProps.placeholderText ||
                 this.state.active !== nextState.active ||
                 this.state.suggestTitle !== nextState.suggestTitle ||
                 this.props.value !== nextProps.value);


### PR DESCRIPTION
Addresses #3065. 

It's a major bummer that simply returning true in `shouldComponentUpdate` breaks `Datalist`.