### PR TITLE
Reset color picker sliders on undo/redo

### DIFF
--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -167,12 +167,16 @@ define(function (require, exports) {
             return descriptor.playObject(historyPlayObject)
                 .bind(this)
                 .then(function () {
-                    return this.dispatchAsync(events.history.ADJUST_HISTORY_STATE, {
-                            documentID: documentID,
-                            count: count });
+                    this.dispatch(events.history.ADJUST_HISTORY_STATE, {
+                        documentID: documentID,
+                        count: count
+                    });
                 })
                 .then(function () {
                     return this.transfer(documentActions.updateDocument);
+                })
+                .then(function () {
+                    this.dispatch(events.history.FINISH_ADJUSTING_HISTORY_STATE);
                 });
         }
     };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -177,6 +177,7 @@ define(function (require, exports, module) {
             LOAD_HISTORY_STATE: "loadHistoryState",
             LOAD_HISTORY_STATE_REVERT: "loadHistoryStateRevert",
             ADJUST_HISTORY_STATE: "adjustHistoryState",
+            FINISH_ADJUSTING_HISTORY_STATE: "finishedAdjustingHistoryState",
             FINALIZE_HISTORY_STATE: "finalizeHistoryState",
             DELETE_DOCUMENT_HISTORY: "deleteDocumentHistory"
         },


### PR DESCRIPTION
This fixes two distinct problems with the color picker and undo/redo:

1. The `ColorInput` listens for `timetravel` events and uses them to forcefully reset the positions of the sliders to an up-to-date value. But, currently, it is simply resetting the sliders to their current position, which achieves nothing. This fixes that by using a value derived by instead re-parsing the input props to determine the correct color to which the sliders should be reset. This involves factoring out the parsing logic currently in the `render` method (which is totally gross) into a separate method which can be called by `render` and by this `timetravel` handler. Mostly this is just a cut-and-paste refactoring, though I did have to make some minor changes to account for `swatchClassProps` and friends.
2. The history store currently emits the `timetravel` event when "adjusting" the history state, but in this case it also seems to need to call `updateDocument` in order to update the document model. But this means that the `timetravel` event currently happens well before the document model has been updated, which means even with fix 1) above, the `ColorInput` re-parses its input props before they've been correctly updated. My proposed workaround (which is not intended to be the last word, but instead to just be a minimal fix) involves an additional history event `FINISH_ADJUSTING_HISTORY_STATE`, which is emitted after the history-related `updateDocument` call is complete, and to have the history store emit its `timetravel` event when handling this, instead of earlier in the `ADJUST_HISTORY_STATE` event.

Addresses #3117. 

@mcilroyc is probably the best person to review this, but I welcome analysis and testing from anyone else!