### PR TITLE
Prioritize documents.beforeStartup higher than tools.beforeStartup

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -359,7 +359,7 @@ define(function (require, exports) {
             });
     };
     initActiveDocument.reads = [locks.PS_DOC];
-    initActiveDocument.writes = [locks.JS_DOC];
+    initActiveDocument.writes = [locks.JS_DOC, locks.JS_APP];
     initActiveDocument.transfers = [historyActions.queryCurrentHistory, "layers.deselectAll"];
 
     /**
@@ -1166,5 +1166,11 @@ define(function (require, exports) {
     exports.onReset = onReset;
 
     exports._getDocumentByRef = _getDocumentByRef;
-    exports._priority = -99;
+    
+    // This module needs to have a higher priority than tools
+    // Otherwise, if rectangle tool is selected, we set shape defaults
+    // which causes PS to set the fill color, and if there is an active document
+    // with a shape layer selected, this will reset the color of that shape
+    // But if document is initialized, we do a selection dance, avoiding this situation
+    exports._priority = 1;
 });

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -902,8 +902,5 @@ define(function (require, exports) {
     exports.beforeStartup = beforeStartup;
     exports.onReset = onReset;
 
-    // This module must have a higher priority than the document module to avoid
-    // duplicate current-document updates on startup, but lower priority than the
-    // ui module so that defaults, which tool select handlers rely on, can be set.
     exports._priority = 0;
 });


### PR DESCRIPTION
Problem was, tools.installShapeDefaults would directly change the current active fill/stroke color if there was no document model loaded. And if we had rectangle tool selected in PS, during `tools.beforeStartup`, we would initialize the rectangle tool, and since `documents.beforeStartup` was not yet called, reset the defaults.

Solution was to move initTool call to tools.afterStartup, so document can be initialized in our models before we try to set shape defaults.

Addresses #3169