### PR TITLE
Move adapter requires to object requires

### DIFF
--- a/src/js/actions/application.js
+++ b/src/js/actions/application.js
@@ -26,11 +26,11 @@ define(function (require, exports) {
 
     var Promise = require("bluebird");
 
-    var descriptor = require("adapter/ps/descriptor");
+    var descriptor = require("adapter").ps.descriptor;
 
     var events = require("../events"),
         locks = require("js/locks"),
-        ruler = require("adapter/lib/ruler");
+        ruler = require("adapter").lib.ruler;
 
     /**
      * Gets the application version

--- a/src/js/actions/dialog.js
+++ b/src/js/actions/dialog.js
@@ -26,8 +26,8 @@ define(function (require, exports) {
 
     var Promise = require("bluebird");
 
-    var adapterUI = require("adapter/ps/ui"),
-        adapterOS = require("adapter/os");
+    var adapterUI = require("adapter").ps.ui,
+        adapterOS = require("adapter").os;
 
     var events = require("../events"),
         policy = require("./policy"),

--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -27,10 +27,10 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         _ = require("lodash");
 
-    var photoshopEvent = require("adapter/lib/photoshopEvent"),
-        descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        selectionLib = require("adapter/lib/selection");
+    var photoshopEvent = require("adapter").lib.photoshopEvent,
+        descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        selectionLib = require("adapter").lib.selection;
 
     var guideActions = require("./guides"),
         exportActions = require("./export"),

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -27,7 +27,7 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         Immutable = require("immutable");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var events = require("../events"),
         locks = require("../locks"),

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -27,11 +27,11 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         Immutable = require("immutable");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        layerLib = require("adapter/lib/layer"),
-        documentLib = require("adapter/lib/document"),
-        generatorLib = require("adapter/lib/generator"),
-        preferenceLib = require("adapter/lib/preference");
+    var descriptor = require("adapter").ps.descriptor,
+        layerLib = require("adapter").lib.layer,
+        documentLib = require("adapter").lib.document,
+        generatorLib = require("adapter").lib.generator,
+        preferenceLib = require("adapter").lib.preference;
 
     var dialog = require("./dialog"),
         preferences = require("./preferences"),

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -27,10 +27,10 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         _ = require("lodash");
         
-    var descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        adapterUI = require("adapter/ps/ui"),
-        adapterOS = require("adapter/os");
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        adapterUI = require("adapter").ps.ui,
+        adapterOS = require("adapter").os;
 
     var locks = require("js/locks"),
         events = require("js/events"),

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -27,10 +27,10 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         _ = require("lodash");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        ps = require("adapter/ps"),
-        documentLib = require("adapter/lib/document"),
-        historyLib = require("adapter/lib/history"),
+    var descriptor = require("adapter").ps.descriptor,
+        ps = require("adapter").ps,
+        documentLib = require("adapter").lib.document,
+        historyLib = require("adapter").lib.history,
         layerActions = require("./layers"),
         toolActions = require("./tools"),
         documentActions = require("./documents");

--- a/src/js/actions/keyevents.js
+++ b/src/js/actions/keyevents.js
@@ -26,7 +26,7 @@ define(function (require, exports) {
 
     var Promise = require("bluebird");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var events = require("../events"),
         log = require("js/util/log"),

--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -27,8 +27,8 @@ define(function (require, exports) {
     var _ = require("lodash"),
         Immutable = require("immutable");
 
-    var layerEffectLib = require("adapter/lib/layerEffect"),
-        documentLib = require("adapter/lib/document");
+    var layerEffectLib = require("adapter").lib.layerEffect,
+        documentLib = require("adapter").lib.document;
 
     var Color = require("js/models/color"),
         LayerEffect = require("js/models/effects/layereffect"),

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -28,14 +28,14 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         _ = require("lodash");
         
-    var photoshopEvent = require("adapter/lib/photoshopEvent"),
-        artboardLib = require("adapter/lib/artboard"),
-        boundsLib = require("adapter/lib/bounds"),
-        descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        layerLib = require("adapter/lib/layer"),
-        vectorMaskLib = require("adapter/lib/vectorMask"),
-        OS = require("adapter/os");
+    var photoshopEvent = require("adapter").lib.photoshopEvent,
+        artboardLib = require("adapter").lib.artboard,
+        boundsLib = require("adapter").lib.bounds,
+        descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer,
+        vectorMaskLib = require("adapter").lib.vectorMask,
+        OS = require("adapter").os;
 
     var Layer = require("js/models/layer"),
         collection = require("js/util/collection"),

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -29,14 +29,14 @@ define(function (require, exports) {
         _ = require("lodash"),
         CCLibraries = require("file://shared/libs/cc-libraries-api.min.js");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        docAdapter = require("adapter/lib/document"),
-        colorAdapter = require("adapter/lib/color"),
-        layerEffectAdapter = require("adapter/lib/layerEffect"),
-        textLayerAdapter = require("adapter/lib/textLayer"),
-        libraryAdapter = require("adapter/lib/libraries"),
-        documentLib = require("adapter/lib/document"),
-        os = require("adapter/os");
+    var descriptor = require("adapter").ps.descriptor,
+        docAdapter = require("adapter").lib.document,
+        colorAdapter = require("adapter").lib.color,
+        layerEffectAdapter = require("adapter").lib.layerEffect,
+        textLayerAdapter = require("adapter").lib.textLayer,
+        libraryAdapter = require("adapter").lib.libraries,
+        documentLib = require("adapter").lib.document,
+        os = require("adapter").os;
 
     var events = require("js/events"),
         locks = require("js/locks"),

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -28,9 +28,9 @@ define(function (require, exports) {
         _ = require("lodash");
 
     var adapter = require("adapter"),
-        ps = require("adapter/ps"),
-        ui = require("adapter/ps/ui"),
-        descriptor = require("adapter/ps/descriptor");
+        ps = require("adapter").ps,
+        ui = require("adapter").ps.ui,
+        descriptor = require("adapter").ps.descriptor;
 
     var events = require("js/events"),
         locks = require("js/locks"),

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -26,8 +26,8 @@ define(function (require, exports) {
 
     var Promise = require("bluebird");
 
-    var adapterUI = require("adapter/ps/ui"),
-        adapterOS = require("adapter/os");
+    var adapterUI = require("adapter").ps.ui,
+        adapterOS = require("adapter").os;
 
     var events = require("js/events"),
         locks = require("js/locks"),

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -28,11 +28,11 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         CCLibraries = require("file://shared/libs/cc-libraries-api.min.js");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        layerLib = require("adapter/lib/layer"),
-        libraryLib = require("adapter/lib/libraries"),
-        documentLib = require("adapter/lib/document"),
-        adapterOS = require("adapter/os");
+    var descriptor = require("adapter").ps.descriptor,
+        layerLib = require("adapter").lib.layer,
+        libraryLib = require("adapter").lib.libraries,
+        documentLib = require("adapter").lib.document,
+        adapterOS = require("adapter").os;
 
     var Color = require("js/models/color"),
         uiUtil = require("js/util/ui"),

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -28,11 +28,11 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         _ = require("lodash");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        layerLib = require("adapter/lib/layer"),
-        pathLib = require("adapter/lib/path"),
-        documentLib = require("adapter/lib/document"),
-        contentLayerLib = require("adapter/lib/contentLayer");
+    var descriptor = require("adapter").ps.descriptor,
+        layerLib = require("adapter").lib.layer,
+        pathLib = require("adapter").lib.path,
+        documentLib = require("adapter").lib.document,
+        contentLayerLib = require("adapter").lib.contentLayer;
 
     var events = require("../events"),
         locks = require("js/locks"),

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -27,8 +27,8 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         _ = require("lodash");
 
-    var os = require("adapter/os"),
-        ui = require("adapter/ps/ui");
+    var os = require("adapter").os,
+        ui = require("adapter").ps.ui;
 
     var events = require("js/events"),
         locks = require("js/locks"),

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -28,10 +28,10 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         _ = require("lodash");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool"),
-        adapterOS = require("adapter/os"),
-        adapterUI = require("adapter/ps/ui");
+    var descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool,
+        adapterOS = require("adapter").os,
+        adapterUI = require("adapter").ps.ui;
 
     var keyUtil = require("js/util/key"),
         system = require("js/util/system"),

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -28,16 +28,16 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         _ = require("lodash");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool"),
-        layerLib = require("adapter/lib/layer"),
-        documentLib = require("adapter/lib/document"),
-        adapterOS = require("adapter/os"),
-        adapterUI = require("adapter/ps/ui"),
-        adapterPS = require("adapter/ps"),
-        UI = require("adapter/ps/ui"),
-        OS = require("adapter/os"),
-        vectorMaskLib = require("adapter/lib/vectorMask");
+    var descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool,
+        layerLib = require("adapter").lib.layer,
+        documentLib = require("adapter").lib.document,
+        adapterOS = require("adapter").os,
+        adapterUI = require("adapter").ps.ui,
+        adapterPS = require("adapter").ps,
+        UI = require("adapter").ps.ui,
+        OS = require("adapter").os,
+        vectorMaskLib = require("adapter").lib.vectorMask;
 
     var events = require("../events"),
         guides = require("./guides"),

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -28,12 +28,12 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         _ = require("lodash");
         
-    var descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        layerLib = require("adapter/lib/layer"),
-        artboardLib = require("adapter/lib/artboard"),
-        contentLib = require("adapter/lib/contentLayer"),
-        unitLib = require("adapter/lib/unit"),
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer,
+        artboardLib = require("adapter").lib.artboard,
+        contentLib = require("adapter").lib.contentLayer,
+        unitLib = require("adapter").lib.unit,
         uiUtil = require("js/util/ui");
 
     var events = require("../events"),

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -27,11 +27,11 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         _ = require("lodash");
 
-    var textLayerLib = require("adapter/lib/textLayer"),
-        descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        layerLib = require("adapter/lib/layer"),
-        appLib = require("adapter/lib/application");
+    var textLayerLib = require("adapter").lib.textLayer,
+        descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer,
+        appLib = require("adapter").lib.application;
 
     var layerActions = require("./layers"),
         events = require("../events"),

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -28,10 +28,10 @@ define(function (require, exports) {
         _ = require("lodash");
 
     var adapter = require("adapter"),
-        descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        adapterUI = require("adapter/ps/ui"),
-        adapterOS = require("adapter/os");
+        descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        adapterUI = require("adapter").ps.ui,
+        adapterOS = require("adapter").os;
 
     var Bounds = require("js/models/bounds"),
         events = require("js/events"),

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -29,8 +29,8 @@ define(function (require, exports, module) {
         EventEmitter = require("eventEmitter"),
         _ = require("lodash");
 
-    var ps = require("adapter/ps"),
-        util = require("adapter/util");
+    var ps = require("adapter").ps,
+        util = require("adapter").util;
 
     var locks = require("./locks"),
         events = require("./events"),

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         Immutable = require("immutable");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var DocumentHeaderTab = require("jsx!js/jsx/DocumentHeaderTab"),
         Button = require("jsx!js/jsx/shared/Button"),

--- a/src/js/jsx/Guard.jsx
+++ b/src/js/jsx/Guard.jsx
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
     var React = require("react"),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var synchronization = require("js/util/synchronization");
 

--- a/src/js/jsx/Help.jsx
+++ b/src/js/jsx/Help.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     var Dialog = require("jsx!./shared/Dialog"),
         FirstLaunch = require("jsx!./help/FirstLaunch"),
         KeyboardShortcuts = require("jsx!./help/KeyboardShortcuts"),
-        os = require("adapter/os");
+        os = require("adapter").os;
 
     /**
      * Unique identifier for the First Launch Dialog

--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         classnames = require("classnames");
 
-    var adapterOS = require("adapter/os"),
+    var adapterOS = require("adapter").os,
         headlights = require("js/util/headlights");
 
     var PolicyOverlay = require("jsx!js/jsx/tools/PolicyOverlay"),

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var os = require("adapter/os"),
+    var os = require("adapter").os,
         Dialog = require("jsx!./shared/Dialog"),
         SearchBar = require("jsx!./search/SearchBar"),
         search = require("js/stores/search");

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var ToolbarIcon = require("jsx!js/jsx/ToolbarIcon"),
         Zoom = require("jsx!js/jsx/Zoom"),

--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
 
     var React = require("react");
 
-    var OS = require("adapter/os");
+    var OS = require("adapter").os;
 
     var log = require("js/util/log");
 

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         _ = require("lodash");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var collection = require("js/util/collection"),
         strings = require("i18n!nls/strings"),

--- a/src/js/jsx/sections/export/ExportModal.jsx
+++ b/src/js/jsx/sections/export/ExportModal.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var Dialog = require("jsx!js/jsx/shared/Dialog"),
         ExportAllPanel = require("jsx!./ExportAllPanel");

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var ExportList = require("jsx!js/jsx/sections/export/ExportList"),
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         LayerFace = require("jsx!./LayerFace"),

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var os = require("adapter/os"),
+    var os = require("adapter").os,
         synchronization = require("js/util/synchronization"),
         strings = require("i18n!nls/strings"),
         ui = require("js/util/ui"),

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         classnames = require("classnames");
 
-    var os = require("adapter/os"),
+    var os = require("adapter").os,
         Layer = require("js/models/layer");
 
     var TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         _ = require("lodash"),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         Button = require("jsx!js/jsx/shared/Button"),

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var contentLayerLib = require("adapter/lib/contentLayer");
+    var contentLayerLib = require("adapter").lib.contentLayer;
 
     var Color = require("js/models/color"),
         StrokeAlignment = require("jsx!./StrokeAlignment"),

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable"),
         classnames = require("classnames");
 
-    var textLayer = require("adapter/lib/textLayer");
+    var textLayer = require("adapter").lib.textLayer;
 
     var Label = require("jsx!js/jsx/shared/Label"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),

--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable");
 
-    var contentLayerLib = require("adapter/lib/contentLayer");
+    var contentLayerLib = require("adapter").lib.contentLayer;
 
     var LayerBlendMode = require("jsx!./LayerBlendMode"),
         Opacity = require("jsx!./Opacity"),

--- a/src/js/jsx/shared/Carousel.jsx
+++ b/src/js/jsx/shared/Carousel.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         classnames = require("classnames");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         tinycolor = require("tinycolor"),
         _ = require("lodash");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var Focusable = require("js/jsx/mixin/Focusable"),
         Dialog = require("jsx!js/jsx/shared/Dialog"),

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         classnames = require("classnames"),
         _ = require("lodash");
 
-    var os = require("adapter/os");
+    var os = require("adapter").os;
 
     var math = require("js/util/math");
 

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         d3 = require("d3"),
         _ = require("lodash");
 
-    var OS = require("adapter/os");
+    var OS = require("adapter").os;
 
     var mathUtil = require("js/util/math");
 

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         d3 = require("d3"),
         _ = require("lodash");
 
-    var UI = require("adapter/ps/ui");
+    var UI = require("adapter").ps.ui;
 
     var PolicyOverlay = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("policy", "ui")],

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         d3 = require("d3"),
         _ = require("lodash");
 
-    var OS = require("adapter/os");
+    var OS = require("adapter").os;
 
     var system = require("js/util/system"),
         headlights = require("js/util/headlights"),

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -31,8 +31,8 @@ define(function (require, exports, module) {
         d3 = require("d3"),
         _ = require("lodash");
 
-    var UI = require("adapter/ps/ui"),
-        OS = require("adapter/os");
+    var UI = require("adapter").ps.ui,
+        OS = require("adapter").os;
 
     var system = require("js/util/system"),
         collection = require("js/util/collection"),

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
 
     var Immutable = require("immutable");
 
-    var layerLib = require("adapter/lib/layer"),
+    var layerLib = require("adapter").lib.layer,
         objUtil = require("js/util/object");
 
     /**

--- a/src/js/models/eventpolicy.js
+++ b/src/js/models/eventpolicy.js
@@ -24,7 +24,7 @@
 define(function (require, exports) {
     "use strict";
 
-    var util = require("adapter/util"),
+    var util = require("adapter").util,
         keyutil = require("js/util/key");
 
     /**

--- a/src/js/models/fill.js
+++ b/src/js/models/fill.js
@@ -27,8 +27,8 @@ define(function (require, exports, module) {
     var Immutable = require("immutable");
 
     var Color = require("./color"),
-        layerLib = require("adapter/lib/layer"),
-        contentLayerLib = require("adapter/lib/contentLayer"),
+        layerLib = require("adapter").lib.layer,
+        contentLayerLib = require("adapter").lib.contentLayer,
         objUtil = require("js/util/object"),
         log = require("js/util/log");
 

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
 
     var Immutable = require("immutable");
 
-    var layerLib = require("adapter/lib/layer");
+    var layerLib = require("adapter").lib.layer;
 
     var object = require("js/util/object"),
         Bounds = require("./bounds"),

--- a/src/js/models/layernode.js
+++ b/src/js/models/layernode.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
 
     var Immutable = require("immutable");
 
-    var layerLib = require("adapter/lib/layer");
+    var layerLib = require("adapter").lib.layer;
 
     /**
      * A node in the layer tree structure.

--- a/src/js/models/menuitem.js
+++ b/src/js/models/menuitem.js
@@ -24,11 +24,11 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var os = require("adapter/os"),
+    var os = require("adapter").os,
         _ = require("lodash"),
         Immutable = require("immutable");
 
-    var UI = require("adapter/ps/ui");
+    var UI = require("adapter").ps.ui;
 
     var menuLabels = require("i18n!nls/menu"),
         keyutil = require("js/util/key"),

--- a/src/js/models/radii.js
+++ b/src/js/models/radii.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
 
     var unit = require("js/util/unit"),
         objUtil = require("js/util/object"),
-        contentLib = require("adapter/lib/contentLayer");
+        contentLib = require("adapter").lib.contentLayer;
 
     /**
      * Model for a bounds rectangle, we extract it from the layer descriptor

--- a/src/js/models/stroke.js
+++ b/src/js/models/stroke.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     var Color = require("./color"),
         unit = require("../util/unit"),
         objUtil = require("js/util/object"),
-        contentLayerLib = require("adapter/lib/contentLayer"),
+        contentLayerLib = require("adapter").lib.contentLayer,
         log = require("js/util/log");
 
     /**

--- a/src/js/tools/ellipse.js
+++ b/src/js/tools/ellipse.js
@@ -26,12 +26,12 @@ define(function (require, exports, module) {
   
     var Promise = require("bluebird");
 
-    var util = require("adapter/util"),
-        descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        vectorMaskLib = require("adapter/lib/vectorMask");
+    var util = require("adapter").util,
+        descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        vectorMaskLib = require("adapter").lib.vectorMask;
 
     var Tool = require("js/models/tool"),
         toolActions = require("js/actions/tools"),

--- a/src/js/tools/pen.js
+++ b/src/js/tools/pen.js
@@ -26,12 +26,12 @@ define(function (require, exports, module) {
 
     var Promise = require("bluebird");
     
-    var util = require("adapter/util"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        toolLib = require("adapter/lib/tool"),
-        descriptor = require("adapter/ps/descriptor"),
-        vectorMaskLib = require("adapter/lib/vectorMask");
+    var util = require("adapter").util,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        toolLib = require("adapter").lib.tool,
+        descriptor = require("adapter").ps.descriptor,
+        vectorMaskLib = require("adapter").lib.vectorMask;
 
     var Tool = require("js/models/tool"),
         shortcuts = require("js/actions/shortcuts"),

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -26,12 +26,12 @@ define(function (require, exports, module) {
 
     var Promise = require("bluebird");
 
-    var util = require("adapter/util"),
-        descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        vectorMaskLib = require("adapter/lib/vectorMask");
+    var util = require("adapter").util,
+        descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        vectorMaskLib = require("adapter").lib.vectorMask;
 
     var Tool = require("js/models/tool"),
         toolActions = require("js/actions/tools"),

--- a/src/js/tools/sampler.js
+++ b/src/js/tools/sampler.js
@@ -24,9 +24,9 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        util = require("adapter/util");
+    var OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        util = require("adapter").util;
 
     var events = require("js/events"),
         Tool = require("js/models/tool"),

--- a/src/js/tools/superselect.js
+++ b/src/js/tools/superselect.js
@@ -26,13 +26,13 @@ define(function (require, exports, module) {
 
     var _ = require("lodash");
 
-    var util = require("adapter/util"),
-        descriptor = require("adapter/ps/descriptor"),
-        adapterPS = require("adapter/ps"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        toolLib = require("adapter/lib/tool"),
-        vectorMaskLib = require("adapter/lib/vectorMask");
+    var util = require("adapter").util,
+        descriptor = require("adapter").ps.descriptor,
+        adapterPS = require("adapter").ps,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        toolLib = require("adapter").lib.tool,
+        vectorMaskLib = require("adapter").lib.vectorMask;
 
     var Tool = require("js/models/tool"),
         VectorTool = require("./superselect/vector"),

--- a/src/js/tools/superselect/type.js
+++ b/src/js/tools/superselect/type.js
@@ -24,10 +24,10 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var util = require("adapter/util"),
-        descriptor = require("adapter/ps/descriptor"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui");
+    var util = require("adapter").util,
+        descriptor = require("adapter").ps.descriptor,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui;
         
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),

--- a/src/js/tools/superselect/vector.js
+++ b/src/js/tools/superselect/vector.js
@@ -26,12 +26,12 @@ define(function (require, exports, module) {
 
     var Promise = require("bluebird");
 
-    var util = require("adapter/util"),
-        PS = require("adapter/ps"),
-        OS = require("adapter/os"),
-        UI = require("adapter/ps/ui"),
-        descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool");
+    var util = require("adapter").util,
+        PS = require("adapter").ps,
+        OS = require("adapter").os,
+        UI = require("adapter").ps.ui,
+        descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool;
         
     var Tool = require("js/models/tool"),
         shortcuts = require("js/actions/shortcuts"),

--- a/src/js/tools/type.js
+++ b/src/js/tools/type.js
@@ -26,10 +26,10 @@ define(function (require, exports, module) {
 
     var Immutable = require("immutable");
 
-    var util = require("adapter/util"),
-        descriptor = require("adapter/ps/descriptor"),
-        toolLib = require("adapter/lib/tool"),
-        UI = require("adapter/ps/ui");
+    var util = require("adapter").util,
+        descriptor = require("adapter").ps.descriptor,
+        toolLib = require("adapter").lib.tool,
+        UI = require("adapter").ps.ui;
 
     var Color = require("js/models/color"),
         Tool = require("js/models/tool"),

--- a/src/js/util/async-dependency-queue.js
+++ b/src/js/util/async-dependency-queue.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Promise = require("bluebird"),
         _ = require("lodash");
 
-    var util = require("adapter/util");
+    var util = require("adapter").util;
 
     /**
      * A job managed by an AsyncDependencyQueue instance.

--- a/src/js/util/headlights.js
+++ b/src/js/util/headlights.js
@@ -25,7 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var Promise = require("bluebird"),
-        adapterPS = require("adapter/ps"),
+        adapterPS = require("adapter").ps,
         global = require("./global");
 
     /**

--- a/src/js/util/key.js
+++ b/src/js/util/key.js
@@ -25,7 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var system = require("js/util/system"),
-        os = require("adapter/os");
+        os = require("adapter").os;
 
     /**
      * Convert a set of semantic key modifers to a sequence of bits, suitable

--- a/src/js/util/layeractions.js
+++ b/src/js/util/layeractions.js
@@ -27,9 +27,9 @@ define(function (require, exports) {
     var _ = require("lodash"),
         Promise = require("bluebird");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        layerLib = require("adapter/lib/layer");
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer;
 
     var log = require("js/util/log"),
         lockingUtil = require("js/util/locking"),

--- a/src/js/util/locking.js
+++ b/src/js/util/locking.js
@@ -28,9 +28,9 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         Promise = require("bluebird");
 
-    var descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        layerLib = require("adapter/lib/layer");
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer;
 
     var collection = require("js/util/collection");
 

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -25,7 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var _ = require("lodash"),
-        layerLib = require("adapter/lib/layer");
+        layerLib = require("adapter").lib.layer;
    
     /**
      * Get the class name for the layer face icon for the given layer

--- a/src/js/util/ui.js
+++ b/src/js/util/ui.js
@@ -27,9 +27,9 @@ define(function (require, exports) {
     var Immutable = require("immutable");
     
     var adapter = require("adapter"),
-        descriptor = require("adapter/ps/descriptor"),
-        documentLib = require("adapter/lib/document"),
-        hitTestLib = require("adapter/lib/hitTest");
+        descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        hitTestLib = require("adapter").lib.hitTest;
 
     var Bounds = require("js/models/bounds"),
         Color = require("js/models/color");


### PR DESCRIPTION
Instead of directly referring to adapter sources, we expect spaces-adapter to export a single object that we require parts of.

Requires https://github.com/adobe-photoshop/spaces-adapter/pull/163

This is an intermediate step that'll make it a lot easier to work on webpack efforts in parallel.

