### PR TITLE
Fix sibling highlighting when in a grouped layer

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         OS = require("adapter/os");
 
     var system = require("js/util/system"),
+        collection = require("js/util/collection"),
         mathUtil = require("js/util/math"),
         keyUtil = require("js/util/key"),
         uiUtil = require("js/util/ui");
@@ -497,7 +498,11 @@ define(function (require, exports, module) {
             uiUtil.hitTestLayers(this.state.document.id, canvasMouse.x, canvasMouse.y)
                 .bind(this)
                 .then(function (hitLayerIDs) {
-                    return hitLayerIDs.findLast(function (id) {
+                    var selectableLayers = this.state.document.layers.selectable,
+                        selectableLayerIDs = collection.pluck(selectableLayers, "id"),
+                        considerIDs = collection.intersection(selectableLayerIDs, hitLayerIDs);
+
+                    return considerIDs.findLast(function (id) {
                         var layer = this.state.document.layers.byID(id);
 
                         return layer && !layer.isArtboard;

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -500,7 +500,7 @@ define(function (require, exports, module) {
                 .then(function (hitLayerIDs) {
                     var selectableLayers = this.state.document.layers.selectable,
                         selectableLayerIDs = collection.pluck(selectableLayers, "id"),
-                        considerIDs = collection.intersection(selectableLayerIDs, hitLayerIDs);
+                        considerIDs = collection.intersection(hitLayerIDs, selectableLayerIDs);
 
                     return considerIDs.findLast(function (id) {
                         var layer = this.state.document.layers.byID(id);


### PR DESCRIPTION
Highlighting wouldn't work right when you were in a group and tried highlighting the siblings. Problem was, we would use whatever the hitTest was returning us, and with recent changes (or maybe it was wrong for the last two months) the order was different, and the layer we want to highlight would be preceded by it's owner group.

Now I consider what's super selectable, and only use the intersection of those with what PS tells us we're hovering over.

Addresses #3132