### PR TITLE
Increase the minimum layer size for a core issue

### DIFF
--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -36,8 +36,12 @@ define(function (require, exports, module) {
         strings = require("i18n!nls/strings"),
         collection = require("js/util/collection");
 
+    // The minimum layer size in PS is 0.1 pixel, but it has an issue with some smart objects and graphic layers 
+    // when set to less than 0.5 pixel.
+    // 
+    // FIXME: restore to 0.1 pixel when the issue is fixed https://watsonexp.corp.adobe.com/#bug=4080692
     var MAX_LAYER_SIZE = 32000,
-        MIN_LAYER_SIZE = 0.1;
+        MIN_LAYER_SIZE = 0.5;
 
     var Size = React.createClass({
         mixins: [FluxMixin],


### PR DESCRIPTION
Addresses #3153: if you set a LLSO's size to less than 0.5, it will turn into a bad state with null X/Y/W/H. More testings show that this is not limited to LLSO: any pixel layers and SOs that link to an image will have the same issue. 

Reproduce:

drag-n-drop an image from browser to create a pixel layer, and set the width / height to less than 0.5

I created a watson bug for this (https://watsonexp.corp.adobe.com/#bug=4080692), and the most risk-free work around to me is increasing the minimum size to 0.5 pixel. Please let me know if you disagree with the solution (breaking UX?) and we can come up with a better one.