### PR TITLE
Coalesce multiple text attribute updates when pasting/sampling text styles

### DIFF
--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -410,7 +410,8 @@ define(function (require, exports, module) {
                     var applyTypeStyleFunc = function () {
                         if (sample.value) {
                             // Apply the type style to selected layers
-                            fluxActions.type.applyTextStyle(this.state.document, null, sample.value);
+                            fluxActions.type.applyTextStyle(this.state.document, null, sample.value,
+                                null, { ignoreAlpha: false });
                         }
                         d3.event.stopPropagation();
                     }.bind(this);


### PR DESCRIPTION

This PR addresses the following issues:

1. copy/paste text styles will flash the opacity field. Fix for #3049 
2. sampling text styles should include opacity. 