### PR TITLE
Fix cloaking rectangle bug when display configuration changes

### DIFF
--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -73,7 +73,10 @@ define(function (require, exports, module) {
         _updatePanelSizesDebounced: null,
 
         componentDidMount: function () {
-            this._updatePanelSizesDebounced = synchronization.debounce(this._updatePanelSizes, this, 500);
+            this._updatePanelSizesDebounced = synchronization.debounce(function () {
+                return this._updatePanelSizes();
+            }, this, 500);
+
             os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
             this._updatePanelSizes();
         },


### PR DESCRIPTION
This fixes a bug in which the `displayConfigurationChanged` event handler's event argument would be interpreted as a truthy argument to `_updatePanelSizes`, preventing `iconBarWidth` from being correctly set, thus making the cloaking rectangle too large and causing the UI to flash out when panning the canvas.

Addresses #3101. Low risk, AFAICT.