### PR TITLE
Remove the capture of ID from historyState events

### DIFF
--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -296,7 +296,6 @@ define(function (require, exports) {
         var payload = {
             source: "listener", // for human convenience
             documentID: documentID,
-            id: event.ID,
             name: event.name,
             totalStates: event.historyStates + 1, // yes, seriously.
             currentState: event.currentHistoryState // seems to be zero-base already (unlike get historyState)


### PR DESCRIPTION
Reduces the impact of #3115.  In PR #3052 I began capturing "ID" from the historyState events from photoshop.  But, given the subsequent simplification of that PR (which attempts to handle touch undo events, and was eventually simplified), it is not strictly necessary to track ID.  Thus, this PR backs out that single line of code, which should prevent the errors described in 3115.

That said, the color picker is still not working correctly wrt history; it sometimes seems to invalidate the history states.  I believe this regression happened independent of 3052, possibly much earlier.