### PR TITLE
Fix sampler and copy/paste text layer with multiple text styles

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -551,18 +551,19 @@ define(function (require, exports) {
     var pasteLayerStyle = function (document, targetLayers) {
         var applicationStore = this.flux.store("application"),
             currentDocument = applicationStore.getCurrentDocument(),
-            selectedLayers = currentDocument.layers.selected;
+            selectedLayers = currentDocument.layers.selected,
+            styleStore = this.flux.store("style"),
+            style = styleStore.getClipboardStyle();
 
         document = document || currentDocument;
         targetLayers = targetLayers || document ? selectedLayers : null;
 
-        if (!targetLayers) {
+        if (!targetLayers || !style) {
             return Promise.resolve();
         }
         
-        var styleStore = this.flux.store("style"),
-            style = styleStore.getClipboardStyle(),
-            shapeLayers = Immutable.List(),
+    
+        var shapeLayers = Immutable.List(),
             textLayers = Immutable.List(),
             nonTextLayers = Immutable.List(),
             transactionOpts = {

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -76,7 +76,7 @@ define(function (require, exports) {
                 
                 return Promise.resolve(color);
             case layerKinds.TEXT:
-                color = sourceLayer.text.characterStyle.color;
+                color = sourceLayer.text.firstCharacterStyle.color;
                 color = color && color.setOpacity(sourceLayer.opacity);
 
                 return Promise.resolve(color);
@@ -499,7 +499,7 @@ define(function (require, exports) {
             break;
         case source.layerKinds.TEXT:
             var fontStore = this.flux.store("font"),
-                textColor = source.text.characterStyle.color;
+                textColor = source.text.firstCharacterStyle.color;
 
             style.fillColor = textColor && textColor.setOpacity(100);
             style.typeStyle = fontStore.getTypeObjectFromLayer(source);

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -149,7 +149,7 @@ define(function (require, exports, module) {
 
             var fontStore = this.getFlux().store("font"),
                 text = this.props.document.layers.selected.first().text,
-                characterStyle = text.characterStyle,
+                characterStyle = text.firstCharacterStyle,
                 textHasMissingFont = !fontStore.getFontFamilyFromPostScriptName(characterStyle.postScriptName);
 
             return !textHasMissingFont;
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
 
             var addTextColorButton = this._createColorButton(function (layer) {
                 return !layer.isTextLayer() ? null :
-                    { color: layer.text.characterStyle.color, title: strings.TOOLTIPS.ADD_TEXT_COLOR };
+                    { color: layer.text.firstCharacterStyle.color, title: strings.TOOLTIPS.ADD_TEXT_COLOR };
             });
 
             return (

--- a/src/js/models/characterstyle.js
+++ b/src/js/models/characterstyle.js
@@ -163,13 +163,16 @@ define(function (require, exports, module) {
      * @param {object} documentDescriptor
      * @param {object} layerDescriptor
      * @param {object} textDescriptor
-     * @return {CharacterStyle}
+     * @return {{firstTextStyle: CharacterStyle, uniformTextStyle: CharacterStyle}}
      */
     CharacterStyle.fromTextDescriptor = function (documentDescriptor, layerDescriptor, textDescriptor) {
         var textStyleRanges = textDescriptor.textStyleRange;
 
         if (!textStyleRanges || textStyleRanges.length === 0) {
-            return new CharacterStyle();
+            return {
+                firstCharStyle: new CharacterStyle(),
+                uniformCharStyle: new CharacterStyle()
+            };
         }
 
         // Only the first style range contains the baseParentStyle
@@ -195,7 +198,10 @@ define(function (require, exports, module) {
                 return reducedModel;
             }, {});
 
-        return new CharacterStyle(reducedModel);
+        return {
+            firstCharStyle: characterStyles.first(),
+            uniformCharStyle: new CharacterStyle(reducedModel)
+        };
     };
 
     module.exports = CharacterStyle;

--- a/src/js/models/text.js
+++ b/src/js/models/text.js
@@ -32,13 +32,23 @@ define(function (require, exports, module) {
     /**
      * Represents the style and context of a text layer
      * 
-     * @constructor  
+     * @constructor
      */
     var Text = Immutable.Record({
         /**
+         * Uniform character style of multiple text ranges. If text has one text range, then `characterStyle`
+         * equals to `firstCharacterStyle`. Attribute will be null if multiple text ranges have mixed value.
+         *
          * @type {CharacterStyle}
          */
         characterStyle: null,
+        
+        /**
+         * The first character style in the text ranges
+         *
+         * @type {CharacterStyle}
+         */
+        firstCharacterStyle: null,
 
         /**
          * @type {ParagraphStyle}
@@ -73,8 +83,11 @@ define(function (require, exports, module) {
         if (textShapes.length !== 1) {
             throw new Error("Too many text shapes!");
         }
-
-        model.characterStyle = CharacterStyle.fromTextDescriptor(documentDescriptor, layerDescriptor, textKey);
+        
+        var textStyles = CharacterStyle.fromTextDescriptor(documentDescriptor, layerDescriptor, textKey);
+        
+        model.characterStyle = textStyles.uniformCharStyle;
+        model.firstCharacterStyle = textStyles.firstCharStyle;
         model.paragraphStyle = ParagraphStyle.fromTextDescriptor(documentDescriptor, layerDescriptor, textKey);
         model.box = textShapes[0].char._value === "box";
 

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
                 };
             }
 
-            if (textStyle.leading >= 0) {
+            if (Number.isFinite(textStyle.leading) && textStyle.leading >= 0) {
                 obj.lineHeight = {
                     type: "pt",
                     value: textStyle.leading

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
             }
 
             var obj = {},
-                textStyle = layer.text.characterStyle,
+                textStyle = layer.text.firstCharacterStyle,
                 psName = textStyle.postScriptName,
                 fontObj = this._postScriptMap.get(psName, null),
                 paragraphStyle = layer.text.paragraphStyle;

--- a/src/js/stores/font.js
+++ b/src/js/stores/font.js
@@ -28,7 +28,8 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
     
     var events = require("../events"),
-        log = require("js/util/log");
+        log = require("js/util/log"),
+        Color = require("js/models/color");
 
     var FontStore = Fluxxor.createStore({
 
@@ -219,11 +220,7 @@ define(function (require, exports, module) {
             } else {
                 obj.color = {
                     mode: "RGB",
-                    value: {
-                        r: 0,
-                        g: 0,
-                        b: 0
-                    },
+                    value: Color.DEFAULT,
                     type: "process"
                 };
             }


### PR DESCRIPTION
Addresses issue #3123 

If a text has multiple text styles (multiple text ranges with different text style), we will use the first character style (and the stroke color) in these tools:

* sampler
* copy/paste appearance
* create text style in libraries panel