### PR TITLE
Layer Panel performance improvements

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -89,8 +89,8 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps, nextState) {
             var depth = nextProps.depth,
-                isLayerChanged = !!nextProps.changedLayerIDPaths[depth] &&
-                    nextProps.changedLayerIDPaths[depth].has(nextProps.layerID);
+                isLayerChanged = !!nextProps.changedLayerPaths[depth] &&
+                    nextProps.changedLayerPaths[depth].has(nextProps.layerID);
 
             if (isLayerChanged) {
                 return true;
@@ -154,7 +154,10 @@ define(function (require, exports, module) {
             }
         },
         
-        /** @ignore */
+        /**
+         * @private
+         * @return {Document}
+         */
         _getDocument: function () {
             return this.getFlux().stores.document.getDocument(this.props.documentID);
         },
@@ -171,7 +174,12 @@ define(function (require, exports, module) {
             event.stopPropagation();
         },
         
-        /** @ignore */
+        /**
+         * Handle layer face change.
+         * 
+         * @private
+         * @type {Document~LayerFaceListener}
+         */
         _handleLayerFaceChange: function (nextLayer) {
             this.setState({
                 layer: nextLayer
@@ -595,7 +603,7 @@ define(function (require, exports, module) {
             if (hasChildren && (layer.expanded || this._isExpanded)) {
                 this._isExpanded = true;
                 
-                var LayersList = require("jsx!./LayersList");
+                var LayersList = require("./LayersList");
 
                 layerList = (
                     <LayersList
@@ -603,7 +611,7 @@ define(function (require, exports, module) {
                         documentID={this.props.documentID}
                         layerNodes={this.props.layerNodes}
                         depth={this.props.depth + 1}
-                        changedLayerIDPaths={this.props.changedLayerIDPaths}/>
+                        changedLayerPaths={this.props.changedLayerPaths}/>
                 );
             }
             

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -388,11 +388,12 @@ define(function (require, exports, module) {
         _handleBeforeDragStart: function () {
             // Photoshop logic is, if we drag a selected layers, all selected layers are being reordered
             // If we drag an unselected layer, only that layer will be reordered
-            var layer = this.state.layer,
+            var document = this._getDocument(),
+                layer = document.layers.byID(this.props.layerID),
                 draggedLayers = Immutable.List([layer]);
 
             if (layer.selected) {
-                draggedLayers = this._getDocument().layers.selected.filter(function (layer) {
+                draggedLayers = document.layers.selected.filter(function (layer) {
                     // For now, we only check for background layer, but we might prevent locked layers dragging later
                     return !layer.isBackground;
                 }, this);

--- a/src/js/jsx/sections/layers/LayersList.jsx
+++ b/src/js/jsx/sections/layers/LayersList.jsx
@@ -26,10 +26,11 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React);
+        FluxMixin = Fluxxor.FluxMixin(React),
+        _ = require("lodash");
 
-    var DummyLayerFace = require("jsx!./DummyLayerFace"),
-        LayerFace = require("jsx!./LayerFace");
+    var DummyLayerFace = require("./DummyLayerFace"),
+        LayerFace = require("./LayerFace");
 
     var LayersList = React.createClass({
         mixins: [FluxMixin],
@@ -44,7 +45,7 @@ define(function (require, exports, module) {
         
         getInitialState: function () {
             return {
-                changedLayerIDPaths: []
+                changedLayerPaths: []
             };
         },
         
@@ -59,11 +60,20 @@ define(function (require, exports, module) {
                 this.getFlux().stores.document.removeLayerTreeListener(this.props.documentID);
             }
         },
+        
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return !_.isEqual(this.props.changedLayerPaths, nextProps.changedLayerPaths) ||
+                !_.isEqual(this.state.changedLayerPaths, nextState.changedLayerPaths);
+        },
 
-        /** @ignore */
-        _handleLayerTreeChange: function (changedLayerIDPaths) {
+        /**
+         * Re-render layer list if its layer tree changed.
+         * 
+         * @type {Document~LayerTreeListener}
+         */
+        _handleLayerTreeChange: function (changedLayerPaths) {
             this.setState({
-                changedLayerIDPaths: changedLayerIDPaths
+                changedLayerPaths: changedLayerPaths
             });
         },
 
@@ -74,8 +84,8 @@ define(function (require, exports, module) {
                     var layer = document.layers.byID(layerNode.id);
 
                     if (!layer.isGroupEnd) {
-                        var changedLayerIDPaths = this.props.isRoot ?
-                                this.state.changedLayerIDPaths : this.props.changedLayerIDPaths;
+                        var changedLayerPaths = this.props.isRoot ?
+                                this.state.changedLayerPaths : this.props.changedLayerPaths;
 
                         results.push(
                             <LayerFace
@@ -85,7 +95,7 @@ define(function (require, exports, module) {
                                 documentID={this.props.documentID}
                                 layerID={layer.id}
                                 layerNodes={layerNode.children}
-                                changedLayerIDPaths={changedLayerIDPaths}/>
+                                changedLayerPaths={changedLayerPaths}/>
                         );
                     }
                     

--- a/src/js/jsx/sections/layers/LayersList.jsx
+++ b/src/js/jsx/sections/layers/LayersList.jsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React);
+
+    var DummyLayerFace = require("jsx!./DummyLayerFace"),
+        LayerFace = require("jsx!./LayerFace");
+
+    var LayersList = React.createClass({
+        mixins: [FluxMixin],
+
+        getDefaultProps: function () {
+            return {
+                depth: 0,
+                rootLayer: null
+            };
+        },
+
+        render: function () {
+            var layerFaces = this.props.layerNodes.reduce(function (results, layerNode) {
+                var layer = this.props.document.layers.byID(layerNode.id);
+                
+                if (!layer.isGroupEnd) {
+                    results.push(
+                        <LayerFace
+                            key={layer.key}
+                            disabled={this.props.disabled}
+                            document={this.props.document}
+                            depth={this.props.depth}
+                            layer={layer}
+                            childNodes={layerNode.children}
+                            changedLayerIDPaths={this.props.changedLayerIDPaths}/>
+                    );
+                }
+                
+                return results;
+            }.bind(this), []);
+            
+            // This is the top layer list
+            if (!this.props.rootLayer) {
+                var bottomLayer = this.props.document.layers.byIndex(1);
+                
+                if (bottomLayer.isGroupEnd) {
+                    layerFaces.push(
+                        <DummyLayerFace key="dummy" document={this.props.document}/>
+                    );
+                }
+            }
+            
+            return (
+                <ul className="layer-list">
+                    {layerFaces}
+                </ul>
+            );
+        }
+    });
+
+    module.exports = LayersList;
+});

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -83,21 +83,6 @@ define(function (require, exports, module) {
         _setTooltipThrottled: null,
 
         /**
-         * Set of layer IDs that is or was expanded. Used to avoid
-         * rendering child faces until they are first visible.
-         *
-         * @private
-         * @type {Set.<number>}
-         */
-        _expandedLayerIDs: new Set(),
-        
-        /**
-         * Set of layer IDs that are changed in the last document model update. This is updated when LayerPanel 
-         * receives a new "document" prop. See "LayerPanel#_layerDiff" for details.
-         */
-        _changedLayerIDs: new Set(),
-
-        /**
          * The last layer element scrolled to. Used by _scrollToSelection
          * when determining whether to scroll.
          *
@@ -142,19 +127,9 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps) {
-            if (this.props.disabled !== nextProps.disabled ||
-                this.props.active !== nextProps.active) {
-                return true;
-            }
-
-            if (this.props.visible !== nextProps.visible ||
-                this.props.active !== nextProps.active) {
-                return true;
-            }
-            
-            this._changedLayerIDs = this._layerDiff(this.props.document, nextProps.document);
-            
-            return this._changedLayerIDs.size !== 0;
+            return this.props.disabled !== nextProps.disabled ||
+                this.props.visible !== nextProps.visible ||
+                this.props.active !== nextProps.active;
         },
         
         /**
@@ -314,17 +289,12 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var doc = this.props.document,
-                changedLayerIDPaths = this._getLayerPaths(this._changedLayerIDs),
-                childComponents = (
-                    <LayersList
-                        isRoot={true}
-                        disabled={this.props.disabled}
-                        document={doc}
-                        layerNodes={doc.layers.roots}
-                        changedLayerIDPaths={changedLayerIDPaths}
-                        />
-                );
+            var layersListComponent = (
+                <LayersList
+                    isRoot={true}
+                    disabled={this.props.disabled}
+                    documentID={this.props.document.id}/>
+            );
 
             var containerClasses = classnames({
                 "section-container": true,
@@ -353,7 +323,7 @@ define(function (require, exports, module) {
                         className={containerClasses}
                         onClick={this._handleContainerClick}
                         onClickCapture={this._handleContainerClickCapture}>
-                        {childComponents}
+                        {layersListComponent}
                     </div>
                 </section>
             );

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -83,13 +83,13 @@ define(function (require, exports, module) {
         _setTooltipThrottled: null,
 
         /**
-         * The last layer element scrolled to. Used by _scrollToSelection
+         * The list of layers last scrolled to. Used by _scrollToSelection
          * when determining whether to scroll.
          *
          * @private
-         * @type {HTMLElement}
+         * @type {Immutable.List.<Layer>}
          */
-        _lastScrolledTo: null,
+        _lastScrolledTo: Immutable.List(),
 
         /**
          * Used to suppress scrolling into view when the selection is changed
@@ -119,11 +119,11 @@ define(function (require, exports, module) {
         },
 
         componentDidMount: function () {
-            this._scrollToSelection();
+            this._scrollToSelection(this.props.document.layers);
         },
 
         componentDidUpdate: function () {
-            this._scrollToSelection();
+            this._scrollToSelection(this.props.document.layers);
         },
 
         shouldComponentUpdate: function (nextProps) {
@@ -236,38 +236,38 @@ define(function (require, exports, module) {
         /**
          * Scrolls the layers panel to make (newly) selected layers visible.
          */
-         _scrollToSelection: function (layerStructure) {
-             // This is set when a face is clicked on initially. Suppressing the call
-             // to scrollIntoViewIfNeeded below prevents a forced synchronous layout.
-             if (this._suppressNextScrollTo) {
-                 this._suppressNextScrollTo = false;
-                 this._lastScrolledTo = Immutable.List();
-                 return;
-             }
+        _scrollToSelection: function (layerStructure) {
+            // This is set when a face is clicked on initially. Suppressing the call
+            // to scrollIntoViewIfNeeded below prevents a forced synchronous layout.
+            if (this._suppressNextScrollTo) {
+                this._suppressNextScrollTo = false;
+                this._lastScrolledTo = Immutable.List();
+                return;
+            }
 
-             var selected = layerStructure.selected;
-             if (selected.isEmpty()) {
-                 return;
-             }
+            var selected = layerStructure.selected;
+            if (selected.isEmpty()) {
+                return;
+            }
 
-             var previous = this._lastScrolledTo,
-                 next = collection.difference(selected, previous),
-                 visible = next.filterNot(function (layer) {
-                     return layerStructure.hasCollapsedAncestor(layer);
-                 });
+            var previous = this._lastScrolledTo,
+                next = collection.difference(selected, previous),
+                visible = next.filterNot(function (layer) {
+                    return layerStructure.hasCollapsedAncestor(layer);
+                });
 
-             if (visible.isEmpty()) {
-                 return;
-             }
+            if (visible.isEmpty()) {
+                return;
+            }
 
-             var focusLayer = visible.first(),
-                 childNode = ReactDOM.findDOMNode(this.refs[focusLayer.key]);
+            var focusLayer = visible.first(),
+                childNode = ReactDOM.findDOMNode(this.refs[focusLayer.key]);
 
-             if (childNode) {
-                 childNode.scrollIntoViewIfNeeded();
-                 this._lastScrolledTo = next;
-             }
-         },
+            if (childNode) {
+                childNode.scrollIntoViewIfNeeded();
+                this._lastScrolledTo = next;
+            }
+        },
 
         /**
          * Deselects all layers.

--- a/src/js/models/documentindex.js
+++ b/src/js/models/documentindex.js
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
             hasNextActiveDocumentID = typeof nextActiveDocumentID === "number";
 
         if (hasOpenDocuments !== hasNextActiveDocumentID) {
-            throw new Error("There must be a next active document ID if there are open documents");
+            throw new Error("There must be a next active document ID iff there are open documents");
         }
 
         var nextActiveDocumentIndex;

--- a/src/js/models/documentindex.js
+++ b/src/js/models/documentindex.js
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
             hasNextActiveDocumentID = typeof nextActiveDocumentID === "number";
 
         if (hasOpenDocuments !== hasNextActiveDocumentID) {
-            throw new Error("There must be a next active document ID iff there are open documents");
+            throw new Error("There must be a next active document ID if there are open documents");
         }
 
         var nextActiveDocumentIndex;

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -384,6 +384,7 @@ define(function (require, exports, module) {
                 smartObject: this.smartObject
             });
         },
+
         /**
          * This layer is safe to be super-selected
          * @type {boolean}

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -37,14 +37,24 @@ define(function (require, exports, module) {
     var DocumentStore = Fluxxor.createStore({
 
         /**
-         * @type {Object.<number, Document>}
+         * @private
+         * @type {Map.<number, Document>}
          */
         _openDocuments: null,
         
-        // TODO
+        /**
+         * Stores the previous version of the current document for calculating the layer diff.
+         * 
+         * @private
+         * @type {Map.<number, Document>}
+         */
         _oldDocuments: null,
+        
+        /**
+         * @private
+         * @type {Map.<number, LayerDiff>}
+         */
         _layerDiffs: null,
-        _layerListeners: null,
 
         initialize: function () {
             this.bindActions(
@@ -136,11 +146,6 @@ define(function (require, exports, module) {
         getDocument: function (id) {
             return this._openDocuments[id] || null;
         },
-        
-        /** @ignore */
-        getDocumentDiff: function (id) {
-            return this._layerDiffs[id] || null;
-        },
 
         /**
          * Construct a document model from a document and array of layer descriptors.
@@ -208,14 +213,14 @@ define(function (require, exports, module) {
                     var diff = this._layerDiffs[nextDocument.id];
                     if (diff.layerTree.size !== 0) {
                         var layerPaths = _getLayerPaths(diff.layerTree, nextDocument);
+
                         this.emit("layer-tree-change-" + nextDocument.id, layerPaths);
                     }
 
                     diff.layerFace.forEach(function (layerID) {
-                        var eventName = ["layer-face-change", nextDocument.id, layerID].join("-"),
-                            nextLayer = nextDocument.layers.byID(layerID);
+                        var nextLayer = nextDocument.layers.byID(layerID);
 
-                        this.emit(eventName, nextLayer);
+                        this.emit(this._layerFaceEventName(nextDocument.id, layerID), nextLayer);
                     }, this);
                 }
 
@@ -294,7 +299,7 @@ define(function (require, exports, module) {
                 document = this._openDocuments[documentID],
                 nextDocument = document.resize(size.w, size.h);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -320,7 +325,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.addLayers(layerIDs, descriptors, selected, replace, document),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
         },
 
         /**
@@ -340,7 +345,7 @@ define(function (require, exports, module) {
                 nextDocument = document.merge(props),
                 guides = payload.guides;
 
-            this.setDocument(nextDocument, {dirty: true, supressChange: !!guides});
+            this.setDocument(nextDocument, { dirty: true, supressChange: !!guides });
 
             if (guides) {
                 this._handleGuidesUpdated(payload);
@@ -366,7 +371,7 @@ define(function (require, exports, module) {
                 nextDocument = document.set("layers", nextLayers),
                 suppressDirty = payload.suppressDirty;
 
-            this.setDocument(nextDocument, {dirty: !suppressDirty, performLayerDiff: true});
+            this.setDocument(nextDocument, { dirty: !suppressDirty, performLayerDiff: true });
         },
 
         /**
@@ -382,7 +387,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.resetBounds(boundsObjs),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -398,7 +403,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.replaceLayersByIndex(document, descriptors),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true, performLayerDiff: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
         },
 
         /**
@@ -434,7 +439,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setVisibility(layerProps),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true, performLayerDiff: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
         },
 
         /**
@@ -449,7 +454,7 @@ define(function (require, exports, module) {
                 layerIDs = Immutable.List.of(layerID),
                 locked = payload.locked;
 
-            this._updateLayerProperties(documentID, layerIDs, { locked: locked }, {performLayerDiff: true});
+            this._updateLayerProperties(documentID, layerIDs, { locked: locked }, { performLayerDiff: true });
         },
 
         /**
@@ -544,7 +549,7 @@ define(function (require, exports, module) {
                 layerIDs = Immutable.List.of(layerID),
                 name = payload.name;
 
-            this._updateLayerProperties(documentID, layerIDs, { name: name }, {performLayerDiff: true});
+            this._updateLayerProperties(documentID, layerIDs, { name: name }, { performLayerDiff: true });
         },
 
         /**
@@ -573,7 +578,7 @@ define(function (require, exports, module) {
                 updatedLayers = document.layers.deleteLayers(layerIDs),
                 nextDocument = document.set("layers", updatedLayers);
 
-            this.setDocument(nextDocument, {dirty: true, performLayerDiff: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
 
             if (payload.selectedIndices) {
                 this._updateLayerSelectionByIndices(nextDocument, Immutable.Set(payload.selectedIndices));
@@ -600,7 +605,7 @@ define(function (require, exports, module) {
                     isArtboard, bounds),
                 nextDocument = document.set("layers", updatedLayers);
 
-            this.setDocument(nextDocument, {dirty: true, supressChange: suppressChange});
+            this.setDocument(nextDocument, { dirty: true, supressChange: suppressChange, performLayerDiff: true });
         },
 
         /**
@@ -620,7 +625,7 @@ define(function (require, exports, module) {
                 selectedLayers = reorderedLayers.updateSelection(selectedIDs),
                 nextDocument = document.set("layers", selectedLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
         },
 
         /**
@@ -642,7 +647,7 @@ define(function (require, exports, module) {
                 nextLayers = reorderLayers.updateSelection(selectedIDs),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true, performLayerDiff: true});
+            this.setDocument(nextDocument, { dirty: true, performLayerDiff: true });
         },
 
         /**
@@ -657,7 +662,7 @@ define(function (require, exports, module) {
             var nextLayers = document.layers.updateSelection(selectedIDs, pivotID),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {performLayerDiff: true});
+            this.setDocument(nextDocument, { performLayerDiff: true });
         },
 
         /**
@@ -714,7 +719,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.repositionLayers(payload.positions),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -730,7 +735,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.resizeLayers(payload.sizes),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -747,7 +752,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setLayersProportional(layerIDs, proportional),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -764,7 +769,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setBorderRadii(layerIDs, radii),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -789,7 +794,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setFillProperties(layerIDs, fillProperties),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -814,7 +819,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setStrokeProperties(layerIDs, strokeProperties),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -832,7 +837,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.addStroke(layerIDs, strokeStyleDescriptor),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -861,7 +866,7 @@ define(function (require, exports, module) {
                     layerIDs, layerEffectIndex, layerEffectType, layerEffectProperties),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -905,7 +910,7 @@ define(function (require, exports, module) {
                 }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -932,7 +937,7 @@ define(function (require, exports, module) {
             var nextLayers = document.layers.deleteLayerEffectProperties(layerIDs, layerEffectIndex, layerEffectType),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -964,7 +969,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setCharacterStyleProperties(layerIDs, { postScriptName: postScriptName }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -983,7 +988,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setCharacterStyleProperties(layerIDs, { textSize: size }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1020,7 +1025,7 @@ define(function (require, exports, module) {
 
             var nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1039,7 +1044,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setCharacterStyleProperties(layerIDs, { tracking: tracking }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1058,7 +1063,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setCharacterStyleProperties(layerIDs, { leading: leading }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1077,7 +1082,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setParagraphStyleProperties(layerIDs, { alignment: alignment }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1117,7 +1122,7 @@ define(function (require, exports, module) {
                     .setParagraphStyleProperties(layerIDs, paragraphProperties),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1172,7 +1177,7 @@ define(function (require, exports, module) {
 
             var nextDocument = document.setIn(["guides", index], nextGuide);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1188,7 +1193,7 @@ define(function (require, exports, module) {
 
             var nextDocument = document.deleteIn(["guides", index]);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
 
         /**
@@ -1203,7 +1208,7 @@ define(function (require, exports, module) {
 
             var nextDocument = document.set("guides", Immutable.List());
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
         
         /**
@@ -1220,38 +1225,86 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setProperties(layerIDs, { vectorMaskEnabled: vectorMaskEnabled }),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, {dirty: true});
+            this.setDocument(nextDocument, { dirty: true });
         },
+        
+        /**
+         * @callback Document~LayerTreeListener
+         * @param {LayerPath} changedLayerPaths
+         */
 
-        /** @ignore */
+        /**
+         * Listen to layer tree changes including:
+         *
+         * - create layer
+         * - delete layer
+         * - reorder layer
+         * - undo any of changes above
+         *
+         * The event callback will receive the path to the changed layer from the root. For example
+         * 
+         *
+         * @param {number} documentID
+         * @param {Document~LayerTreeListener} callback
+         */
         addLayerTreeListener: function (documentID, callback) {
             this.on("layer-tree-change-" + documentID, callback);
         },
 
-        /** @ignore */
+        /**
+         * Remove layer tree listener.
+         *
+         * @param {number} documentID
+         * @param {Document~LayerTreeListener} callback
+         */
         removeLayerTreeListener: function (documentID, callback) {
             this.removeListener("layer-tree-change-" + documentID, callback);
         },
+        
+        /**
+         * Return layer face event name.
+         *
+         * @private
+         * @param {number} documentID
+         * @param {number} layerID
+         * @return {string}
+         */
+        _layerFaceEventName: function (documentID, layerID) {
+            return ["layer-face-change", documentID, layerID].join("-");
+        },
+        
+        /**
+         * @callback Document~LayerFaceListener
+         * @param {Layer} nextLayer
+         */
 
-        /** @ignore */
+        /**
+         * Listen to layer face (Layer#face) changes.
+         *
+         * @param {number} documentID
+         * @param {number} layerID
+         * @param {Document~LayerFaceListener} callback
+         */
         addLayerFaceListener: function (documentID, layerID, callback) {
-            var eventName = ["layer-face-change", documentID, layerID].join("-");
-
-            this.on(eventName, callback);
+            this.on(this._layerFaceEventName(documentID, layerID), callback);
         },
 
-        /** @ignore */
+        /**
+         * Remove layer face listener.
+         *
+         * @param {number} documentID
+         * @param {number} layerID
+         * @param {Document~LayerFaceListener} callback
+         */
         removeLayerFaceListener: function (documentID, layerID, callback) {
-            var eventName = ["layer-face-change", documentID, layerID].join("-");
-
-            this.removeListener(eventName, callback);
+            this.removeListener(this._layerFaceEventName(documentID, layerID), callback);
         }
     });
     
     
     /**
-     * Get the layer faces that correspond to the current document. Used for
-     * fast, coarse invalidation.
+     * Get the layer attributes that correspond to the given document. Used by "_layerDiff" for calculating 
+     * the diff between the current and next documents.
      *
      * @private
      * @param {Document} document
@@ -1277,15 +1330,18 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Return IDs of the layers that are changed between two document models. Changes include:
-     * - creation
-     * - deletion
-     * - update (e.g. select, expand, reorder, rename)
+     *
+     * Returns IDs of the layers that are changed between two document models. See "LayerDiff" for details.
      *
      * @private
      * @param  {Document} document
      * @param  {Document} nextDocument
-     * @return {Set.<number>}
+     * @return {LayerDiff}
+     *
+     * @typedef {object} LayerDiff
+     * @property {Set.<number>} layerFace - IDs of the layers that have updates in their face (Layer#face) attributes.
+     * @property {Set.<number>} layerTree - IDs of the layers that changed in the layer tree. This usually means the 
+     *                                      layer tree is changed due to layer creation / deletion / reorder.
      */
     var _layerDiff = function (document, nextDocument) {
         var diff = {
@@ -1327,15 +1383,24 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Return the paths of the given layer IDs in the layer tree. 
+     * Return the merged paths of the given layer IDs in the layer tree. 
      * For example:
-     *   given: [10]
-     *   returns: [[1, 6, 8, 10]]
-     *   where 1 is the root, 6 and 8 are the parents
+     *   given layer IDs [10]
+     *   path [1, 6, 10]
+     *   returns [Set.<1>, Set.<6>, Set.<10>]
+     *   - 1 is the root, 6 is the parent
+     *
+     *   given layer IDs [10, 20]
+     *   paths [1, 6, 10], [2, 9, 12, 20]
+     *   returns [Set.<1, 2>, Set.<6, 9>, Set.<10, 12>, Set.<20>]
+     *   - in this case, the result is the merge path of the two paths, which is easier and fast to know whether 
+     *   - a layer is changed via its depth and id.
      *
      * @private
      * @param  {Set.<number>} layerIDs
-     * @return {Array.<Set.<number>>}
+     * @return {LayerPath}
+     *
+     * @typedef {Array.<Set.<number>>} LayerPath
      */
     var _getLayerPaths = function (layerIDs, document) {
         var result = [],
@@ -1361,7 +1426,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Used by "LayerPanel#_getLayerPaths" for searching layer path in the tree.
+     * Used by "_getLayerPaths" for searching layer path in the tree.
      * 
      * @private
      * @param  {Array.<number>} path - the current path to the "node"

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -204,13 +204,17 @@ define(function (require, exports, module) {
          * End the current drag operation.
          */
         stopDrag: function () {
+            if (this._isDropping) {
+                return;
+            }
+            
+            this._isDropping = true;
+            
             var onDropPromise = Promise.resolve();
 
             if (this._dropTarget) {
                 onDropPromise = this._dropTarget.onDrop(this._dragTargets, this._dragPosition);
             }
-            
-            this._isDropping = true;
 
             onDropPromise
                 .bind(this)
@@ -219,7 +223,7 @@ define(function (require, exports, module) {
                     this._dragTargets = Immutable.List();
                     this._dropTarget = null;
                     this._hasValidDropTarget = false;
-                    this._dragPosition = null; // Removing this causes an offset
+                    this._dragPosition = null;
                     this._initialDragPosition = null;
                     this._isDropping = false;
                     this.emit("stop-drag");

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -438,7 +438,7 @@ define(function (require, exports, module) {
                 nextDocument = nextDocument.overlayVisibility(currentDocument);
 
                 // these will emit their own changes
-                this.flux.store("document").setDocument(nextDocument, {performLayerDiff: true});
+                this.flux.store("document").setDocument(nextDocument, { performLayerDiff: true });
                 this.flux.store("export").setDocumentExports(documentID, nextDocumentExports);
                 this.emit("timetravel");
             }

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -438,7 +438,7 @@ define(function (require, exports, module) {
                 nextDocument = nextDocument.overlayVisibility(currentDocument);
 
                 // these will emit their own changes
-                this.flux.store("document").setDocument(nextDocument);
+                this.flux.store("document").setDocument(nextDocument, {performLayerDiff: true});
                 this.flux.store("export").setDocumentExports(documentID, nextDocumentExports);
                 this.emit("timetravel");
             }

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -133,37 +133,53 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     }
 }
 
-.face__not-visible input[type="text"].face__name {
-    color: @item-hover;
-    opacity: @label-hidden-opacity;
+// Layer visibility state
+.face__not-visible, .layer-group__not-visible .layer-list {
+    input[type="text"].face__name {
+        color: @item-hover;
+        opacity: @label-hidden-opacity;
+    }
 }
 
-.face__select_immediate input[type="text"].face__name {
-    color: @item;
+// Layer descendents selection state
+.layer-group__selected {
+    .face, .face:hover {
+        background-color: @list-select-child-color;
+        
+        input[type="text"], input[type="text"]:disabled {
+            border-bottom: solid @hairline transparent;
+        }
+    }
 }
 
-.face__select_immediate:hover input[type="text"].face__name {
-    color: @item;
-}
+// Layer direct selection state
+.face__selected, .layer-group__selected .face__selected {
+    &, &:hover {
+        background-color: @list-select-color;
+    }
 
-.face__select_immediate, .face__select_immediate:hover {
-    background-color: @list-select-color;
-}
-
-.face__select_immediate .face__name, .face__select_immediate:hover .face__name {
-    color: @item;
-}
-
-.face__group_start {
-    margin-bottom: 0;
-}
-
-.face__select_child, .face__select_child:hover,
-.face__select_descendant, .face__select_descendant:hover {
-    background-color: @list-select-child-color;
+    input[type="text"].face__name,
+    &:hover input[type="text"].face__name,
+    .face__name, &:hover .face__name {
+        color: @item;
+    }
     
-    input[type="text"], input[type="text"]:disabled {
+    input[type="text"].face__name {
         border-bottom: solid @hairline transparent;
+    }
+    
+    input[type="text"].face__name:focus,
+    input[type="text"].face__name:focus {
+        border-bottom: solid @hairline @focus-highlight;
+        color: @item;
+        -webkit-user-select: text;
+    }
+}
+
+// Layer Group collapsed state
+.layer-group__collapsed {
+    > .layer-list {
+        display: none;
     }
 }
 
@@ -171,24 +187,9 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     color: @item-active;
 }
 
-.face__select_immediate .face__leash {
-
-}
-
 .face__drop_target, .face__drop_target:hover {
     background-color: none;
     cursor: -webkit-grabbing;
-}
-
-.face__select_immediate input[type="text"].face__name {
-    border-bottom: solid @hairline transparent;
-}
-
-.face__select_immediate input[type="text"].face__name:focus,
-input[type="text"].face__name:focus {
-    border-bottom: solid @hairline @focus-highlight;
-    color: @item;
-    -webkit-user-select: text;
 }
 
 // Drop state
@@ -218,7 +219,7 @@ input[type="text"].face__name:focus {
 }
 
 // Drag state
-.face__drag_target {
+.face__drag-target {
     background-color: none;
     opacity: 0.5;
     position: fixed;
@@ -228,13 +229,8 @@ input[type="text"].face__name:focus {
     pointer-events: none;
 }
 
-// Group collapsed state
-.layer__ancestor_collapsed {
-    display: none;
-}
-
-.layer__group_start.layer__select.layer__group_collapsed {
-    background-color: inherit;
+.layer-group__drag-target {
+    padding-top: 2.8rem;
 }
 
 // Layer name focus/blur state

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -205,6 +205,18 @@ svg use {
     }
 }
 
+.layer-group__invisible {
+    .face:hover .button-toggle,
+    .face .button-toggle {
+        svg {
+            fill: @icon-hover;
+            opacity: @label-hidden-opacity;
+            stroke: none;
+            display: block;
+        }
+    }
+}
+
 .face.face__not-visible:hover .button-toggle,
 .face.face__not-visible .button-toggle {
     svg {
@@ -295,7 +307,7 @@ svg use {
     }
 }
 
-.face__not-visible {
+.layer-group__not-visible .face, .face__not-visible {
     .face__kind, 
     &:hover .face__kind
     &.face[data-kind="group"]:hover .face__kind,


### PR DESCRIPTION
**This PR is based on #3216, so it will show unrelated commits; I will rebase once #3216 is merged. To view the actual changes, please see commit 6e5745a **

Previously we have a flat structure in the layer panel: it has no parent / children hierarchy in the DOM. This structure has two problems: whenever its document model changed, LayerPanel has to 1) check each LayerFace for rendering, and 2) enforces a relatively complicated `shouldComponentUpdate` and `render` implementations in LayerFace. In this PR, I made the change to convert the LayerFace list into a tree structure to avoid massive rendering due to parent layer change, and implemented a light-weight `layerDiff` function (< 25ms) for less SCU calls.

##### better performance for layer selection / expanding / toggling visibility

Before, when a layer is selected / expanded / hidden, all the LayerFace have to be checked and then re-render descendants to reflect the parent layer; this is slow, especially when the changed layer is the root (for example, collapsing an art board). With the introduced tree structure, we can simply update the changed LayerFace (changed layers are the diff of the current and next layer tree) and let the browser update the children via CSS selector (e.g. ```.layer__selected .children {background-color: blue}```). 

###### Layer selection before / after
<img width="400" alt="layer-selection-before" src="https://cloud.githubusercontent.com/assets/118264/11135872/2826403e-895e-11e5-9058-ee98599791be.png">
<img width="400" alt="layer-selection-after" src="https://cloud.githubusercontent.com/assets/118264/11135873/2a805d2e-895e-11e5-9a56-30e643b6257b.png">
(larger time span indicates the number of children updated)

###### Layer expansion before / after
<img width="400" alt="layer-expansion-before" src="https://cloud.githubusercontent.com/assets/118264/11135883/49f3a904-895e-11e5-81de-57fd467b0e7d.png">
(larger time span indicates the number of children updated)

<img width="400" alt="layer-expansion-after" src="https://cloud.githubusercontent.com/assets/118264/11135884/4c43a31c-895e-11e5-8947-63a724b42012.png">

##### Other attempts I tried

* manage the selection / expand / visibility state in each LayerFace component. I successfully implemented the individual selection state, but not seeing a lot of improvement. It might also become complicated when it comes to history / group selection / drag and drop
* improve Position / Size panel performance. I see a total of 60ms spend on these two panels when layer selection changed, but there are not much room for improvement as the update seems necessary.

##### Profiling tools

For people who are interested in performance, this is a snippet (https://gist.github.com/shaoshing/fd37e4bd9cf2ede17cb6) that I used which will mark the `render` and `shouldComponentUpdate` calls in the Timeline (will provide a much better view of what is running during the scripting time) and also log their run times. Might be useful to have some interesting findings.

<img width="751" alt="screen shot 2015-11-12 at 12 33 03 pm" src="https://cloud.githubusercontent.com/assets/118264/11153057/2ec6bf58-89eb-11e5-9893-e559eea4af5e.png">
<img width="778" alt="screen shot 2015-11-12 at 12 34 31 pm" src="https://cloud.githubusercontent.com/assets/118264/11153058/2ec79e5a-89eb-11e5-91ab-2e47dd6a0d35.png">
