### PR TITLE
Headlights tracking more

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2468,7 +2468,7 @@ define(function (require, exports) {
                 // Log the tool used to make this layer
                 if (currentTool) {
                     var toolID = currentTool.id;
-                    headlights.logEvent("tools", "create", toolID);
+                    headlights.logEvent("tools", "create", _.kebabCase(toolID));
                 }
 
                 break;

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -24,7 +24,8 @@
 define(function (require, exports) {
     "use strict";
 
-    var Promise = require("bluebird");
+    var Promise = require("bluebird"),
+        _ = require("lodash");
 
     var adapter = require("adapter"),
         ps = require("adapter/ps"),
@@ -292,7 +293,7 @@ define(function (require, exports) {
         }
 
         if (!$dontLog) {
-            headlights.logEvent("menu", subcategory, event);
+            headlights.logEvent("menu", subcategory, _.kebabCase(event));
         }
 
         action($payload);

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -45,6 +45,7 @@ define(function (require, exports) {
         transformActions = require("./transform"),
         toolActions = require("./tools"),
         layerActionsUtil = require("js/util/layeractions"),
+        headlights = require("js/util/headlights"),
         strings = require("i18n!nls/strings");
 
     /**
@@ -345,6 +346,12 @@ define(function (require, exports) {
             docStore = this.flux.store("document"),
             coords = uiStore.transformWindowToCanvas(x, y),
             layerTree = doc.layers;
+        
+        if (secondary) {
+            headlights.logEvent("tools", "eyedropper-secondary", "copy-all-effects");
+        } else {
+            headlights.logEvent("tools", "eyedropper-primary", "copy-all-effects");
+        }
         
         return uiUtil.hitTestLayers(doc.id, coords.x, coords.y)
             .bind(this)

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -25,7 +25,8 @@ define(function (require, exports) {
     "use strict";
 
     var Promise = require("bluebird"),
-        Immutable = require("immutable");
+        Immutable = require("immutable"),
+        _ = require("lodash");
 
     var descriptor = require("adapter/ps/descriptor"),
         toolLib = require("adapter/lib/tool"),
@@ -53,7 +54,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var _logSuperselect = function (eventName) {
-        return headlights.logEvent("tools", "superselect", eventName);
+        return headlights.logEvent("tools", "superselect", _.kebabCase(eventName));
     };
 
     /**

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -755,7 +755,7 @@ define(function (require, exports) {
             }
         }
 
-        headlights.logEvent("tools", "mask-mode-" + currentLayer.kind);
+        headlights.logEvent("tools", "mask-mode", String(currentLayer.kind));
     };
     changeVectorMaskMode.reads = [locks.JS_APP, locks.JS_TOOL, locks.PS_DOC, locks.PS_TOOL];
     changeVectorMaskMode.writes = [locks.JS_TOOL, locks.PS_DOC];

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         strings = require("i18n!nls/strings"),
         synchronization = require("js/util/synchronization"),
         searchStore = require("js/stores/search"),
+        headlights = require("js/util/headlights"),
         exportStore = require("js/stores/export");
 
     var DocumentHeader = React.createClass({
@@ -218,6 +219,7 @@ define(function (require, exports, module) {
          */
         _openExportPanel: function () {
             this.getFlux().actions.export.openExportPanel();
+            headlights.logEvent("user-interface", "document-header-button", "export-panel");
         },
 
         /**
@@ -225,6 +227,7 @@ define(function (require, exports, module) {
          */
         _toggleSearch: function () {
             this.getFlux().actions.search.toggleSearchBar();
+            headlights.logEvent("user-interface", "document-header-button", "search");
         },
 
         /**
@@ -232,6 +235,7 @@ define(function (require, exports, module) {
          */
         _changeMaskMode: function () {
             this.getFlux().actions.tools.changeVectorMaskMode(!this.state.maskModeActive);
+            headlights.logEvent("user-interface", "document-header-button", "mask-mode-" + !this.state.maskModeActive);
         },
 
         render: function () {

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -227,6 +227,11 @@ define(function (require, exports, module) {
                 propertiesPanel = nextState[components.PROPERTIES_COL];
             }
 
+            if (swapModifier) {
+                layersLibPanel = !layersLibPanel;
+                propertiesPanel = !propertiesPanel;
+            }
+
             if (layersLibPanel && propertiesPanel) {
                 currentlyVisible = "layersLibrary-properties-visible";
             } else if (layersLibPanel) {
@@ -253,6 +258,7 @@ define(function (require, exports, module) {
             nextState[panelName] = !this.state[panelName];
 
             this.getFlux().actions.preferences.setPreferences(nextState);
+            headlights.logEvent("user-interface", "panel-toggle", panelName);
         },
 
         render: function () {

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -428,7 +428,7 @@ define(function (require, exports, module) {
                     this._updateFilter(id);
                 } else {
                     this.props.executeOption(id);
-                    headlights.logEvent("search", filtersString, category);
+                    headlights.logEvent("search", filtersString, _.kebabCase(category));
                 }
             }
         },

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
             this._forceVisible();
             this.getFlux().actions.export.addAssetThrottled(document, documentExports, selectedLayers, props);
             
-            if (preset) {
+            if (typeof preset === "string") {
                 headlights.logEvent("export", "preset", preset);
             } else {
                 headlights.logEvent("export", "create", "single-asset");

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
 
             this.getFlux().actions.sampler.copyLayerStyle(document, source);
             event.stopPropagation();
-            headlights.logEvent("style", "create", "copy-all-styles");
+            headlights.logEvent("tools", "appearance-panel-icon", "copy-all-styles");
         },
 
         /**
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
 
             this.getFlux().actions.sampler.pasteLayerStyle(document, targetLayers);
             event.stopPropagation();
-            headlights.logEvent("style", "create", "paste-all-styles");
+            headlights.logEvent("tools", "appearance-panel-icon", "paste-all-styles");
         },
 
         render: function () {

--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -33,15 +33,25 @@ define(function (require, exports, module) {
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),
+        synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights");
 
     var BlendMode = require("jsx!./BlendMode"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton");
 
+    /**
+     * Debounced version of headlights.logEvents to help prevent false changes from 
+     * datalists from being logged. 
+     *
+     * @private
+     * @type {function(*)}
+     */
+    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
+
     var ColorOverlay = React.createClass({
         mixins: [FluxMixin],
-        
+
         shouldComponentUpdate: function (nextProps) {
             var sameLayerIDs = collection.pluck(this.props.layers, "id")
                 .equals(collection.pluck(nextProps.layers, "id"));
@@ -104,7 +114,8 @@ define(function (require, exports, module) {
                     this.props.index,
                     blendMode,
                     LayerEffect.COLOR_OVERLAY);
-            headlights.logEvent("edit", "color-overlay-blendmode-input", blendMode);
+
+            logEventDebounced("edit", "color-overlay-blendmode-input", blendMode);
         },
 
         /**

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
 
             this.getFlux().actions.sampler.copyLayerEffects(document, source);
             event.stopPropagation();
-            headlights.logEvent("tools", "sampler", "copy-all-effects");
+            headlights.logEvent("tools", "effects-panel-icon", "copy-all-effects");
         },
 
         /**
@@ -164,7 +164,7 @@ define(function (require, exports, module) {
 
             this.getFlux().actions.sampler.pasteLayerEffects(document, targetLayers);
             event.stopPropagation();
-            headlights.logEvent("tools", "sampler", "paste-all-effects");
+            headlights.logEvent("tools", "effects-panel-icon", "paste-all-effects");
         },
 
         /**

--- a/src/js/jsx/sections/style/LayerBlendMode.jsx
+++ b/src/js/jsx/sections/style/LayerBlendMode.jsx
@@ -31,8 +31,18 @@ define(function (require, exports, module) {
 
     var BlendMode = require("jsx!./BlendMode"),
         strings = require("i18n!nls/strings"),
+        synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         collection = require("js/util/collection");
+
+    /**
+     * Debounced version of headlights.logEvents to help prevent false changes from 
+     * datalists from being logged. 
+     *
+     * @private
+     * @type {function(*)}
+     */
+    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
 
     var LayerBlendMode = React.createClass({
         mixins: [FluxMixin],
@@ -61,7 +71,8 @@ define(function (require, exports, module) {
         _handleChange: function (mode) {
             this.getFlux().actions.layers
                 .setBlendModeThrottled(this.props.document, this.props.layers, mode);
-            headlights.logEvent("edit", "layer-blendmode-input", mode);
+
+            logEventDebounced("edit", "layer-blendmode-input", mode);
         },
 
         render: function () {

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -34,13 +34,23 @@ define(function (require, exports) {
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        strings = require("i18n!nls/strings"),
+        synchronization = require("js/util/synchronization");
 
     var Label = require("jsx!js/jsx/shared/Label"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         BlendMode = require("jsx!./BlendMode"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton");
+
+    /**
+     * Debounced version of headlights.logEvents to help prevent false changes from 
+     * datalists from being logged. 
+     *
+     * @private
+     * @type {function(*)}
+     */
+    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
 
     var MIN_SPREAD = 0,
         MAX_SPREAD = 100,
@@ -219,7 +229,7 @@ define(function (require, exports) {
                     blendMode,
                     this.props.type);
             // Currently does not differentiate between inner and drop shadows
-            headlights.logEvent("edit", "shadow-blendmode-input", blendMode);
+            logEventDebounced("edit", "shadow-blendmode-input", blendMode);
         },
 
         /**
@@ -242,6 +252,7 @@ define(function (require, exports) {
         _handleDelete: function () {
             this.getFlux().actions.layerEffects.deleteEffect(
                 this.props.document, this.props.layers, this.props.index, this.props.type);
+            
             headlights.logEvent("effect", "delete", "shadow");
         },
 

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         StrokeEffect = require("js/models/effects/stroke"),
         collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),
-        headlights = require("js/util/headlights");
+        headlights = require("js/util/headlights"),
+        synchronization = require("js/util/synchronization");
 
     var Label = require("jsx!js/jsx/shared/Label"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
@@ -42,6 +43,15 @@ define(function (require, exports, module) {
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
         StrokeAlignment = require("jsx!./StrokeAlignment");
+
+    /**
+     * Debounced version of headlights.logEvents to help prevent false changes from 
+     * datalists from being logged. 
+     *
+     * @private
+     * @type {function(*)}
+     */
+    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
         
     /**
      * Limits of stroke size.
@@ -117,7 +127,8 @@ define(function (require, exports, module) {
                     this.props.index,
                     blendMode,
                     LayerEffect.STROKE);
-            headlights.logEvent("edit", "stroke-blendmode-input", blendMode);
+
+            logEventDebounced("edit", "stroke-blendmode-input", blendMode);
         },
         
         /**

--- a/src/js/util/headlights.js
+++ b/src/js/util/headlights.js
@@ -49,6 +49,6 @@ define(function (require, exports) {
             return adapterPS.logHeadlightsEvent(category, subcategory, event);
         }
     };
-    
+
     exports.logEvent = logEvent;
 });


### PR DESCRIPTION
References #3107 -- fix now 

With this: 

- Command + click on the panel icons logs the correct event (none-visible) 
- Mouse over blend mode in stroke, layer, shadow, and color-overlay now should track only track the final blendmode chosen
- Export panel + icon logs the correct event -- preset or no preset 
- Toggling individual panels are now tracked
- Document header icons are all tracked 
- Primary sampler and secondary sampler are tracked 
