### PR TITLE
Added global shortcuts to the search options

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -40,7 +40,7 @@ define(function (require, exports) {
         headlights = require("js/util/headlights"),
         policyActions = require("./policy"),
         preferencesActions = require("./preferences"),
-        searchActions = require("./search/menucommands");
+        searchActions = require("./search/commands");
 
     var macMenuJSON = require("text!static/menu-mac.json"),
         winMenuJSON = require("text!static/menu-win.json"),
@@ -285,7 +285,6 @@ define(function (require, exports) {
     /**
      * Call action for menu command
      *
-     * @private
      * @param {string} commandID 
      */
     var _playMenuCommand = function (commandID) {
@@ -488,7 +487,6 @@ define(function (require, exports) {
     /**
      * Send info about menu commands to search store
      *
-     * @private
      * @return {Promise}
      */
     var afterStartup = function () {

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -63,7 +63,7 @@ define(function (require, exports) {
         var searchStore = this.flux.store("search");
 
         searchStore.registerSearch(ID,
-            ["CURRENT_DOC", "RECENT_DOC", "ALL_LAYER", "MENU_COMMAND", "LIBRARY"]);
+            ["CURRENT_DOC", "RECENT_DOC", "ALL_LAYER", "MENU_COMMAND", "LIBRARY", "GLOBAL_SHORTCUT"]);
 
         return Promise.resolve();
     };

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -901,7 +901,8 @@ define(function (require, exports) {
             specs.push({
                 key: activationKey,
                 modifiers: {},
-                fn: activateTool
+                fn: activateTool,
+                name: tool.name
             });
 
             // Add U as another shortcut for rectangle tool, hidden in here for now
@@ -926,7 +927,8 @@ define(function (require, exports) {
         shortcutSpecs.push({
             key: utilShortcuts.GLOBAL.TOOLS.MASK_SELECT,
             modifiers: {},
-            fn: _vectorMaskHandler
+            fn: _vectorMaskHandler,
+            name: "Vector Mask"
         });
 
         _vectorSelectMaskHandler = function () {
@@ -938,7 +940,8 @@ define(function (require, exports) {
         shortcutSpecs.push({
             key: utilShortcuts.GLOBAL.TOOLS.VECTOR_SELECT,
             modifiers: {},
-            fn: _vectorSelectMaskHandler
+            fn: _vectorSelectMaskHandler,
+            name: "Super Select Vector"
         });
 
         var shortcutsPromise = this.transfer(shortcuts.addShortcuts, shortcutSpecs),

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -292,7 +292,7 @@ define(function (require, exports, module) {
                     }
 
                     return {
-                        id: type + "-" + item.id,
+                        id: type + "-" + item.id.toString(),
                         title: name,
                         pathInfo: newPathInfo,
                         svgType: item.iconID,

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -470,7 +470,8 @@
             "RECENT_DOC": "Recent Documents",
             "MENU_COMMAND": "Menu Commands",
             "LIBRARY": "All Libraries",
-            "FILTER": "Limit search to…"
+            "FILTER": "Limit search to…",
+            "GLOBAL_SHORTCUT": "Global Shortcuts"
         },
         "CATEGORIES": {
             "CURRENT_DOC": "Open Documents",
@@ -488,7 +489,8 @@
             "LIBRARY": "All Libraries",
             "GRAPHIC": "Graphics",
             "LAYERSTYLE": "Layer Styles",
-            "CHARACTERSTYLE": "Character Styles"
+            "CHARACTERSTYLE": "Character Styles",
+            "GLOBAL_SHORTCUT": "Global Shortcuts"
         },
         "MODIFIERS": {
             "COMMAND": "Cmd",


### PR DESCRIPTION
With this PR, global shortcuts are added to the options that are pulled up when the search bar is prompted. 

1.) commands.js now provides the search provider for both Global Shortcuts and Menu Commands. One thing I need input on is whether we want to combine global shortcuts and menu commands under one header "Commands" in the UI, or keep them under separate labels. For now, they are separate.  

2.) Whenever we call .addShortcut, an extra parameter is being added for a name. This allows us to provide a name for the shortcut when it shows up in the UI. Currently, this is way we will distinguish between which global shortcuts will be listed as options in the search bar. For example, pressing "esc" is the global shortcut to dismiss a dialog, but we do not want this to appear in the search options under Global Shortcuts. 