### PR TITLE
Allow nudging selected points in select vector-edit mode and pen tool

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2531,6 +2531,7 @@ define(function (require, exports) {
         descriptor.addListener("subtractFrom", _updateShapeHandler);
         // Supposed to be intersectWith, but it's defined twice and interfaceWhite is defined before
         descriptor.addListener("interfaceWhite", _updateShapeHandler);
+        descriptor.addListener("nudgePathPoints", _updateShapeHandler);
 
         // Listener for path changes
         _pathOperationHandler = function (event) {

--- a/src/js/tools/pen.js
+++ b/src/js/tools/pen.js
@@ -120,12 +120,24 @@ define(function (require, exports, module) {
             deleteKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE),
             escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ESCAPE),
+            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
+            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT),
+            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
+            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT);
             
         this.keyboardPolicyList = [
             backspaceKeyPolicy,
             deleteKeyPolicy,
-            escapeKeyPolicy
+            escapeKeyPolicy,
+            arrowUpKeyPolicy, // Arrow keys for nudging points
+            arrowRightKeyPolicy,
+            arrowDownKeyPolicy,
+            arrowLeftKeyPolicy
         ];
         
         this.selectHandler = _selectHandler;

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -140,13 +140,25 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),
             deleteKeyPolicy = new KeyboardEventPolicy(UI.policyAction.NEVER_PROPAGATE,
-                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE);
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.DELETE),
+            arrowUpKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_UP),
+            arrowRightKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_RIGHT),
+            arrowDownKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_DOWN),
+            arrowLeftKeyPolicy = new KeyboardEventPolicy(UI.policyAction.FOCUS_PROPAGATE,
+                OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.ARROW_LEFT);
             
         this.keyboardPolicyList = [
             escapeKeyPolicy, // Switch back to newSelect
             enterKeyPolicy, // Switch back to newSelect
             backspaceKeyPolicy, // Delete selected vertices
-            deleteKeyPolicy // Delete selected vertices
+            deleteKeyPolicy, // Delete selected vertices,
+            arrowUpKeyPolicy, // Arrow keys for nudging points
+            arrowRightKeyPolicy,
+            arrowDownKeyPolicy,
+            arrowLeftKeyPolicy
         ];
 
         var vectorMaskPointerPolicy = new PointerEventPolicy(UI.policyAction.ALPHA_PROPAGATE,


### PR DESCRIPTION
This adds `FOCUS_PROPAGATE` arrow key policies in superselect vector mode and the pen tool to allow nudging selected points. Pretty cool.

Addresses #3075.