### PR TITLE
copy/paste: set text color by fill color, if style is not copied from text layer.

### DIFF
--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -598,6 +598,8 @@ define(function (require, exports) {
             textStylePromise = (!style.typeStyle || textLayers.isEmpty()) ? Promise.resolve() :
                 this.transfer(typeActions.applyTextStyle, document, textLayers, style.typeStyle, actionOpts,
                 { ignoreAlpha: false }),
+            textColorPromise = (style.typeStyle || !style.fillColor || textLayers.isEmpty()) ? Promise.resolve() :
+                this.transfer(typeActions.setColor, document, textLayers, style.fillColor, actionOpts),
             layerBlendModePromise = (!style.blendMode || targetLayers.isEmpty()) ? Promise.resolve() :
                 this.transfer(layerActions.setBlendMode, document, targetLayers, style.blendMode, actionOpts),
             layerOpacityPromise = Promise.resolve();
@@ -615,6 +617,7 @@ define(function (require, exports) {
                 shapeStrokePromise,
                 shapeRadiiPromise,
                 textStylePromise,
+                textColorPromise,
                 layerBlendModePromise,
                 layerOpacityPromise
             )

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -694,12 +694,19 @@ define(function (require, exports, module) {
         
         // If the layer is text layer, and the updated attributes include opacity, 
         // then we sync the new opacity to its CharacterStyle.
+        // 
+        // FIXME: we should avoid keeping multiple copies of the same attribute in different objects.
         if (properties.opacity && this.isTextLayer()) {
-            var charStyleColorPath = ["text", "characterStyle", "color"],
-                charStyleColor = this.getIn(charStyleColorPath),
-                nextCharStyleColor = charStyleColor.setOpacity(nextLayer.opacity);
+            var charStyle = nextLayer.text.characterStyle,
+                nextCharStyle = !charStyle.color ? charStyle :
+                    charStyle.set("color", charStyle.color.setOpacity(nextLayer.opacity)),
+                firstCharStyle = nextLayer.text.firstCharacterStyle,
+                nextFirstCharStyle = firstCharStyle.set("color", firstCharStyle.color.setOpacity(nextLayer.opacity));
 
-            nextLayer = nextLayer.setIn(charStyleColorPath, nextCharStyleColor);
+            nextLayer = nextLayer.set("text", nextLayer.text.merge({
+                characterStyle: nextCharStyle,
+                firstCharacterStyle: nextFirstCharStyle
+            }));
         }
 
         return nextLayer;

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1624,7 +1624,11 @@ define(function (require, exports, module) {
      * @return {LayerStructure}
      */
     LayerStructure.prototype.setCharacterStyleProperties = function (layerIDs, properties) {
-        return this._setTextStyleProperties("characterStyle", layerIDs, properties);
+        var nextLayers = this._setTextStyleProperties("characterStyle", layerIDs, properties);
+
+        nextLayers = nextLayers._setTextStyleProperties("firstCharacterStyle", layerIDs, properties);
+
+        return nextLayers;
     };
 
     /**


### PR DESCRIPTION
Addresses issue #3134 . 

Also fixed bugs related to out of sycn between `Text#firstCharacterStyle` and `Text#characterStyle`: after updating text style (size, color, tracking), clicking copy button will copy the out-dated style.