### PR TITLE
Fix for wrong last selected library.

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -1035,10 +1035,10 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var selectLibrary = function (id) {
-        var libraryState = this.flux.stores.library.getState();
-        
         this.dispatch(events.libraries.LIBRARY_SELECTED, { id: id });
         
+        var libraryState = this.flux.stores.library.getState();
+
         return this.transfer(preferencesActions.setPreference,
             _LAST_SELECTED_LIBRARY_ID_PREF, libraryState.currentLibraryID);
     };

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -561,7 +561,7 @@ define(function (require, exports) {
         if (!targetLayers || !style) {
             return Promise.resolve();
         }
-        
+
         var shapeLayers = Immutable.List(),
             textLayers = Immutable.List(),
             nonTextLayers = Immutable.List(),

--- a/src/style/shared/drop-down.less
+++ b/src/style/shared/drop-down.less
@@ -25,6 +25,7 @@
     font-size: @text-medium;
     background: url("data:image/svg+xml;charset=UTF-8,<svg width='11' height='7' viewBox='0 0 11 7' xmlns='http://www.w3.org/2000/svg'><title>drop-down</title><path d='M1.885 1.74l2.93 2.722m.685.68L9.164 1.74' stroke-linecap='square' stroke='#cecece' stroke-width='1.5' fill='none' fill-rule='evenodd'/></svg>") no-repeat right @bg-panel; 
     background-size: 1rem;
+    padding-right: 1rem;
     outline: none;
 }
 


### PR DESCRIPTION
Addresses issue #3168, which your last selected library was wrong due to reading the library state at a wrong timing. 

~~Removed extra lines #3166~~

Added right padding to dropdown input to avoid long title overlapping with the arrow icon.

<img width="379" alt="screen shot 2015-11-03 at 9 23 48 am" src="https://cloud.githubusercontent.com/assets/118264/10915935/d9550852-820d-11e5-8aa7-03fd6ad8f5cc.png">
