### PR TITLE
Change targeted dialog position via state, remove arrow of color picker when place above target

### DIFF
--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -1052,7 +1052,7 @@ define(function (require, exports, module) {
             });
 
             return (
-                <div className="color-picker">
+                <div>
                     <ColorType {...this.props}
                         ref="input"
                         color={color}

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -99,6 +99,10 @@
     &:before {
         .dialog-pointer(1.6rem);
     }
+    
+    &.placed-above:before {
+        display: none;
+    }
 }
 
 .color-picker .drop-down {


### PR DESCRIPTION
While attempting to work on #2560, I changed the targeted positioning of the dialogs to happen via state changes rather than the direct changing of properties

IT SEEMS TO WORK FINE. But that statement is a little worrisome, so more eyes/click to check would be better.

Also, that little arrow on the color picker goes away when it is placed above the target element