### PR TITLE
Factor out colors-shared from color theme files

### DIFF
--- a/src/style/main.less
+++ b/src/style/main.less
@@ -31,6 +31,7 @@
 
 @import "./shared/animation.less";
 @import "./shared/label.less";
+@import "./shared/colors-shared.less";
 @import "./shared/colors-@{stop}.less";
 
 @import "./shared/compact-stats.less";

--- a/src/style/shared/colors-dark.less
+++ b/src/style/shared/colors-dark.less
@@ -83,38 +83,3 @@
 
 /* Libraries */
 @layer-style-preview-background: #B2B2B2;
-
-/* General Utilities */
-
-.shadow() {
-    -webkit-filter: shadow(0 1px 0 @mid-bg-alt)
-}
-
-.color-transparency(@color, @alpha: 1) {
-    color: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-transparency(@color, @alpha: 1) {
-    background: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.border-transparency(@size, @lineType, @color, @alpha: 1) {
-    border: @size @lineType rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-checkerboard(@size: 10) {
-    @halfsize: @size / 2;
-    background-color: @color-preview-background;
-    // checkerboard
-    background-image:
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%),
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%);
-    background-size: ~"@{size}px" ~"@{size}px";
-    background-position: 0 0, ~"@{halfsize}px" ~"@{halfsize}px";
-}
-
-.random-color(){
-  @random-color: `Math.floor(Math.random()*16777215).toString(16)`;
-  @color-hex: e(@random-color);
-  @color: ~"#@{color-hex}";
-}

--- a/src/style/shared/colors-light.less
+++ b/src/style/shared/colors-light.less
@@ -83,38 +83,3 @@
 
 /* Libraries */
 @layer-style-preview-background: #E3E3E3;
-
-/* General Utilities */
-
-.shadow() {
-    -webkit-filter: shadow(0 1px 0 @mid-bg-alt)
-}
-
-.color-transparency(@color, @alpha: 1) {
-    color: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-transparency(@color, @alpha: 1) {
-    background: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.border-transparency(@size, @lineType, @color, @alpha: 1) {
-    border: @size @lineType rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-checkerboard(@size: 10) {
-    @halfsize: @size / 2;
-    background-color: @color-preview-background;
-    // checkerboard
-    background-image:
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%),
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%);
-    background-size: ~"@{size}px" ~"@{size}px";
-    background-position: 0 0, ~"@{halfsize}px" ~"@{halfsize}px";
-}
-
-.random-color(){
-  @random-color: `Math.floor(Math.random()*16777215).toString(16)`;
-  @color-hex: e(@random-color);
-  @color: ~"#@{color-hex}";
-}

--- a/src/style/shared/colors-medium.less
+++ b/src/style/shared/colors-medium.less
@@ -82,38 +82,3 @@
 
 /* Libraries */
 @layer-style-preview-background: #E3E3E3;
-
-/* General Utilities */
-
-.shadow() {
-    -webkit-filter: shadow(0 1px 0 @mid-bg-alt)
-}
-
-.color-transparency(@color, @alpha: 1) {
-    color: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-transparency(@color, @alpha: 1) {
-    background: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.border-transparency(@size, @lineType, @color, @alpha: 1) {
-    border: @size @lineType rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-checkerboard(@size: 10) {
-    @halfsize: @size / 2;
-    background-color: @color-preview-background;
-    // checkerboard
-    background-image:
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%),
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%);
-    background-size: ~"@{size}px" ~"@{size}px";
-    background-position: 0 0, ~"@{halfsize}px" ~"@{halfsize}px";
-}
-
-.random-color(){
-  @random-color: `Math.floor(Math.random()*16777215).toString(16)`;
-  @color-hex: e(@random-color);
-  @color: ~"#@{color-hex}";
-}

--- a/src/style/shared/colors-original.less
+++ b/src/style/shared/colors-original.less
@@ -83,38 +83,3 @@
 
 /* Libraries */
 @layer-style-preview-background: #B2B2B2;
-
-/* General Utilities */
-
-.shadow() {
-    -webkit-filter: shadow(0 1px 0 @mid-bg-alt)
-}
-
-.color-transparency(@color, @alpha: 1) {
-    color: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-transparency(@color, @alpha: 1) {
-    background: rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.border-transparency(@size, @lineType, @color, @alpha: 1) {
-    border: @size @lineType rgba( red(@color), green(@color), blue(@color), @alpha);
-}
-
-.background-checkerboard(@size: 10) {
-    @halfsize: @size / 2;
-    background-color: @color-preview-background;
-    // checkerboard
-    background-image:
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%),
-    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%);
-    background-size: ~"@{size}px" ~"@{size}px";
-    background-position: 0 0, ~"@{halfsize}px" ~"@{halfsize}px";
-}
-
-.random-color(){
-  @random-color: `Math.floor(Math.random()*16777215).toString(16)`;
-  @color-hex: e(@random-color);
-  @color: ~"#@{color-hex}";
-}

--- a/src/style/shared/colors-shared.less
+++ b/src/style/shared/colors-shared.less
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/* General Utilities */
+
+.shadow() {
+    -webkit-filter: shadow(0 1px 0 @mid-bg-alt)
+}
+
+.color-transparency(@color, @alpha: 1) {
+    color: rgba( red(@color), green(@color), blue(@color), @alpha);
+}
+
+.background-transparency(@color, @alpha: 1) {
+    background: rgba( red(@color), green(@color), blue(@color), @alpha);
+}
+
+.border-transparency(@size, @lineType, @color, @alpha: 1) {
+    border: @size @lineType rgba( red(@color), green(@color), blue(@color), @alpha);
+}
+
+.background-checkerboard(@size: 10) {
+    @halfsize: @size / 2;
+    background-color: @color-preview-background;
+    // checkerboard
+    background-image:
+    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%),
+    -webkit-linear-gradient(45deg, @color-checkerboard 25%, transparent 25%,transparent 75%, @color-checkerboard 75%, @color-checkerboard 100%);
+    background-size: ~"@{size}px" ~"@{size}px";
+    background-position: 0 0, ~"@{halfsize}px" ~"@{halfsize}px";
+}
+
+.random-color(){
+  @random-color: `Math.floor(Math.random()*16777215).toString(16)`;
+  @color-hex: e(@random-color);
+  @color: ~"#@{color-hex}";
+}


### PR DESCRIPTION
This is a very simple factoring of the shared color styles functions into their own file, `colors-shared.less`, instead of being duplicated in each of the color theme files. It's just a copy-paste job.

Addresses: concerns.