### PR TITLE
`transform.setRadius` should exclude layers that does not support radius.

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -978,12 +978,13 @@ define(function (require, exports) {
      * @param {boolean=} options.coalesce Whether this history state should be coalesce with the previous one
      */
     var setRadius = function (document, layers, radius, options) {
-        layers = _filterTransform(document, layers, true);
+        options = _.merge({}, options);
+        layers = _filterTransform(document, layers, true)
+            .filter(function (l) { return !!l.radii; }); // Exclude layers without radii attribute
+
         if (layers.isEmpty()) {
             return Promise.resolve();
         }
-
-        options = _.merge({}, options);
 
         var dispatchPromise = this.dispatchAsync(events.document.history.optimistic.RADII_CHANGED, {
             documentID: document.id,


### PR DESCRIPTION
Otherwise, the document store will try to update the layer's radii attribute and then get reverted by the `resetLayer` action, which flash the radius slider when copy/paste layer styles. 

Addresses issue #3050 