### PR TITLE
JSCS 2.5

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -18,6 +18,9 @@
     ],
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleSpaces": true,
+    "disallowNestedTernaries": {
+        "maxLevel": 1
+    },
     "disallowNewlineBeforeBlockStatements": true,
     "disallowOperatorBeforeLineBreak": [
         "."
@@ -43,6 +46,7 @@
     "disallowSpacesInsideArrayBrackets": "nested",
     "disallowSpacesInsideBrackets": true,
     "disallowSpacesInsideParentheses": true,
+    "disallowTabs": true,
     "disallowTrailingComma": true,
     "disallowTrailingWhitespaceInSource": true,
     "esnext": true,
@@ -90,6 +94,9 @@
     "requireParenthesesAroundIIFE": true,
     "requireSemicolons": true,
     "requireSpaceAfterBinaryOperators": true,
+    "requireSpaceAfterComma": {
+        "allExcept": ["trailing"]
+    },
     "requireSpaceAfterKeywords": true,
     "requireSpaceAfterLineComment": true,
     "requireSpaceBeforeBinaryOperators": true,
@@ -144,7 +151,9 @@
         "checkReturnTypes": true,
         "checkRedundantReturns": true,
         "requireReturnTypes": true,
-        "enforceExistence": "exceptExports",
+        "enforceExistence": {
+            "allExcept": ["exports"]
+        },
         "enforceExistenceExcept": [
             "get",
             "setup",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-requirejs": "^0.4.4",
-    "grunt-jscs": "~2.1.0",
+    "grunt-jscs": "^2.3.0",
     "grunt-jsdoc": "^0.6.8",
     "grunt-jsonlint": "^1.0.4",
     "grunt-jsxhint": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-jsxhint": "^0.6.0",
     "grunt-lintspaces": "^0.7.0",
     "node-lintspaces": "shaoshing/node-lintspaces",
-    "jscs-jsdoc": "shaoshing/jscs-jsdoc#v1.1.0.x",
+    "jscs-jsdoc": "shaoshing/jscs-jsdoc#7fbf64b",
     "jscs-trailing-whitespace-in-source": "0.0.1",
     "lodash": "^3.10.1",
     "react-tools": "^0.13.1"

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1451,7 +1451,7 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Layer} layer
      * @param {boolean} visible Whether to show or hide the layer
-
+     * 
      * @returns {Promise}
      */
     var setVisibility = function (document, layer, visible) {
@@ -1658,7 +1658,7 @@ define(function (require, exports) {
      * @param {boolean=} suppressHistory Optional. If true, emit an event that does NOT add a new history state
      * @param {boolean=} amendHistory Optional. If true, update the current state (requires suppressHistory)
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
-     **/
+     */
     var resetIndex = function (document, suppressHistory, amendHistory) {
         if (typeof document === "undefined") {
             document = this.flux.store("application").getCurrentDocument();
@@ -1712,8 +1712,8 @@ define(function (require, exports) {
      *                               If a string, the reference enum type ("front", "back", "previous", "next")
      *
      * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
-     *, or rejects if targetIndex is invalid, as example when it is a child of one of the layers in layer spec
-     **/
+     * , or rejects if targetIndex is invalid, as example when it is a child of one of the layers in layer spec
+     */
     var reorderLayers = function (document, layerSpec, target) {
         if (!Immutable.Iterable.isIterable(layerSpec)) {
             layerSpec = Immutable.List.of(layerSpec);

--- a/src/js/actions/mask.js
+++ b/src/js/actions/mask.js
@@ -128,7 +128,7 @@ define(function (require, exports) {
     };
     handleDeleteVectorMask.reads = [locks.JS_APP, locks.JS_DOC];
     handleDeleteVectorMask.writes = [];
-    handleDeleteVectorMask.transfers = [layerActions.resetLayers,layerActions.deleteVectorMask,
+    handleDeleteVectorMask.transfers = [layerActions.resetLayers, layerActions.deleteVectorMask,
         toolActions.changeVectorMaskMode, menuActions.native];
 
     exports.handleDeleteVectorMask = handleDeleteVectorMask;

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1488,7 +1488,7 @@ define(function (require, exports, module) {
      * @param {number | Immutable.List.<number>} layerEffectIndex index of effect, or per-layer List thereof
      * @param {string} layerEffectType type of layer effect
      * @param {object | Immutable.List.<object>} layerEffectProperties properties to merge, or per-layer List thereof.
-     *                  				         If property is null, the layer effect will be deleted.
+     *  If property is null, the layer effect will be deleted.
      * @return {LayerStructure}
      */
     LayerStructure.prototype.setLayerEffectProperties = function (layerIDs,

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
          *  keyObject: object,
          *  validate: function:
          *  onDrop: function(keyObject) 
-         *  	function should return a Promise instance to indicate the completion of an onDrop event. 
+         *      function should return a Promise instance to indicate the completion of an onDrop event. 
          * }
          * 
          * @private


### PR DESCRIPTION
1. Upgrade to grunt-jscs 2.3, which includes JSCS 2.5.
2. Tighten up the config a bit using the new rules.
3. Point to @shaoshing's updated jsdoc plugin, which implements a JSDoc-enforcement project suitable for our repo.

In the process, I filed jscs-dev/node-jscs#1946.

To test: `rm -rf node_modules && npm install && grunt jscs`.

Addresses #2880.