### PR TITLE
Replace mergeDeep calls in LayerStructure with shallow merge calls

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1453,16 +1453,12 @@ define(function (require, exports) {
      * @param {Document} document
      * @param {Layer} layer
      * @param {boolean} visible Whether to show or hide the layer
-     * 
      * @returns {Promise}
      */
     var setVisibility = function (document, layer, visible) {
         var payload = {
                 documentID: document.id,
-                layerProps: {
-                    layerID: layer.id,
-                    visible: visible
-                }
+                layerProps: Immutable.Map([[layer.id, visible]])
             },
             command = visible ? layerLib.show : layerLib.hide,
             layerRef = [
@@ -1713,8 +1709,8 @@ define(function (require, exports) {
      * @param {number|string} target If a number, the target index to move layers to
      *                               If a string, the reference enum type ("front", "back", "previous", "next")
      *
-     * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected
-     * , or rejects if targetIndex is invalid, as example when it is a child of one of the layers in layer spec
+     * @return {Promise} Resolves to the new ordered IDs of layers as well as what layers should be selected,
+     *  or rejects if targetIndex is invalid, as example when it is a child of one of the layers in layer spec
      */
     var reorderLayers = function (document, layerSpec, target) {
         if (!Immutable.Iterable.isIterable(layerSpec)) {

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -88,8 +88,7 @@ define(function (require, exports, module) {
             SET_GROUP_EXPANSION: "setGroupExpansion",
             VISIBILITY_CHANGED: "layerVisibilityChanged",
             REORDER_LAYERS: "reorderLayersNoHistory",
-            LAYER_BOUNDS_CHANGED: "layerBoundsChanged",
-            RESET_BOUNDS: "resetBoundsNoHistory", // slightly different than above LAYER_BOUNDS_CHANGED
+            RESET_BOUNDS: "resetBoundsNoHistory",
             RESET_LAYERS: "resetLayers",
             RESET_LAYERS_BY_INDEX: "resetLayersByIndex",
             REPOSITION_LAYERS: "repositionLayersNoHistory",

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1022,7 +1022,7 @@ define(function (require, exports, module) {
             }, this);
         }.bind(this));
 
-        return this.set("layers", this.layers.merge(nextLayers));
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     /**
@@ -1093,6 +1093,20 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Set the visibility of the given layer IDs.
+     *
+     * @param {Immutable.Map.<number, boolean>} visibilityMap Map from layerID to visibility
+     * @return {LayerStructure}
+     */
+    LayerStructure.prototype.setVisibility = function (visibilityMap) {
+        var layerMap = visibilityMap.map(function (visible, layerID) {
+            return this.byID(layerID).set("visible", visible);
+        }, this);
+
+        return this.mergeIn(["layers"], layerMap);
+    };
+
+    /**
      * Update basic properties of the given layers.
      *
      * @param {Immutable.Iterable.<number>} layerIDs
@@ -1104,18 +1118,7 @@ define(function (require, exports, module) {
                 return [layerID, this.byID(layerID).setProperties(properties)];
             }, this));
 
-        return this.set("layers", this.layers.merge(updatedLayers));
-    };
-
-    /**
-     * Merges properties into the layers based on a map of simple property maps, keyed by layer ID
-     *
-     * @param {Immutable.Map.<number, Immutable.Map>} layerMap
-     */
-    LayerStructure.prototype.setLayerPropsMap = function (layerMap) {
-        return this.mergeDeep({
-            layers: layerMap
-        });
+        return this.mergeIn(["layers"], updatedLayers);
     };
 
     /**
@@ -1126,15 +1129,11 @@ define(function (require, exports, module) {
      * @return {LayerStructure}
      */
     LayerStructure.prototype._updateBounds = function (allBounds) {
-        var nextBounds = allBounds.map(function (bounds) {
-            return Immutable.Map({
-                bounds: bounds
-            });
-        });
+        var layerMap = allBounds.map(function (bounds, layerID) {
+            return this.byID(layerID).set("bounds", bounds);
+        }, this);
 
-        return this.mergeDeep({
-            layers: nextBounds
-        });
+        return this.mergeIn(["layers"], layerMap);
     };
 
     /**
@@ -1166,15 +1165,14 @@ define(function (require, exports, module) {
      * @return {LayerStructure}
      */
     LayerStructure.prototype.setLayersProportional = function (layerIDs, proportional) {
-        var nextLayers = Immutable.Map(layerIDs.reduce(function (map, layerID) {
-                return map.set(layerID, Immutable.Map({
-                    proportionalScaling: proportional
-                }));
-            }, new Map()));
+        var nextLayerMap = Immutable.Map(layerIDs.reduce(function (map, layerID) {
+            var layer = this.byID(layerID),
+                nextLayer = layer.set("proportionalScaling", proportional);
 
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+            return map.set(layerID, nextLayer);
+        }, new Map(), this));
+
+        return this.mergeIn(["layers"], nextLayerMap);
     };
 
     /**
@@ -1385,15 +1383,14 @@ define(function (require, exports, module) {
      */
     LayerStructure.prototype.setBorderRadii = function (layerIDs, radii) {
         var nextRadii = new Radii(radii),
-            nextLayers = Immutable.Map(layerIDs.reduce(function (map, layerID) {
-                return map.set(layerID, Immutable.Map({
-                    radii: nextRadii
-                }));
-            }, new Map()));
+            nextLayerMap = layerIDs.reduce(function (map, layerID) {
+                var layer = this.byID(layerID),
+                    nextLayer = layer.set("radii", nextRadii);
 
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+                return map.set(layerID, nextLayer);
+            }, new Map(), this);
+
+        return this.mergeIn(["layers"], nextLayerMap);
     };
 
     /**
@@ -1418,9 +1415,7 @@ define(function (require, exports, module) {
             return map.set(layerID, nextLayer);
         }, new Map(), this));
 
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     /**
@@ -1449,9 +1444,7 @@ define(function (require, exports, module) {
             return map.set(layerID, nextLayer);
         }, new Map(), this));
        
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     /**
@@ -1476,9 +1469,7 @@ define(function (require, exports, module) {
             return map.set(layerID, nextLayer);
         }, new Map(), this));
 
-        return this.mergeDeep({
-            layers: nextLayers
-        });
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     /**
@@ -1613,7 +1604,7 @@ define(function (require, exports, module) {
             return map.set(layerID, nextLayer);
         }, new Map(), this));
 
-        return this.set("layers", this.layers.merge(nextLayers));
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     /**
@@ -1660,7 +1651,7 @@ define(function (require, exports, module) {
                 return layer;
             });
 
-        return this.set("layers", this.layers.merge(nextLayers));
+        return this.mergeIn(["layers"], nextLayers);
     };
 
     module.exports = LayerStructure;


### PR DESCRIPTION
In the past, incorrect or unnecessary `mergeDeep` calls have caused both functional correctness and performance issues. This replaces all the `mergeDeep` calls inside of `LayerStructure`, where most of them exist. In the process, I noticed that the `LAYER_BOUNDS_CHANGED` event was unused, so I also deleted that, as well as its handler in the document store.

Partially addresses #3066. "Partially" because some calls still remain. In particular, one in the `dialog` store and a few in the `documentexports` model. Any ideas about those, @mcilroyc?