### PR TITLE
Fix leaf highlighting

### DIFF
--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -371,4 +371,5 @@ define(function (require, exports) {
     exports.restoreAllPolicies = restoreAllPolicies;
 
     exports.beforeStartup = beforeStartup;
+    exports._priority = 1;
 });

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -242,16 +242,11 @@ define(function (require, exports, module) {
          * @param {LayerTree} layerTree layerTree of the current document
          */
         drawBoundRectangles: function (svg, layerTree) {
-            var indexOf = layerTree.indexOf.bind(layerTree),
-                scale = this._scale,
+            var scale = this._scale,
                 renderLayers;
 
             if (this.state.leafBounds) {
-                renderLayers = layerTree.leaves
-                    .filterNot(function (layer) {
-                        return layerTree.hasInvisibleAncestor(layer) || !layer.superSelectable;
-                    })
-                    .sortBy(indexOf);
+                renderLayers = layerTree.selectableLeaves;
 
                 // We add artboards here, so they are shown selectable
                 renderLayers = renderLayers.concat(layerTree.artboards);
@@ -498,7 +493,9 @@ define(function (require, exports, module) {
             uiUtil.hitTestLayers(this.state.document.id, canvasMouse.x, canvasMouse.y)
                 .bind(this)
                 .then(function (hitLayerIDs) {
-                    var selectableLayers = this.state.document.layers.selectable,
+                    var selectableLayers = this.state.leafBounds ?
+                            this.state.document.layers.selectableLeaves :
+                            this.state.document.layers.selectable,
                         selectableLayerIDs = collection.pluck(selectableLayers, "id"),
                         considerIDs = collection.intersection(hitLayerIDs, selectableLayerIDs);
 

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -420,6 +420,19 @@ define(function (require, exports, module) {
         },
 
         /**
+         * The subset of Layer models that are leaves and are selectable
+         *
+         * @return {Immutable.List.<Layer>}
+         */
+        "selectableLeaves": function () {
+            return this.leaves
+                .filterNot(function (layer) {
+                    return this.hasInvisibleAncestor(layer) || !layer.superSelectable;
+                }, this)
+                .sortBy(this.indexOf.bind(this));
+        },
+
+        /**
          * The subset of Layer models that are all selected or are descendants of selected
          *
          * @return {Immutable.List.<Layer>}


### PR DESCRIPTION
Our latest changes to mouse over highlighting did not consider leaf layers... to fix it, I've added layerstructure.selectableLeaves which is used twice in SuperselectOverlay. #3224

Also fixed a related issue, where due to priority being higher, `policy.beforeStartup` would run after `tools.beforeStartup` and overwrite the active tool's mouse mode, which broke highlighting until user switched tools.

