### PR TITLE
Run grunt tasks concurrently

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
             html: { src: "src/index-build.html", dest: "build/index.html" },
             img: { expand: true, cwd: "src/img", src: "**", dest: "build/img/" }
         },
-        "requirejs": {
+        requirejs: {
             en: getRequireOptions("en"),
             de: getRequireOptions("de"),
             fr: getRequireOptions("fr"),
@@ -165,6 +165,10 @@ module.exports = function (grunt) {
             light: getLessConfigForStop("light"),
             medium: getLessConfigForStop("medium"),
             dark: getLessConfigForStop("dark")
+        },
+        concurrent: {
+            test: ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
+            requirejs: ["requirejs:en", "requirejs:de", "requirejs:fr", "requirejs:ja"]
         }
     });
 
@@ -179,8 +183,12 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-requirejs");
     grunt.loadNpmTasks("grunt-contrib-less");
 
-    grunt.registerTask("test", ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"]);
-    grunt.registerTask("compile", ["clean", "copy:requirejs", "copy:html", "copy:img", "less", "requirejs"]);
+    grunt.loadNpmTasks("grunt-concurrent");
+
+    grunt.registerTask("seqtest", ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"]);
+    grunt.registerTask("test", ["concurrent:test"]);
+    grunt.registerTask("seqcompile", ["clean", "copy:requirejs", "copy:html", "copy:img", "less", "requirejs"]);
+    grunt.registerTask("compile", ["clean", "copy:requirejs", "copy:html", "copy:img", "less", "concurrent:requirejs"]);
     grunt.registerTask("compile:en", ["clean", "copy:requirejs", "copy:html", "copy:img", "less", "requirejs:en"]);
     grunt.registerTask("build", ["test", "compile"]);
     grunt.registerTask("default", ["test"]);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "grunt": "^0.4.5",
+    "grunt-concurrent": "^2.0.4",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-less": "^1.0.0",
@@ -25,10 +26,10 @@
     "grunt-jsonlint": "^1.0.4",
     "grunt-jsxhint": "^0.6.0",
     "grunt-lintspaces": "^0.7.0",
-    "node-lintspaces": "shaoshing/node-lintspaces",
     "jscs-jsdoc": "shaoshing/jscs-jsdoc#7fbf64b",
     "jscs-trailing-whitespace-in-source": "0.0.1",
     "lodash": "^3.10.1",
+    "node-lintspaces": "shaoshing/node-lintspaces",
     "react-tools": "^0.13.1"
   }
 }


### PR DESCRIPTION
This changes the `test` and `requirejs` grunt tasks to execute their subtasks concurrently. Since the subtasks just spawn grunt child processes, this effectively runs the subtasks in parallel. 

On an i7, this speeds up `grunt test` from ~15s to 9s, and `grunt requirejs` (which is called by `grunt compile` and `grunt build`) from 140s to 45s.

This requires you to run `npm install`.