### PR TITLE
Update menu items on group expansion/collapse

### DIFF
--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -101,6 +101,7 @@ define(function (require, exports, module) {
                 events.document.history.optimistic.RADII_CHANGED, this._updateMenuItems,
                 events.document.history.optimistic.FILL_COLOR_CHANGED, this._updateMenuItems,
                 events.document.history.optimistic.FILL_OPACITY_CHANGED, this._updateMenuItems,
+                events.document.SET_GROUP_EXPANSION, this._updateMenuItems,
                 events.document.STROKE_ALIGNMENT_CHANGED, this._updateMenuItems,
                 events.document.STROKE_ENABLED_CHANGED, this._updateMenuItems,
                 events.document.STROKE_WIDTH_CHANGED, this._updateMenuItems,


### PR DESCRIPTION
We didn't, so doc would be set dirty, but save would be disabled. Which is #3191.