### PR TITLE
Copy/Past text should include opacity and tracking - edge cases

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -157,6 +157,26 @@ define(function (require, exports, module) {
                 return;
             }
 
+            this._setPostScript(postScriptName);
+        },
+        
+        /**
+         * Handle change of type weight.
+         *
+         * @private
+         * @param {string} postScriptName
+         */
+        _handleTypeWeightChange: function (postScriptName) {
+            this._setPostScript(postScriptName);
+        },
+        
+        /**
+         * Set the type face of the selected text layers.
+         *
+         * @private
+         * @param {string} postScriptName
+         */
+        _setPostScript: function (postScriptName) {
             var document = this.props.document,
                 layers = document.layers.selected.filter(function (layer) {
                     return layer.kind === layer.layerKinds.TEXT;
@@ -510,25 +530,25 @@ define(function (require, exports, module) {
 
             // Alternate font styles for the chosen type family
             var familyFontOptions = familyFonts && familyFonts
-                .valueSeq()
-                .sortBy(function (familyFontObj) {
-                    return familyFontObj.postScriptName;
-                })
-                .map(function (familyFontObj) {
-                    var style = familyFontObj.style,
-                        searchableStyle = style;
+                    .valueSeq()
+                    .sortBy(function (familyFontObj) {
+                        return familyFontObj.postScriptName;
+                    })
+                    .map(function (familyFontObj) {
+                        var style = familyFontObj.style,
+                            searchableStyle = style;
 
-                    return {
-                        id: familyFontObj.postScriptName,
-                        title: style,
-                        style: {
-                            "fontFamily": familyName,
-                            "fontStyle": this._getCSSFontStyle(searchableStyle),
-                            "fontWeight": this._getCSSFontWeight(searchableStyle)
-                        }
-                    };
-                }, this)
-                .toList();
+                        return {
+                            id: familyFontObj.postScriptName,
+                            title: style,
+                            style: {
+                                "fontFamily": familyName,
+                                "fontStyle": this._getCSSFontStyle(searchableStyle),
+                                "fontWeight": this._getCSSFontWeight(searchableStyle)
+                            }
+                        };
+                    }, this)
+                    .toList();
 
             var typeOverlay = function (colorTiny) {
                 if (familyName === strings.STYLE.TYPE.MIXED) {
@@ -657,7 +677,7 @@ define(function (require, exports, module) {
                                 value={styleTitle}
                                 defaultSelected={postScriptFamilyName}
                                 options={familyFontOptions}
-                                onChange={this._handleTypefaceChange}
+                                onChange={this._handleTypeWeightChange}
                                 size="column-22" />
                         </div>
                     </div>

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -682,6 +682,28 @@ define(function (require, exports, module) {
     Layer.prototype.getLibraryElementReference = function () {
         return this.isCloudLinkedSmartObject() ? this.smartObject.link.elementReference : null;
     };
+    
+    /**
+     * Batch update layer properties.
+     *
+     * @param {object} properties
+     * @return {Layer}
+     */
+    Layer.prototype.setProperties = function (properties) {
+        var nextLayer = this.merge(properties);
+        
+        // If the update layer is text layer, and the updated attributes include opacity, 
+        // then we have to sync the new opacity to its CharacterStyle.
+        if (properties.opacity && this.isTextLayer()) {
+            var charStyleColorPath = ["text", "characterStyle", "color"],
+                charStyleColor = this.getIn(charStyleColorPath),
+                nextCharStyleColor = charStyleColor.setOpacity(nextLayer.opacity);
+
+            nextLayer = nextLayer.setIn(charStyleColorPath, nextCharStyleColor);
+        }
+
+        return nextLayer;
+    };
 
     module.exports = Layer;
 });

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -692,8 +692,8 @@ define(function (require, exports, module) {
     Layer.prototype.setProperties = function (properties) {
         var nextLayer = this.merge(properties);
         
-        // If the update layer is text layer, and the updated attributes include opacity, 
-        // then we have to sync the new opacity to its CharacterStyle.
+        // If the layer is text layer, and the updated attributes include opacity, 
+        // then we sync the new opacity to its CharacterStyle.
         if (properties.opacity && this.isTextLayer()) {
             var charStyleColorPath = ["text", "characterStyle", "color"],
                 charStyleColor = this.getIn(charStyleColorPath),

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1100,15 +1100,11 @@ define(function (require, exports, module) {
      * @return {LayerStructure}
      */
     LayerStructure.prototype.setProperties = function (layerIDs, properties) {
-        var nextProperties = Immutable.Map(properties),
-            updatedLayers = Immutable.Map(layerIDs.reduce(function (layers, layerID) {
-                layers.set(layerID, nextProperties);
-                return layers;
-            }.bind(this), new Map()));
+        var updatedLayers = Immutable.Map(layerIDs.map(function (layerID) {
+                return [layerID, this.byID(layerID).setProperties(properties)];
+            }, this));
 
-        return this.mergeDeep({
-            layers: updatedLayers
-        });
+        return this.set("layers", this.layers.merge(updatedLayers));
     };
 
     /**

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
                 };
             }
 
-            if (textStyle.tracking) {
+            if (Number.isFinite(textStyle.tracking)) {
                 obj.adbeTracking = textStyle.tracking;
                 // Adobe tracking is a value of thousandths of an em so store that value for CSS letter-spacing
                 obj.letterSpacing = {


### PR DESCRIPTION
These two styles are included in the previous PR, and this PR covers some edge cases:

1. copy/paste should include 0 tracking.
2. opacity is not copied after changing. Addresses #3100 
3. bonus: fix changing type weight.