### PR TITLE
Increase the number of generator connection retries during 'debug' mode

### DIFF
--- a/src/js/util/exportservice.js
+++ b/src/js/util/exportservice.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
      * @param {boolean=} quickCheck If truthy, perform an abbreviated attempt establish a connection
      */
     var ExportService = function (port, quickCheck) {
-        var maxConnectionAttempts = quickCheck ? (CONNECTION_MAX_ATTEMPTS / 10) : CONNECTION_MAX_ATTEMPTS,
+        var maxConnectionAttempts = quickCheck ? (CONNECTION_MAX_ATTEMPTS / 2) : CONNECTION_MAX_ATTEMPTS,
             getRemotePort = function (callback) {
                 callback(null, port || GENERATOR_DEFAULT_PORT);
             };


### PR DESCRIPTION
This helps generator crash crash recovery in debug mode, and should have no effect in non-debug mode.

When in debug mode, we do an abbreviated attempt to connect to generator in order to find the possible existence of a remote generator.  This is simply to make it convenient for developers.  The problem is that this leaves the connection in "super quick mode" which gives up too quickly after a crash-restart.  This quick-fix simply makes it "kinda quick mode".  

@chadrolfs - you may want to use this branch when initially testing the generator crash-restart functionality which is available as of dev mac 842.