### PR TITLE
History cleanup: fix resetIndex to only amend history

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -912,8 +912,11 @@ define(function (require, exports) {
         // If the new layer is already existed (by expanding a libraries graphic that is an embedded SO),
         // we reset the layer to update its smart object type and position.
         if (layer) {
-            return this.transfer(layerActions.resetLayers, document, layer)
+            return this.transfer(historyActions.newHistoryStateRogueSafe, document.id)
                 .bind(this)
+                .then(function () {
+                    return this.transfer(layerActions.resetLayers, document, layer);
+                })
                 .then(function () {
                     return this.transfer(layerActions.resetIndex, document);
                 });
@@ -923,7 +926,8 @@ define(function (require, exports) {
     };
     handlePlaceEvent.reads = [locks.JS_APP];
     handlePlaceEvent.writes = [];
-    handlePlaceEvent.transfers = [updateDocument, "layers.addLayers", "layers.resetLayers", "layers.resetIndex"];
+    handlePlaceEvent.transfers = [updateDocument, "layers.addLayers", "layers.resetLayers", "layers.resetIndex",
+        "history.newHistoryStateRogueSafe"];
     handlePlaceEvent.modal = true;
 
     /**

--- a/src/js/actions/tool/type.js
+++ b/src/js/actions/tool/type.js
@@ -38,8 +38,7 @@ define(function (require, exports) {
      * Layers can be moved using type tool by holding down cmd
      * We need to reset the bounds correctly during this
      */
-    var _moveHandler,
-        _typeChangedHandler,
+    var _typeChangedHandler,
         _layerCreatedHandler,
         _layerDeletedHandler,
         _toolModalStateChangedHandler;
@@ -102,9 +101,6 @@ define(function (require, exports) {
      */
     var select = function () {
         // If this is set, means we didn't get to deselect the tool last time
-        if (_moveHandler) {
-            descriptor.removeListener("move", _moveHandler);
-        }
         if (_typeChangedHandler) {
             descriptor.removeListener("updateTextProperties", _typeChangedHandler);
         }
@@ -117,14 +113,6 @@ define(function (require, exports) {
         if (_toolModalStateChangedHandler) {
             descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
         }
-
-        _moveHandler = function () {
-            var documentStore = this.flux.store("application"),
-                currentDocument = documentStore.getCurrentDocument();
-
-            this.flux.actions.layers.resetBounds(currentDocument, currentDocument.layers.allSelected);
-        }.bind(this);
-        descriptor.addListener("move", _moveHandler);
 
         _typeChangedHandler = this.flux.actions.toolType.updateTextPropertiesHandlerThrottled.bind(this);
         descriptor.addListener("updateTextProperties", _typeChangedHandler);
@@ -209,13 +197,11 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var deselect = function () {
-        descriptor.removeListener("move", _moveHandler);
         descriptor.removeListener("updateTextProperties", _typeChangedHandler);
         descriptor.removeListener("createTextLayer", _layerCreatedHandler);
         descriptor.removeListener("deleteTextLayer", _layerDeletedHandler);
         descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
         
-        _moveHandler = null;
         _typeChangedHandler = null;
         _layerCreatedHandler = null;
         _layerDeletedHandler = null;

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1159,7 +1159,8 @@ define(function (require, exports) {
             .then(function () {
                 nextDoc = appStore.getCurrentDocument();
                 return this.transfer("layers.resetSelection", nextDoc);
-            }).then(function () {
+            })
+            .then(function () {
                 nextDoc = appStore.getCurrentDocument();
                 return this.transfer("layers.resetIndex", nextDoc);
             });
@@ -1183,8 +1184,7 @@ define(function (require, exports) {
         // TODO does this still need to debounce?  Are there cases where we get several events that correspond to
         // one history state?
         _artboardTransformHandler = synchronization.debounce(function () {
-            this.flux.actions.transform.handleTransformArtboard();
-            return Promise.resolve();
+            return this.flux.actions.transform.handleTransformArtboard();
         }, this);
 
         _layerTransformHandler = function (event) {

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -655,7 +655,11 @@ define(function (require, exports, module) {
          */
         _handleUnifiedHistory: function (payload) {
             if (payload.history && payload.history.newState) {
-                this._handlePreHistoryEvent.call(this, payload);
+                if (payload.history.amendRogue) {
+                    this._handlePostHistoryEvent.call(this, payload);
+                } else {
+                    this._handlePreHistoryEvent.call(this, payload);
+                }
             } else {
                 this._handleHistoryAmendment.call(this, payload);
             }

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -39,6 +39,7 @@
         "SET_TYPE_TRACKING": "Set Type Tracking",
         "SET_TYPE_ALIGNMENT": "Set Type Alignment",
         "UNGROUP_LAYERS": "Ungroup layers",
+        "REORDER_LAYERS": "Reorder Layers",
         "MODIFY_EXPORT_ASSETS": "Updated Export Asset Configurations",
         "APPLY_TEXT_STYLE": "Apply Text Style",
         "APPLY_LAYER_STYLE": "Apply Layer Style",


### PR DESCRIPTION
Updates `layers.resetIndex()` to only amend history.  This continues the effort started in a recent PR which did the same for resetLayers and resetBounds.  This required fixing the two instances that relied on resetIndex to *create* history state by explicitly creating a history state early. 

This adds a second flavor of the generic action to create history state called `newHistoryStateRogueSafe` which will amend a previous state IF it as create roguely (via PS initiated event, described as flow number 1 [here](https://github.com/adobe-photoshop/spaces-design/wiki/History-Subsystem)

Two other things...
- Convert "editArtboardEvent" handler to use new flux action
- Remove 'move' handler from type tool because it is redundant to the handler in actions/transform

Testing note: this affects (hopefully with no functional change) the following:

1. placing layers (from lib, etc)
1. reordering layers
1. moving text layers while in type tool (using CMD drag)
1. transforming artboards