### PR TITLE
Fix modal flag of transferred actions during type tool use

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -182,6 +182,7 @@ define(function (require, exports) {
     resetGuidePolicies.reads = [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI];
     resetGuidePolicies.writes = [];
     resetGuidePolicies.transfers = [policy.removePointerPolicies, policy.addPointerPolicies];
+    resetGuidePolicies.modal = true;
 
     /**
      * Creates a guide and starts tracking it for user to place in desired location

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -551,6 +551,7 @@ define(function (require, exports) {
     resetLayers.reads = [locks.PS_DOC];
     resetLayers.writes = [locks.JS_DOC];
     resetLayers.transfers = [tools.resetBorderPolicies];
+    resetLayers.modal = true;
 
     /**
      * Emit a RESET_BOUNDS with bounds descriptors for the given layers.
@@ -765,6 +766,7 @@ define(function (require, exports) {
     initializeLayers.reads = [];
     initializeLayers.writes = [];
     initializeLayers.transfers = [resetLayers];
+    initializeLayers.modal = true;
 
     /**
      * Expand or collapse the given group layers in the layers panel.

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -308,6 +308,7 @@ define(function (require, exports) {
         policy.addPointerPolicies,
         guides.resetGuidePolicies
     ];
+    resetBorderPolicies.modal = true;
 
     /**
      * Swaps the policies of the current tool with the next tool


### PR DESCRIPTION
These actions were not modal, so during type tool use, we were killing modal state. Fixes type tool use