### PR TITLE
Fix for duplicate layers due to adding graphic from cc libraries.

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -908,11 +908,23 @@ define(function (require, exports) {
             return this.transfer(updateDocument);
         }
 
+        var layer = document.layers.byID(newLayerID);
+        
+        // If the new layer is already existed (by expanding a libraries graphic that is an embedded SO),
+        // we reset the layer to update its smart object type and position.
+        if (layer) {
+            return this.transfer(layerActions.resetLayers, document, layer)
+                .bind(this)
+                .then(function () {
+                    return this.transfer(layerActions.resetIndex, document);
+                });
+        }
+
         return this.transfer(layerActions.addLayers, document, newLayerID, true, replacedLayerID || false);
     };
     handlePlaceEvent.reads = [locks.JS_APP];
     handlePlaceEvent.writes = [];
-    handlePlaceEvent.transfers = [updateDocument, "layers.addLayers"];
+    handlePlaceEvent.transfers = [updateDocument, "layers.addLayers", "layers.resetLayers", "layers.resetIndex"];
     handlePlaceEvent.modal = true;
 
     /**

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -381,6 +381,14 @@ define(function (require, exports) {
         if (typeof layerSpec === "number") {
             layerSpec = [layerSpec];
         }
+        
+        layerSpec.forEach(function (layerID) {
+            var layer = document.layers.byID(layerID);
+
+            if (layer) {
+                throw new Error("Trying to add a layer that is already existed: " + layerID + " " + layer.name);
+            }
+        });
 
         if (selected === undefined) {
             selected = true;

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -386,7 +386,7 @@ define(function (require, exports) {
             var layer = document.layers.byID(layerID);
 
             if (layer) {
-                throw new Error("Trying to add a layer that is already existed: " + layerID + " " + layer.name);
+                throw new Error("Trying to add a layer that already exists: " + layerID + " " + layer.name);
             }
         });
 

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -850,6 +850,7 @@ define(function (require, exports) {
                         //
                         // FIXME: we should instead get IDs back from Photoshop when layers are placed with modifier, 
                         //        so we don't have to get all the layer IDs.
+                        //        https://watsonexp.corp.adobe.com/#bug=4080071
                         if (hasAlt) {
                             return this.transfer(layerActions._getLayerIDsForDocumentID, currentDocument.id)
                                 .bind(this)


### PR DESCRIPTION
This PR fixes duplicate layers in our LayerStructure model due to adding a graphic with ALT key pressed. Usually, when the ALT key is pressed, PS will add the layers contained in the graphic, instead of creating LLSO, and will not enter modal tool state. However, if the graphic contains only one layer and it is an embedded SO, PS will enter modal state tool, which causes adding the duplicate layer when we handle the `placeEvent`.

So the solution is to check whether the layer is existed when handling `placeEvent`. I also added cheker to throw error in the `layers.addLayer`, if we are trying to add duplicate layers. 

To test: drag graphic `Embedded` from library `Test - OK ...` (or import the graphic from http://adobe.ly/1Mh2XAM) onto the canvas while holding the ALT key.

Addresses issues: #3145 #3146 

While testing, you may see the following error, which is because the layer is not ready for reading (same problem again, and I remember we have watson for it) but it is totally ok for this case because we will add the layer later when handling the `placeEvent`.

<img width="1049" alt="screen shot 2015-10-27 at 3 21 50 pm" src="https://cloud.githubusercontent.com/assets/118264/10774817/011a7874-7cc1-11e5-82af-fbcdb318100f.png">