### PR TITLE
Startup Columns Match Layout Preferences

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -421,14 +421,53 @@ define(function (require, exports, module) {
                         <IconBar />
                     </div>
                 );
-            } else {
+            } else if (this.state.propertiesVisible && this.state.layersLibrariesVisible) {
                 return (
+                    //  Show 2 columns and toolbar
+                    <div className="panel-set__container">
+                        <div ref="panelSet"
+                             className="panel-set">
+                            <PanelColumn visible={true} />
+                            <PanelColumn visible={true} />
+                        </div>
+                        <IconBar />
+                    </div>
+                );
+            } else if (this.state.propertiesVisible ||
+                       this.state.layersLibrariesVisible &&
+                       !this.props.singleColumnModeEnabled) {
+                return (
+                    // Just show one column and toolbar
                     <div className="panel-set__container">
                         <div ref="panelSet"
                              className="panel-set">
                             <PanelColumn visible={true} />
                         </div>
                         <IconBar />
+                    </div>
+                );
+            } else if (!this.state.propertiesVisible &&
+                       !this.state.layersLibrariesVisible &&
+                       !this.props.singleColumnModeEnabled) {
+                // Just show toolbar
+                return (
+                    <div className="panel-set__container">
+                        <div ref="panelSet"
+                             className="panel-set">
+                            <PanelColumn visible={false} />
+                        </div>
+                        <IconBar />
+                    </div>
+                );
+            } else if (this.props.singleColumnModeEnabled) {
+                // Just show single column
+                return (
+                    <div className="panel-set__container panel-set__container__small-screen">
+                        <div ref="panelSet"
+                             className="panel-set">
+                            <PanelColumn visible={true}>
+                            </PanelColumn>
+                        </div>
                     </div>
                 );
             }

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -421,6 +421,16 @@ define(function (require, exports, module) {
                         <IconBar />
                     </div>
                 );
+            } else if (this.props.singleColumnModeEnabled) {
+                // Just show single column
+                return (
+                    <div className="panel-set__container panel-set__container__small-screen">
+                        <div ref="panelSet"
+                             className="panel-set">
+                            <PanelColumn visible={true} />
+                        </div>
+                    </div>
+                );
             } else if (this.state.propertiesVisible && this.state.layersLibrariesVisible) {
                 return (
                     //  Show 2 columns and toolbar
@@ -433,8 +443,8 @@ define(function (require, exports, module) {
                         <IconBar />
                     </div>
                 );
-            } else if (this.state.propertiesVisible ||
-                       this.state.layersLibrariesVisible &&
+            } else if (this.state.propertiesVisible || 
+                       this.state.layersLibrariesVisible && 
                        !this.props.singleColumnModeEnabled) {
                 return (
                     // Just show one column and toolbar
@@ -457,17 +467,6 @@ define(function (require, exports, module) {
                             <PanelColumn visible={false} />
                         </div>
                         <IconBar />
-                    </div>
-                );
-            } else if (this.props.singleColumnModeEnabled) {
-                // Just show single column
-                return (
-                    <div className="panel-set__container panel-set__container__small-screen">
-                        <div ref="panelSet"
-                             className="panel-set">
-                            <PanelColumn visible={true}>
-                            </PanelColumn>
-                        </div>
                     </div>
                 );
             }

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -443,8 +443,8 @@ define(function (require, exports, module) {
                         <IconBar />
                     </div>
                 );
-            } else if (this.state.propertiesVisible || 
-                       this.state.layersLibrariesVisible && 
+            } else if (this.state.propertiesVisible ||
+                       this.state.layersLibrariesVisible &&
                        !this.props.singleColumnModeEnabled) {
                 return (
                     // Just show one column and toolbar


### PR DESCRIPTION
Use the app preferences for columns to render the correct column setup
that will be displayed. Avoids the lurching UI drawing once the full app is
loaded.