### PR TITLE
Add an inside policy for shift modifier to border policies

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -180,6 +180,11 @@ define(function (require, exports) {
                 distortModifier,
                 innerRect
             ),
+            insideShiftPolicy = new PointerEventPolicy(adapterUI.policyAction.PROPAGATE_TO_BROWSER,
+                adapterOS.eventKind.LEFT_MOUSE_DOWN,
+                { shift: true },
+                innerRect
+            ),
             // Used for distort/skew transformations
             noOutsetCommandPolicy = new PointerEventPolicy(adapterUI.policyAction.PROPAGATE_BY_ALPHA,
                 adapterOS.eventKind.LEFT_MOUSE_DOWN,
@@ -214,6 +219,7 @@ define(function (require, exports) {
         var pointerPolicyList = [
             insidePolicy,
             insideCommandPolicy,
+            insideShiftPolicy,
             noOutsetCommandPolicy,
             noOutsetShiftPolicy,
             noOutsetCommandShiftPolicy,


### PR DESCRIPTION
The outside propagate_by_alpha policy was kicking in because we didn't handle shift key on the inside area as we should. So holding down shift and clicking within the selection would send the click to PS.

Addresses #3195 