### PR TITLE
Simple layer index validation as a post condition of undo/redo

### DIFF
--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -397,6 +397,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [locks.JS_UI],
         transfers: [history.decrementHistory],
+        post: [layers._verifyLayerIndex],
         modal: true
     };
 
@@ -423,6 +424,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [locks.JS_UI],
         transfers: [history.incrementHistory],
+        post: [layers._verifyLayerIndex],
         modal: true
     };
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2809,6 +2809,7 @@ define(function (require, exports) {
     exports.onReset = onReset;
 
     exports._getLayersForDocument = _getLayersForDocument;
+    exports._verifyLayerIndex = _verifyLayerIndex;
 
     exports.afterStartup = afterStartup;
 });


### PR DESCRIPTION
@iwehrman (or anybody): should we take this opportunity to factor out the _verify* functions into their own file so they can be used across actions?  Or is this "hack" OK for now (exposing the function directly)?