### PR TITLE
French introduction screen positioning fixed

### DIFF
--- a/src/style/help/first-launch.less
+++ b/src/style/help/first-launch.less
@@ -419,10 +419,20 @@
 /**** FRENCH *****/
 
 :lang(fr) .carousel__slide__full {
-    padding-top: 0rem;
+    &.slide-0 {
 
-    img {
-        top: -6rem;
+        padding-top: 0rem;
+
+        img {
+            top: -6rem;
+        }
+    }
+
+    &.slide-5 {
+        h2 {
+            padding-left: 10rem;
+            padding-right: 10rem;
+        }
     }
 }
 


### PR DESCRIPTION
References issue #3076 

Before: 
![](https://www.dropbox.com/s/0t8xna9qp60bh11/before.png?raw=1)

After:
![](https://www.dropbox.com/s/2lt4v0wyjswwx0c/Screenshot%202015-10-22%2000.26.51.png?raw=1)

I have also verified that all other screens are positioned correctly. The only one that needed to be changed was the Swap screen to avoid widows. That change is included in this PR also. 


Before: 
![](https://www.dropbox.com/s/5fl59e6soo5trwy/Screenshot%202015-10-22%2000.29.17.png?raw=1)

After: 
![](https://www.dropbox.com/s/zhw6vujus5efw1z/Screenshot%202015-10-22%2000.26.02.png?raw=1)