### PR TITLE
Took out "suffix" from headlights log

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -180,8 +180,7 @@ define(function (require, exports) {
 
         fileName = prefix ? prefix + "-" + fileName : fileName;
 
-        headlights.logEvent("export", "asset", "scale-" + asset.scale +
-                            "-suffix-" + asset.suffix + "-setting-" + asset.format);
+        headlights.logEvent("export", "asset", "scale-" + asset.scale + "-setting-" + asset.format);
 
         return _exportService.exportAsset(document, layer, asset, fileName, baseDir)
             .bind(this)


### PR DESCRIPTION
Only finite values are allowed to be logged in headlights calls 