### PR TITLE
Make graphic button in the sampler HUB easier to click.

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -732,10 +732,10 @@ define(function (require, exports) {
             // However, for cloud SOs, we use createElement, and let Photoshop deal with relinking
             targets.forEach(function (target) {
                 var targetType = target.smartObjectType(),
-                reference = source.smartObject.link.elementReference,
+                    reference = source.smartObject.link.elementReference,
                     element = CCLibraries.resolveElementReference(reference),
                     playObjects = [];
-                    
+
                 // PS does not allow CLSO to link to another CLSO, so we embed it first as a work around
                 if (targetType === soTypes.CLOUD_LINKED) {
                     playObjects.push(layerLib.embedLinked());

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -437,6 +437,11 @@ define(function (require, exports, module) {
                         .classed("sampler-hud-icon-disabled", !sample.value)
                         .on("click", applyTypeStyleFunc);
                 } else if (sample.type === "layerEffects") {
+                    var duplicateLayerEffectsFunc = function () {
+                        fluxActions.layerEffects.duplicateLayerEffects(this.state.document, null, sample.value);
+                        d3.event.stopPropagation();
+                    }.bind(this);
+                    
                     // background rectangle for the icon so it's clickable easier
                     this._hudGroup
                         .append("rect")
@@ -446,10 +451,7 @@ define(function (require, exports, module) {
                         .attr("height", iconSize)
                         .classed("sampler-hud-background", true)
                         .classed("sampler-hud-icon-disabled", !sample.value)
-                        .on("click", function () {
-                            fluxActions.layerEffects.duplicateLayerEffects(this.state.document, null, sample.value);
-                            d3.event.stopPropagation();
-                        }.bind(this));
+                        .on("click", duplicateLayerEffectsFunc);
 
                     // fx icon
                     this._hudGroup
@@ -461,11 +463,24 @@ define(function (require, exports, module) {
                         .attr("height", iconSize)
                         .classed("sampler-hud", true)
                         .classed("sampler-hud-icon-disabled", !sample.value)
-                        .on("click", function () {
-                            fluxActions.layerEffects.duplicateLayerEffects(this.state.document, null, sample.value);
-                            d3.event.stopPropagation();
-                        }.bind(this));
+                        .on("click", duplicateLayerEffectsFunc);
                 } else if (sample.type === "graphic") {
+                    var replaceGraphicFunc = function () {
+                        fluxActions.sampler.replaceGraphic(this.state.document, null, sample.value);
+                        d3.event.stopPropagation();
+                    }.bind(this);
+                    
+                    // background rectangle for the icon so it's clickable easier
+                    this._hudGroup
+                        .append("rect")
+                        .attr("x", iconLeft)
+                        .attr("y", iconTop)
+                        .attr("width", iconSize)
+                        .attr("height", iconSize)
+                        .classed("sampler-hud-background", true)
+                        .classed("sampler-hud-icon-disabled", !sample.value)
+                        .on("click", replaceGraphicFunc);
+
                     this._hudGroup
                         .append("use")
                         .attr("xlink:href", "img/ico-sampler-graphics.svg#sampler-graphics")
@@ -475,10 +490,7 @@ define(function (require, exports, module) {
                         .attr("height", iconSize)
                         .classed("sampler-hud", true)
                         .classed("sampler-hud-icon-disabled", !sample.value)
-                        .on("click", function () {
-                            fluxActions.sampler.replaceGraphic(this.state.document, null, sample.value);
-                            d3.event.stopPropagation();
-                        }.bind(this));
+                        .on("click", replaceGraphicFunc);
                 }
             }, this);
         },


### PR DESCRIPTION
Make graphic button in the sampler HUB easier to click, just like the Effects and Type buttons.

Addresses #3060

note: If you are testing with LLSO, you may encounter issue #3084