### PR TITLE
Consolidate all localization to a util helper

### DIFF
--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -40,7 +40,7 @@ define(function (require, exports) {
         globalUtil = require("js/util/global"),
         objUtil = require("js/util/object"),
         collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         log = require("js/util/log"),
         global = require("js/util/global"),
         ExportAsset = require("js/models/exportasset"),
@@ -115,7 +115,7 @@ define(function (require, exports) {
 
         var playOptions = suppressHistory ? undefined : {
                 historyStateInfo: {
-                    name: strings.ACTIONS.MODIFY_EXPORT_ASSETS,
+                    name: nls.localize("strings.ACTIONS.MODIFY_EXPORT_ASSETS"),
                     target: documentLib.referenceBy.id(documentID)
                 }
             };
@@ -174,7 +174,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var _exportAsset = function (document, layer, assetIndex, asset, baseDir, prefix) {
-        var baseName = layer ? layer.name : document.nameWithoutExtension || strings.EXPORT.EXPORT_DOCUMENT_FILENAME,
+        var baseName = (layer ? layer.name : document.nameWithoutExtension) ||
+                nls.localize("strings.EXPORT.EXPORT_DOCUMENT_FILENAME"),
             fileName = baseName + asset.suffix,
             _layers = layer ? Immutable.List.of(layer) : null;
 
@@ -258,7 +259,7 @@ define(function (require, exports) {
             assetIndex: assetIndex,
             history: {
                 newState: true,
-                name: strings.ACTIONS.MODIFY_EXPORT_ASSETS
+                name: nls.localize("strings.ACTIONS.MODIFY_EXPORT_ASSETS")
             }
         };
 
@@ -387,7 +388,7 @@ define(function (require, exports) {
             assetPropsArray: shiftedPropsArray,
             history: {
                 newState: true,
-                name: strings.ACTIONS.MODIFY_EXPORT_ASSETS
+                name: nls.localize("strings.ACTIONS.MODIFY_EXPORT_ASSETS")
             }
         };
 
@@ -597,7 +598,7 @@ define(function (require, exports) {
                 assetIndex: assetIndex,
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.MODIFY_EXPORT_ASSETS
+                    name: nls.localize("strings.ACTIONS.MODIFY_EXPORT_ASSETS")
                 }
             };
 

--- a/src/js/actions/layereffects.js
+++ b/src/js/actions/layereffects.js
@@ -35,7 +35,7 @@ define(function (require, exports) {
         events = require("../events"),
         locks = require("js/locks"),
         layerActionsUtil = require("js/util/layeractions"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     /**
@@ -60,7 +60,7 @@ define(function (require, exports) {
                     quality: "draft"
                 },
                 historyStateInfo: {
-                    name: strings.ACTIONS.SET_LAYER_EFFECTS,
+                    name: nls.localize("strings.ACTIONS.SET_LAYER_EFFECTS"),
                     target: documentLib.referenceBy.id(document.id),
                     coalesce: !!coalesce,
                     suppressHistoryStateNotification: !!coalesce
@@ -155,7 +155,7 @@ define(function (require, exports) {
             coalesce: !!coalesce,
             history: {
                 newState: true,
-                name: strings.ACTIONS.SET_LAYER_EFFECTS
+                name: nls.localize("strings.ACTIONS.SET_LAYER_EFFECTS")
             }
         };
 
@@ -216,7 +216,7 @@ define(function (require, exports) {
             layerEffectIndex: effectIndex,
             history: {
                 newState: true,
-                name: strings.ACTIONS.SET_LAYER_EFFECTS
+                name: nls.localize("strings.ACTIONS.SET_LAYER_EFFECTS")
             }
         };
         // Synchronously update the stores
@@ -545,7 +545,7 @@ define(function (require, exports) {
             coalesce: false,
             history: {
                 newState: true,
-                name: strings.ACTIONS.SET_LAYER_EFFECTS
+                name: nls.localize("strings.ACTIONS.SET_LAYER_EFFECTS")
             }
         };
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -52,7 +52,7 @@ define(function (require, exports) {
         locks = require("js/locks"),
         locking = require("js/util/locking"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         global = require("js/util/global"),
         Bounds = require("js/models/bounds");
 
@@ -1220,7 +1220,7 @@ define(function (require, exports) {
             deletePlayObject = layerLib.delete(layerLib.referenceBy.current),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.DELETE_LAYERS,
+                    name: nls.localize("strings.ACTIONS.DELETE_LAYERS"),
                     target: documentLib.referenceBy.id(documentID)
                 }
             };
@@ -1283,7 +1283,7 @@ define(function (require, exports) {
                     groupname: groupResult.name,
                     history: {
                         newState: true,
-                        name: strings.ACTIONS.GROUP_LAYERS
+                        name: nls.localize("strings.ACTIONS.GROUP_LAYERS")
                     }
                 };
 
@@ -1409,7 +1409,7 @@ define(function (require, exports) {
                 .concat(playObjRec.deleteObjects),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.UNGROUP_LAYERS,
+                    name: nls.localize("strings.ACTIONS.UNGROUP_LAYERS"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             };
@@ -1617,7 +1617,7 @@ define(function (require, exports) {
                 coalesce: !!options.coalesce,
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.CHANGE_LAYER_OPACITY
+                    name: nls.localize("strings.ACTIONS.CHANGE_LAYER_OPACITY")
                 }
             },
             playObjects = layers.map(function (layer) {
@@ -1631,7 +1631,7 @@ define(function (require, exports) {
         
         var playOptions = _.merge(options, {
             historyStateInfo: {
-                name: strings.ACTIONS.CHANGE_LAYER_OPACITY,
+                name: nls.localize("strings.ACTIONS.CHANGE_LAYER_OPACITY"),
                 target: documentLib.referenceBy.id(document.id),
                 coalesce: !!options.coalesce,
                 suppressHistoryStateNotification: !!options.coalesce
@@ -1774,9 +1774,10 @@ define(function (require, exports) {
 
         var numberRef = (typeof target === "number"),
             targetRef = numberRef ? layerLib.referenceBy.index(target) : layerLib.referenceBy[target],
-            reorderObj = layerLib.reorder(layerRef, targetRef);
+            reorderObj = layerLib.reorder(layerRef, targetRef),
+            historyStateName = nls.localize("strings.ACTIONS.REORDER_LAYERS");
       
-        return this.transfer(historyActions.newHistoryState, document.id, strings.ACTIONS.REORDER_LAYERS)
+        return this.transfer(historyActions.newHistoryState, document.id, historyStateName)
             .bind(this)
             .then(function () {
                 return descriptor.playObject(reorderObj);
@@ -1946,7 +1947,7 @@ define(function (require, exports) {
         
         options = _.merge({}, options, {
             historyStateInfo: {
-                name: strings.ACTIONS.SET_BLEND_MODE,
+                name: nls.localize("strings.ACTIONS.SET_BLEND_MODE"),
                 target: documentLib.referenceBy.id(document.id)
             }
         });
@@ -1966,7 +1967,7 @@ define(function (require, exports) {
             mode: mode,
             history: {
                 newState: true,
-                name: strings.ACTIONS.SET_BLEND_MODE
+                name: nls.localize("strings.ACTIONS.SET_BLEND_MODE")
             }
         };
 
@@ -2002,7 +2003,7 @@ define(function (require, exports) {
                 proportional: proportional,
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.SET_PROPORTIONAL_SCALE
+                    name: nls.localize("strings.ACTIONS.SET_PROPORTIONAL_SCALE")
                 }
             },
             options = {
@@ -2011,7 +2012,7 @@ define(function (require, exports) {
                     quality: "draft"
                 },
                 historyStateInfo: {
-                    name: strings.ACTIONS.SET_PROPORTIONAL_SCALE,
+                    name: nls.localize("strings.ACTIONS.SET_PROPORTIONAL_SCALE"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             };
@@ -2306,7 +2307,7 @@ define(function (require, exports) {
 
         var duplicateOptions = {
             historyStateInfo: {
-                name: strings.ACTIONS.DUPLICATE_LAYERS,
+                name: nls.localize("strings.ACTIONS.DUPLICATE_LAYERS"),
                 target: documentLib.referenceBy.id(document.id)
             }
         };
@@ -2479,7 +2480,7 @@ define(function (require, exports) {
         if (currentLayer.vectorMaskEnabled) {
             var deleteMaskOptions = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.DELETE_VECTOR_MASK,
+                    name: nls.localize("strings.ACTIONS.DELETE_VECTOR_MASK"),
                     target: documentLib.referenceBy.id(currentDocument.id)
                 }
             };
@@ -2492,7 +2493,7 @@ define(function (require, exports) {
                             vectorMaskEnabled: false,
                             history: {
                                 newState: true,
-                                name: strings.ACTIONS.DELETE_VECTOR_MASK
+                                name: nls.localize("strings.ACTIONS.DELETE_VECTOR_MASK")
                             }
                         },
                         event = events.document.history.REMOVE_VECTOR_MASK_FROM_LAYER;

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -40,7 +40,7 @@ define(function (require, exports) {
 
     var events = require("js/events"),
         locks = require("js/locks"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         pathUtil = require("js/util/path"),
         log = require("js/util/log"),
         layerActionsUtil = require("js/util/layeractions"),
@@ -935,7 +935,7 @@ define(function (require, exports) {
             .bind(this)
             .then(function () {
                 return this.transfer(historyActions.newHistoryState, currentDocument.id,
-                    strings.ACTIONS.APPLY_LAYER_STYLE);
+                    nls.localize("strings.ACTIONS.APPLY_LAYER_STYLE"));
             })
             .then(function (path) {
                 var layerIDs = collection.pluck(selectedUnlockedLayers, "id"),
@@ -943,7 +943,7 @@ define(function (require, exports) {
                     placeObj = layerEffectAdapter.applyLayerStyleFile(layerRef, path),
                     options = {
                         historyStateInfo: {
-                            name: strings.ACTIONS.APPLY_LAYER_STYLE,
+                            name: nls.localize("strings.ACTIONS.APPLY_LAYER_STYLE"),
                             target: documentLib.referenceBy.id(currentDocument.id)
                         }
                     };
@@ -993,7 +993,7 @@ define(function (require, exports) {
             applyObj = textLayerAdapter.applyTextStyle(layerRef, styleData),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.APPLY_TEXT_STYLE,
+                    name: nls.localize("strings.ACTIONS.APPLY_TEXT_STYLE"),
                     target: documentLib.referenceBy.id(currentDocument.id)
                 }
             };
@@ -1001,7 +1001,7 @@ define(function (require, exports) {
         var playPromise = layerActionsUtil.playSimpleLayerActions(currentDocument, textLayers, applyObj,
                 false, options),
             historyPromise = this.transfer(historyActions.newHistoryState, currentDocument.id,
-                strings.ACTIONS.APPLY_TEXT_STYLE);
+                nls.localize("strings.ACTIONS.APPLY_TEXT_STYLE"));
 
         return Promise.join(playPromise, historyPromise)
             .bind(this)
@@ -1036,7 +1036,7 @@ define(function (require, exports) {
             vectorLayers = selectedLayers.filter(function (l) { return l.isVector(); }),
             transactionOpts = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.APPLY_LIBRARY_COLOR,
+                    name: nls.localize("strings.ACTIONS.APPLY_LIBRARY_COLOR"),
                     target: docAdapter.referenceBy.id(currentDocument.id)
                 }
             };

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -46,7 +46,7 @@ define(function (require, exports) {
         transformActions = require("./transform"),
         layerActionsUtil = require("js/util/layeractions"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     /**
      * Gets the color of the source layer, or color at the pixel
@@ -220,7 +220,7 @@ define(function (require, exports) {
             textLayers = Immutable.List(),
             transactionOpts = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.SAMPLE_COLOR,
+                    name: nls.localize("strings.ACTIONS.SAMPLE_COLOR"),
                     target: documentLib.referenceBy.id(doc.id)
                 }
             };
@@ -276,7 +276,7 @@ define(function (require, exports) {
             textLayers = Immutable.List(),
             transactionOpts = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.SAMPLE_STROKE,
+                    name: nls.localize("strings.ACTIONS.SAMPLE_STROKE"),
                     target: documentLib.referenceBy.id(doc.id)
                 }
             };
@@ -579,7 +579,7 @@ define(function (require, exports) {
             nonTextLayers = Immutable.List(),
             transactionOpts = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.PASTE_LAYER_STYLE,
+                    name: nls.localize("strings.ACTIONS.PASTE_LAYER_STYLE"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             };
@@ -831,7 +831,7 @@ define(function (require, exports) {
             .bind(this)
             .tap(function () {
                 return this.transfer(historyActions.newHistoryState, document.id,
-                    strings.ACTIONS.SAMPLE_GRAPHICS);
+                    nls.localize("strings.ACTIONS.SAMPLE_GRAPHICS"));
             })
             .then(function (path) {
                 var documentRef = documentLib.referenceBy.id(document.id),
@@ -841,7 +841,7 @@ define(function (require, exports) {
                             quality: "draft"
                         },
                         historyStateInfo: {
-                            name: strings.ACTIONS.SAMPLE_GRAPHICS,
+                            name: nls.localize("strings.ACTIONS.SAMPLE_GRAPHICS"),
                             target: documentRef,
                             coalesce: false,
                             suppressHistoryStateNotification: false

--- a/src/js/actions/search/commands.js
+++ b/src/js/actions/search/commands.js
@@ -28,8 +28,7 @@ define(function (require, exports) {
         Immutable = require("immutable"),
         keyUtil = require("js/util/key"),
         system = require("js/util/system"),
-        strings = require("i18n!nls/strings"),
-        menuLabels = require("i18n!nls/menu");
+        nls = require("js/util/nls");
 
     var events = require("js/events");
 
@@ -38,6 +37,7 @@ define(function (require, exports) {
 
     /**
      * Get a localized label for the full path of the given menu entry ID
+     * inserting > character between parent names
      *
      * @private
      * @param {string} id
@@ -45,24 +45,27 @@ define(function (require, exports) {
      */
     var _getLabelForEntry = function (id) {
         var parts = id.split("."),
-            path = "",
-            currMenuLabels = menuLabels;
+            resultPath = "",
+            nlsPath = "menus",
+            menuTree;
 
         parts.forEach(function (part) {
-            if (currMenuLabels[part] === undefined) {
-                path = null;
+            nlsPath = nlsPath + "." + part;
+            menuTree = nls.localize(nlsPath);
+
+            if (menuTree === undefined) {
+                resultPath = null;
                 return false;
             }
 
-            if (currMenuLabels[part].$MENU) {
-                path += currMenuLabels[part].$MENU + ">";
-                currMenuLabels = currMenuLabels[part];
+            if (menuTree.$MENU) {
+                resultPath += menuTree.$MENU + ">";
             } else {
-                path += currMenuLabels[part];
+                resultPath += menuTree.part;
             }
         });
 
-        return path;
+        return resultPath;
     };
     
     /**
@@ -76,8 +79,7 @@ define(function (require, exports) {
         var modifierBits = fullShortcut.modifiers,
             keyChar = fullShortcut.keyChar,
             keyCode = fullShortcut.keyCode,
-            modifierStrings = strings.SEARCH.MODIFIERS,
-            keyCodeStrings = strings.KEYCODE,
+            modifierStrings = nls.localize("strings.SEARCH.MODIFIERS"),
             shortcut = "";
 
         var modifierChars = {
@@ -102,7 +104,7 @@ define(function (require, exports) {
         }
 
         if (keyCode) {
-            shortcut += keyCodeStrings[keyCode];
+            shortcut += nls.localize("strings.KEYCODE." + keyCode);
         }
 
         return " " + shortcut + "\u00a0\u00a0\u00a0\u00a0";
@@ -175,7 +177,7 @@ define(function (require, exports) {
     var _getGlobalShortcutString = function (fullShortcut) {
         var modifierBits = fullShortcut.modifiers,
             key = fullShortcut.key,
-            modifierStrings = strings.SEARCH.MODIFIERS,
+            modifierStrings = nls.localize("strings.SEARCH.MODIFIERS"),
             shortcut = "";
 
         if (modifierBits.command) {

--- a/src/js/actions/search/commands.js
+++ b/src/js/actions/search/commands.js
@@ -46,7 +46,7 @@ define(function (require, exports) {
     var _getLabelForEntry = function (id) {
         var parts = id.split("."),
             resultPath = "",
-            nlsPath = "menus",
+            nlsPath = "menu",
             menuTree;
 
         parts.forEach(function (part) {

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -28,7 +28,7 @@ define(function (require, exports) {
 
     var events = require("js/events"),
         collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         libraryActions = require("js/actions/libraries"),
         librariesUtil = require("js/util/libraries");
 
@@ -98,7 +98,7 @@ define(function (require, exports) {
                     libMap = libMap.push({
                         id: id,
                         name: title,
-                        pathInfo: library.name + ": " + strings.SEARCH.CATEGORIES[categoryKey],
+                        pathInfo: library.name + ": " + nls.localize("strings.SEARCH.CATEGORIES." + categoryKey),
                         iconID: _getSVGClass([categoryKey]),
                         category: ["LIBRARY", library.id.replace(/-/g, "."), categoryKey]
                     });

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -39,7 +39,7 @@ define(function (require, exports) {
         layerActions = require("./layers"),
         collection = require("js/util/collection"),
         layerActionsUtil = require("js/util/layeractions"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     /**
      * Merges shape specific options into given options
@@ -197,7 +197,7 @@ define(function (require, exports) {
             strokeObj = contentLayerLib.setStroke(layerRef, stroke),
             strokeJSObj = stroke.toJS();
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_STROKE"));
 
         // toJS gets rid of color so we re-insert it here
         strokeJSObj.color = stroke.color.normalizeAlpha();
@@ -257,7 +257,7 @@ define(function (require, exports) {
             enabledChanging = true;
         }
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE_COLOR);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_STROKE_COLOR"));
 
         var colorPromise,
             psColor,
@@ -365,7 +365,7 @@ define(function (require, exports) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeAlignment(layerRef, alignmentType);
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE_ALIGNMENT);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_STROKE_ALIGNMENT"));
 
         if (_allStrokesExist(layers)) {
             // optimistically dispatch the change event    
@@ -410,7 +410,7 @@ define(function (require, exports) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setStrokeOpacity(layerRef, opacity);
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE_OPACITY);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_STROKE_OPACITY"));
 
         if (_allStrokesExist(layers)) {
             // optimistically dispatch the change event    
@@ -453,7 +453,7 @@ define(function (require, exports) {
         var layerRef = contentLayerLib.referenceBy.current,
             strokeObj = contentLayerLib.setShapeStrokeWidth(layerRef, width);
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_STROKE_WIDTH);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_STROKE_WIDTH"));
 
         if (_allStrokesExist(layers)) {
             // dispatch the change event    
@@ -536,7 +536,7 @@ define(function (require, exports) {
                 options.coalesce),
             colorPromise;
 
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_FILL_COLOR);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_FILL_COLOR"));
 
         if (!color && options.enabled) {
             // If color is not supplied, we want each layer to use it's own color
@@ -587,7 +587,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setFillOpacity = function (document, layers, opacity, options) {
-        options = _mergeOptions(options, document, strings.ACTIONS.SET_FILL_OPACITY);
+        options = _mergeOptions(options, document, nls.localize("strings.ACTIONS.SET_FILL_OPACITY"));
             
         var dispatchPromise = _fillChangeDispatch.call(this,
                 document,
@@ -630,7 +630,7 @@ define(function (require, exports) {
                 documentID: document.id,
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.COMBINE_SHAPES
+                    name: nls.localize("strings.ACTIONS.COMBINE_SHAPES")
                 }
             };
 
@@ -643,7 +643,7 @@ define(function (require, exports) {
 
         var options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.COMBINE_SHAPES,
+                    name: nls.localize("strings.ACTIONS.COMBINE_SHAPES"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             },

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -46,7 +46,7 @@ define(function (require, exports) {
         policy = require("./policy"),
         ui = require("./ui"),
         shortcuts = require("./shortcuts"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         layerActionsUtil = require("js/util/layeractions"),
         system = require("js/util/system"),
         headlights = require("js/util/headlights"),
@@ -634,7 +634,7 @@ define(function (require, exports) {
             policyPromise,
             createMaskOptions = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.ADD_VECTOR_MASK,
+                    name: nls.localize("strings.ACTIONS.ADD_VECTOR_MASK"),
                     target: documentLib.referenceBy.id(currentDocument.id)
                 }
             };
@@ -653,7 +653,7 @@ define(function (require, exports) {
                     vectorMaskEnabled: true,
                     history: {
                         newState: true,
-                        name: strings.ACTIONS.ADD_VECTOR_MASK
+                        name: nls.localize("strings.ACTIONS.ADD_VECTOR_MASK")
                     }
                 },
                 dispatchAdd = this.dispatchAsync(events.document.history.ADD_VECTOR_MASK_TO_LAYER, payload),
@@ -703,7 +703,7 @@ define(function (require, exports) {
                     if (currentLayer.vectorMaskEnabled && currentLayer.vectorMaskEmpty) {
                         var deleteMaskOptions = {
                             historyStateInfo: {
-                                name: strings.ACTIONS.DELETE_VECTOR_MASK,
+                                name: nls.localize("strings.ACTIONS.DELETE_VECTOR_MASK"),
                                 target: documentLib.referenceBy.id(currentDocument.id)
                             }
                         },
@@ -720,7 +720,7 @@ define(function (require, exports) {
                                         vectorMaskEnabled: false,
                                         history: {
                                             newState: true,
-                                            name: strings.ACTIONS.DELETE_VECTOR_MASK
+                                            name: nls.localize("strings.ACTIONS.DELETE_VECTOR_MASK")
                                         }
                                     },
                                     event = events.document.history.REMOVE_VECTOR_MASK_FROM_LAYER;

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -45,7 +45,7 @@ define(function (require, exports) {
         locking = require("js/util/locking"),
         layerActionsUtil = require("js/util/layeractions"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization");
 
     /**
@@ -417,12 +417,12 @@ define(function (require, exports) {
                 positions: [],
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.SET_LAYER_POSITION
+                    name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION")
                 }
             },
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.SET_LAYER_POSITION,
+                    name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             };
@@ -472,7 +472,7 @@ define(function (require, exports) {
                 positions: [],
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.SWAP_LAYERS
+                    name: nls.localize("strings.ACTIONS.SWAP_LAYERS")
                 }
             },
             layerOneActions = _getMoveLayerActions
@@ -486,7 +486,7 @@ define(function (require, exports) {
         // Make sure to show this action as one history state
         var options = {
             historyStateInfo: {
-                name: strings.ACTIONS.SWAP_LAYERS,
+                name: nls.localize("strings.ACTIONS.SWAP_LAYERS"),
                 target: documentRef
             }
         };
@@ -566,13 +566,13 @@ define(function (require, exports) {
                 sizes: [],
                 history: {
                     newState: true,
-                    name: strings.ACTIONS.SET_LAYER_SIZE
+                    name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE")
                 }
             },
             options = {
                 paintOptions: _paintOptions,
                 historyStateInfo: {
-                    name: strings.ACTIONS.SET_LAYER_SIZE,
+                    name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             };
@@ -682,12 +682,12 @@ define(function (require, exports) {
             flipAction = layerLib.flip(ref, axis),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.FLIP_LAYERS,
+                    name: nls.localize("strings.ACTIONS.FLIP_LAYERS"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             },
             historyPromise = this.transfer(historyActions.newHistoryState, document.id,
-                strings.ACTIONS.FLIP_LAYERS),
+                nls.localize("strings.ACTIONS.FLIP_LAYERS")),
             playPromise = locking.playWithLockOverride(document, layers, flipAction, options);
 
         return Promise.join(historyPromise, playPromise)
@@ -805,12 +805,12 @@ define(function (require, exports) {
             alignAction = layerLib.align(ref, align),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.ALIGN_LAYERS,
+                    name: nls.localize("strings.ACTIONS.ALIGN_LAYERS"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             },
             historyPromise = this.transfer(historyActions.newHistoryState, document.id,
-                strings.ACTIONS.ALIGN_LAYERS),
+                nls.localize("strings.ACTIONS.ALIGN_LAYERS")),
             playPromise = locking.playWithLockOverride(document, layers, alignAction, options);
 
         return Promise.join(historyPromise, playPromise)
@@ -979,12 +979,12 @@ define(function (require, exports) {
             distributeAction = layerLib.distribute(ref, align),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.DISTRIBUTE_LAYERS,
+                    name: nls.localize("strings.ACTIONS.DISTRIBUTE_LAYERS"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             },
             historyPromise = this.transfer(historyActions.newHistoryState, document.id,
-                strings.ACTIONS.DISTRIBUTE_LAYERS),
+                nls.localize("strings.ACTIONS.DISTRIBUTE_LAYERS")),
             playPromise = locking.playWithLockOverride(document, layers, distributeAction, options);
         
         return Promise.join(historyPromise, playPromise)
@@ -1071,14 +1071,14 @@ define(function (require, exports) {
             },
             history: {
                 newState: true,
-                name: strings.ACTIONS.SET_RADIUS
+                name: nls.localize("strings.ACTIONS.SET_RADIUS")
             }
         });
         
         options = _.merge(options, {
             paintOptions: _paintOptions,
             historyStateInfo: {
-                name: strings.ACTIONS.SET_RADIUS,
+                name: nls.localize("strings.ACTIONS.SET_RADIUS"),
                 target: documentLib.referenceBy.id(document.id),
                 coalesce: !!options.coalesce,
                 suppressHistoryStateNotification: !!options.coalesce
@@ -1141,12 +1141,12 @@ define(function (require, exports) {
             rotateObj = layerLib.rotate(layerRef, angle),
             options = {
                 historyStateInfo: {
-                    name: strings.ACTIONS.ROTATE_LAYERS,
+                    name: nls.localize("strings.ACTIONS.ROTATE_LAYERS"),
                     target: documentLib.referenceBy.id(document.id)
                 }
             },
             historyPromise = this.transfer(historyActions.newHistoryState, document.id,
-                strings.ACTIONS.ROTATE_LAYERS),
+                nls.localize("strings.ACTIONS.ROTATE_LAYERS")),
             playPromise = locking.playWithLockOverride(document, layers, rotateObj, options);
 
         return Promise.join(historyPromise, playPromise)

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -40,7 +40,7 @@ define(function (require, exports) {
         collection = require("js/util/collection"),
         locking = require("js/util/locking"),
         math = require("js/util/math"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         layerActionsUtil = require("js/util/layeractions"),
         synchronization = require("js/util/synchronization");
 
@@ -152,7 +152,7 @@ define(function (require, exports) {
             modal = this.flux.store("tool").getModalToolState();
 
         var setFacePlayObject = textLayerLib.setPostScript(layerRefs, postscript),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_FACE"), modal),
             setFacePromise = locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions),
             updatePromise = this.transfer(updatePostScript, document, layers, postscript, family, style);
 
@@ -223,7 +223,7 @@ define(function (require, exports) {
             modal = this.flux.store("tool").getModalToolState();
 
         var setFacePlayObject = textLayerLib.setFace(layerRefs, family, style),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_FACE, modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_FACE"), modal),
             setFacePromise = locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions),
             updatePromise = this.transfer(updateFace, document, layers, family, style);
 
@@ -302,7 +302,7 @@ define(function (require, exports) {
             opaqueColor = normalizedColor.opaque(),
             playObject = textLayerLib.setColor(layerRefs, opaqueColor),
             modal = this.flux.store("tool").getModalToolState(),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_COLOR,
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_COLOR"),
                 modal, options.coalesce, options);
 
         if (!options.ignoreAlpha) {
@@ -386,7 +386,7 @@ define(function (require, exports) {
         size = math.clamp(size, PS_MIN_FONT_SIZE, PS_MAX_FONT_SIZE);
 
         var setSizePlayObject = textLayerLib.setSize(layerRefs, size, "px"),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_SIZE, modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_SIZE"), modal),
             setSizePromise = locking.playWithLockOverride(document, layers, setSizePlayObject, typeOptions),
             updatePromise = this.transfer(updateSize, document, layers, size);
 
@@ -454,7 +454,7 @@ define(function (require, exports) {
             psTracking = tracking / 1000; // PS expects tracking values that are 1/1000 what is shown in the UI
 
         var setTrackingPlayObject = textLayerLib.setTracking(layerRefs, psTracking),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_TRACKING, modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_TRACKING"), modal),
             setTrackingPromise = locking.playWithLockOverride(document, layers, setTrackingPlayObject, typeOptions),
             updatePromise = this.transfer(updateTracking, document, layers, tracking);
 
@@ -526,7 +526,7 @@ define(function (require, exports) {
         }
 
         var setLeadingPlayObject = textLayerLib.setLeading(layerRefs, autoLeading, leading, "px"),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_LEADING, modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_LEADING"), modal),
             setLeadingPromise = locking.playWithLockOverride(document, layers, setLeadingPlayObject, typeOptions),
             updatePromise = this.transfer(updateLeading, document, layers, leading);
 
@@ -592,7 +592,7 @@ define(function (require, exports) {
             modal = this.flux.store("tool").getModalToolState();
 
         var setAlignmentPlayObject = textLayerLib.setAlignment(layerRefs, alignment),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.SET_TYPE_ALIGNMENT,
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_ALIGNMENT"),
                 modal, false, options),
             setAlignmentPromise = locking.playWithLockOverride(document, layers, setAlignmentPlayObject, typeOptions),
             transferPromise = this.transfer(updateAlignment, document, layers, alignment);
@@ -672,7 +672,7 @@ define(function (require, exports) {
             textLayerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
             applyObjects = [],
             modal = this.flux.store("tool").getModalToolState(),
-            typeOptions = _getTypeOptions(document.id, strings.ACTIONS.APPLY_TEXT_STYLE,
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.APPLY_TEXT_STYLE"),
                 modal, actionOptions.coalesce, actionOptions);
 
         applyObjects.push(textLayerLib.applyTextStyle(textLayerRefs, style));
@@ -697,7 +697,7 @@ define(function (require, exports) {
         var playPromise = layerActionsUtil.playSimpleLayerActions(document, targetLayers,
                 applyObjects, true, typeOptions),
             historyPromise = this.transfer(historyActions.newHistoryState, document.id,
-                strings.ACTIONS.APPLY_TEXT_STYLE);
+                nls.localize("strings.ACTIONS.APPLY_TEXT_STYLE"));
 
         return Promise.join(playPromise, historyPromise)
             .bind(this)

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
     var DocumentHeaderTab = require("jsx!js/jsx/DocumentHeaderTab"),
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization"),
         searchStore = require("js/stores/search"),
         headlights = require("js/util/headlights"),
@@ -307,7 +307,7 @@ define(function (require, exports, module) {
                         <div className="icon-header-buttons">
                             <Button
                                 className="button-plus search-button"
-                                title={strings.TOOLTIPS.SEARCH}
+                                title={nls.localize("strings.TOOLTIPS.SEARCH")}
                                 onClick={this._toggleSearch}
                                 active={this.state.searchActive}>
                                 <SVGIcon
@@ -315,7 +315,7 @@ define(function (require, exports, module) {
                             </Button>
                             <Button
                                 className="button-plus"
-                                title={strings.TOOLTIPS.VECTOR_MASK_MODE}
+                                title={nls.localize("strings.TOOLTIPS.VECTOR_MASK_MODE")}
                                 onClick={this._changeMaskMode}
                                 disabled={maskDisabled}
                                 active={this.state.maskModeActive}>
@@ -324,7 +324,7 @@ define(function (require, exports, module) {
                             </Button>
                             <Button
                                 className="button-plus export-button"
-                                title={strings.TOOLTIPS.EXPORT_DIALOG}
+                                title={nls.localize("strings.TOOLTIPS.EXPORT_DIALOG")}
                                 disabled={exportDisabled}
                                 active={this.state.exportActive}
                                 onClick={this._openExportPanel}>

--- a/src/js/jsx/DocumentHeaderTab.jsx
+++ b/src/js/jsx/DocumentHeaderTab.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
         classnames = require("classnames");
         
-    var strings = require("i18n!nls/strings");
+    var nls = require("js/util/nls");
 
     var DocumentHeaderTab = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("tool")],
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
             if (this.props.unsupported) {
                 warning = (
                     <span
-                        title={strings.TOOLTIPS.UNSUPPORTED_FEATURES}
+                        title={nls.localize("strings.TOOLTIPS.UNSUPPORTED_FEATURES")}
                         className="document-controls__unsupported">
                         !
                     </span>

--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                 <div className={panelTabBarClassNames}>
                     <Button
                         className="toolbar__backToPs"
-                        title={nls.localize("menus.WINDOW.RETURN_TO_STANDARD")}
+                        title={nls.localize("menu.WINDOW.RETURN_TO_STANDARD")}
                         onClick={this._handleBackToPSClick}>
                         <SVGIcon
                             viewbox="0 0 18 16"

--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
 
     var Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        menu = require("i18n!nls/menu"),
+        nls = require("js/util/nls"),
         headlights = require("js/util/headlights"),
         synchronization = require("js/util/synchronization");
 
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                 <div className={panelTabBarClassNames}>
                     <Button
                         className="toolbar__backToPs"
-                        title={menu.WINDOW.RETURN_TO_STANDARD}
+                        title={nls.localize("menus.WINDOW.RETURN_TO_STANDARD")}
                         onClick={this._handleBackToPSClick}>
                         <SVGIcon
                             viewbox="0 0 18 16"

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
         ExportPanel = require("jsx!./sections/export/ExportPanel"),
         LayersPanel = require("jsx!./sections/layers/LayersPanel"),
         LibrariesPanel = require("jsx!./sections/libraries/LibrariesPanel"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization"),
         system = require("js/util/system"),
         headlights = require("js/util/headlights");
@@ -333,11 +333,11 @@ define(function (require, exports, module) {
                         "toolbar-button": true,
                         "tool-selected": this.state[components.LAYERS_LIBRARY_COL]
                     }),
-                    panelCollapse = strings.TOOLTIPS.PANEL_COLUMN_COLLAPSE,
-                    panelExpand = strings.TOOLTIPS.PANEL_COLUMN_EXPAND,
-                    layerColumnTitle = strings.TOOLTIPS.LAYERS_LIBRARIES +
+                    panelCollapse = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_COLLAPSE"),
+                    panelExpand = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_EXPAND"),
+                    layerColumnTitle = nls.localize("strings.TOOLTIPS.LAYERS_LIBRARIES") +
                         (this.state[components.LAYERS_LIBRARY_COL] ? panelCollapse : panelExpand),
-                    propertiesColumnTitle = strings.TOOLTIPS.PROPERTIES +
+                    propertiesColumnTitle = nls.localize("strings.TOOLTIPS.PROPERTIES") +
                         (this.state[components.PROPERTIES_COL] ? panelCollapse : panelExpand),
                     handlePropertiesColumnVisibilityToggle =
                         this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL),

--- a/src/js/jsx/ToolbarIcon.jsx
+++ b/src/js/jsx/ToolbarIcon.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
 
     var Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
     
     var ToolbarIcon = React.createClass({
         mixins: [FluxMixin],
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
                     id={this.props.id}
                     style={this.props.style}>
                     <Button
-                        title={strings.TOOLS[toolID]}
+                        title={nls.localize("strings.TOOLS." + toolID)}
                         className={buttonClassName}
                         onClick={!this.props.disabled && this.props.onClick}
                         disabled={this.props.disabled}>

--- a/src/js/jsx/help/FirstLaunch.jsx
+++ b/src/js/jsx/help/FirstLaunch.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         _ = require("lodash");
 
     var Carousel = require("jsx!js/jsx/shared/Carousel"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
  
     var FirstLaunch = React.createClass({
@@ -83,47 +83,47 @@ define(function (require, exports, module) {
                 githubURL = "https://www.adobe.com/go/designspace-github",
                 firstLaunchCarouselItems = [
                 (<div className="carousel__slide__full slide-0">
-                    <h1>{strings.FIRST_LAUNCH.SLIDES[0].HEADLINE}</h1>
+                    <h1>{nls.localize("strings.FIRST_LAUNCH.SLIDES.0.HEADLINE")}</h1>
                     <img src="img/first_launch/img_slide_ds.png"/>
-                    <h3>{strings.FIRST_LAUNCH.SLIDES[0].BODY_FIRST}</h3>
-                    <h3>{strings.FIRST_LAUNCH.SLIDES[0].BODY_SECOND}</h3>
+                    <h3>{nls.localize("strings.FIRST_LAUNCH.SLIDES.0.BODY_FIRST")}</h3>
+                    <h3>{nls.localize("strings.FIRST_LAUNCH.SLIDES.0.BODY_SECOND")}</h3>
                 </div>),
                 (<div className="carousel__slide__full">
                     <img src="img/first_launch/img_slide_toolset.gif"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[1].HEADLINE}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.1.HEADLINE")}</h2>
                 </div>),
                 (<div className="carousel__slide__full">
                     <img src="img/first_launch/img_slide_search.png"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[2].HEADLINE_FIRST}</h2>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[2].HEADLINE_SECOND}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.2.HEADLINE_FIRST")}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.2.HEADLINE_SECOND")}</h2>
                 </div>),
                 (<div className="carousel__slide__full slide-3">
                     <img src="img/first_launch/img_slide_sampler.png"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[3].HEADLINE_FIRST}</h2>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[3].HEADLINE_SECOND}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.3.HEADLINE_FIRST")}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.3.HEADLINE_SECOND")}</h2>
                 </div>),
                 (<div className="carousel__slide__full slide-4">
                     <img src="img/first_launch/img_slide_artboards.gif"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[4].HEADLINE}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.4.HEADLINE")}</h2>
                 </div>),
                 (<div className="carousel__slide__full slide-5">
                     <img src="img/first_launch/img_slide_swap.gif"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[5].HEADLINE}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.5.HEADLINE")}</h2>
                 </div>),
                 (<div className="carousel__slide__full slide-6">
                     <img src="img/first_launch/img_slide_switching.gif"/>
-                    <h2>{strings.FIRST_LAUNCH.SLIDES[6].HEADLINE}</h2>
+                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.6.HEADLINE")}</h2>
                 </div>),
                 (<div className="carousel__slide">
                     <div className="carousel__slide__body">
-                        <h1>{strings.FIRST_LAUNCH.SLIDES[7].HEADLINE}</h1>
+                        <h1>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.HEADLINE")}</h1>
                             <ul className="carousel__slide__three__list">
                                 <li>
                                     <div
                                         onClick={this._handleClick.bind(this, psDesignTwitterURL, "twitter")}>
                                         <SVGIcon
                                             CSSID="bird"/>
-                                        <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_FIRST}</h2>
+                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_FIRST")}</h2>
                                     </div>
                                 </li>
                             </ul>
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
                                         onClick={this._handleClick.bind(this, githubURL, "github")}>
                                         <SVGIcon
                                             CSSID="github"/>
-                                        <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_SECOND}</h2>
+                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_SECOND")}</h2>
                                     </div>
                                 </li>
                             </ul>
@@ -143,7 +143,7 @@ define(function (require, exports, module) {
                                         onClick={this._handleClick.bind(this, psForumURL, "forum")}>
                                         <SVGIcon
                                             CSSID="workspace"/>
-                                        <h2>{strings.FIRST_LAUNCH.SLIDES[7].BODY_THIRD}</h2>
+                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_THIRD")}</h2>
                                     </div>
                                 </li>
                             </ul>

--- a/src/js/jsx/help/KeyboardShortcuts.jsx
+++ b/src/js/jsx/help/KeyboardShortcuts.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         _ = require("lodash");
 
     var system = require("js/util/system"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
         
@@ -55,25 +55,36 @@ define(function (require, exports, module) {
             }
         },
 
+        /**
+         * Helper function to translate shortcut related strings
+         *
+         * @private
+         *
+         * @param {string} key Key for the string in strings.KEYBOARD_SHORTCUTS tree
+         * @return {string} Localized result
+         */
+        _translate: function (key) {
+            return nls.localize("strings.KEYBOARD_SHORTCUTS." + key);
+        },
+
         render: function () {
-            var shortcuts = strings.KEYBOARD_SHORTCUTS,
-                holdSelectionInstruction = system.isMac ?
-                    shortcuts.SELECT_TOOL.HOLD_SEL_MAC :
-                    shortcuts.SELECT_TOOL.HOLD_SEL_WIN,
+            var holdSelectionInstruction = system.isMac ?
+                    this._translate("SELECT_TOOL.HOLD_SEL_MAC") :
+                    this._translate("SELECT_TOOL.HOLD_SEL_WIN"),
                 targetLayerInstruction = system.isMac ?
-                    shortcuts.SELECT_TOOL.TARGET_LAYER_MAC :
-                    shortcuts.SELECT_TOOL.TARGET_LAYER_WIN,
+                    this._translate("SELECT_TOOL.TARGET_LAYER_MAC") :
+                    this._translate("SELECT_TOOL.TARGET_LAYER_WIN"),
                 searchInstruction = system.isMac ?
-                    shortcuts.TOOLS.SEARCH_INSTRUCTION_MAC :
-                    shortcuts.TOOLS.SEARCH_INSTRUCTION_WIN,
+                    this._translate("TOOLS.SEARCH_INSTRUCTION_MAC") :
+                    this._translate("TOOLS.SEARCH_INSTRUCTION_WIN"),
                 exportInstruction = system.isMac ?
-                    shortcuts.TOOLS.EXPORT_INSTRUCTION_MAC :
-                    shortcuts.TOOLS.EXPORT_INSTRUCTION_WIN;
+                    this._translate("TOOLS.EXPORT_INSTRUCTION_MAC") :
+                    this._translate("TOOLS.EXPORT_INSTRUCTION_WIN");
             
             return (
                 <div className="keyboard-shortcut__content" onClick={this._dismissDialog}>
                     <div className="keyboard-shortcut__column-1">
-                        <h2 className="keyboard-shortcut__title">{shortcuts.TOOLS_TITLE}</h2>
+                        <h2 className="keyboard-shortcut__title">{this._translate("TOOLS_TITLE")}</h2>
                         <ul className="keyboard-shortcut__list">
                             <li>
                                 <Button>
@@ -81,7 +92,7 @@ define(function (require, exports, module) {
                                 </Button>
                                 <span className="keyboard-shortcut__name">
                                     
-                                    {shortcuts.TOOLS.SELECT}
+                                    {this._translate("TOOLS.SELECT")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">V</span>
                             </li>
@@ -89,61 +100,61 @@ define(function (require, exports, module) {
                                 <Button>
                                     <SVGIcon CSSID="tool-rectangle" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.RECTANGLE}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.RECTANGLE")}</span>
                                 <span className="keyboard-shortcut__instr">R</span>
                             </li>
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="tool-ellipse" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.ELLIPSE}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.ELLIPSE")}</span>
                                 <span className="keyboard-shortcut__instr">E</span>
                             </li>
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="tool-pen" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.PEN}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.PEN")}</span>
                                 <span className="keyboard-shortcut__instr">P</span>
                             </li>
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="tool-typeCreateOrEdit" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.TYPE}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.TYPE")}</span>
                                 <span className="keyboard-shortcut__instr">T</span>
                             </li>
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="tool-eyedropper" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.SAMPLER}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.SAMPLER")}</span>
                                 <span className="keyboard-shortcut__instr">I</span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    &nbsp;&nbsp;&nbsp;&nbsp;{shortcuts.TOOLS.SAMPLER_EFFECTS}
+                                    &nbsp;&nbsp;&nbsp;&nbsp;{this._translate("TOOLS.SAMPLER_EFFECTS")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.TOOLS.SAMPLER_INSTRUCTION_EFFECTS}
+                                    {this._translate("TOOLS.SAMPLER_INSTRUCTION_EFFECTS")}
                                 </span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    &nbsp;&nbsp;&nbsp;&nbsp;{shortcuts.TOOLS.SAMPLER_HUD}
+                                    &nbsp;&nbsp;&nbsp;&nbsp;{this._translate("TOOLS.SAMPLER_HUD")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.TOOLS.SAMPLER_INSTRUCTION_HUD}
+                                    {this._translate("TOOLS.SAMPLER_INSTRUCTION_HUD")}
                                 </span>
                             </li>
                         </ul>
-                        <h2 className="keyboard-shortcut__title">{shortcuts.MORE_TITLE}</h2>
+                        <h2 className="keyboard-shortcut__title">{this._translate("MORE_TITLE")}</h2>
                         <ul className="keyboard-shortcut__list">
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="layer-search-app" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.SEARCH}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.SEARCH")}</span>
                                 <span className="keyboard-shortcut__instr">
                                     {searchInstruction}
                                 </span>
@@ -152,14 +163,14 @@ define(function (require, exports, module) {
                                 <Button>
                                     <SVGIcon CSSID="tool-maskmode" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.MASKMODE}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.MASKMODE")}</span>
                                 <span className="keyboard-shortcut__instr">M</span>
                             </li>
                             <li>
                                 <Button>
                                     <SVGIcon CSSID="extract-all" />
                                 </Button>
-                                <span className="keyboard-shortcut__name">{shortcuts.TOOLS.EXPORT}</span>
+                                <span className="keyboard-shortcut__name">{this._translate("TOOLS.EXPORT")}</span>
                                 <span className="keyboard-shortcut__instr">
                                     {exportInstruction}
                                 </span>
@@ -167,43 +178,43 @@ define(function (require, exports, module) {
                         </ul>
                     </div>
                     <div className="keyboard-shortcut__column-2">
-                        <h2 className="keyboard-shortcut__title">{shortcuts.SELECT_TITLE}</h2>
+                        <h2 className="keyboard-shortcut__title">{this._translate("SELECT_TITLE")}</h2>
                         <ul className="keyboard-shortcut__list">
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.TARGET}
+                                    {this._translate("SELECT_TOOL.TARGET")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.SELECT_TOOL.TARGET_INSTRUCTION}
+                                    {this._translate("SELECT_TOOL.TARGET_INSTRUCTION")}
                                 </span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.EDIT_PATH}
+                                    {this._translate("SELECT_TOOL.EDIT_PATH")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.SELECT_TOOL.EDIT_PATH_INSTRUCTION}
+                                    {this._translate("SELECT_TOOL.EDIT_PATH_INSTRUCTION")}
                                 </span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.EDIT_SMART}
+                                    {this._translate("SELECT_TOOL.EDIT_SMART")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.SELECT_TOOL.EDIT_SMART_INSTRUCTION}
+                                    {this._translate("SELECT_TOOL.EDIT_SMART_INSTRUCTION")}
                                 </span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.BACK_OUT}
+                                    {this._translate("SELECT_TOOL.BACK_OUT")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
-                                    {shortcuts.SELECT_TOOL.BACK_OUT_INSTRUCTION}
+                                    {this._translate("SELECT_TOOL.BACK_OUT_INSTRUCTION")}
                                 </span>
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.HOLD_SELECTION}
+                                    {this._translate("SELECT_TOOL.HOLD_SELECTION")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
                                     {holdSelectionInstruction}
@@ -211,7 +222,7 @@ define(function (require, exports, module) {
                             </li>
                             <li>
                                 <span className="keyboard-shortcut__name">
-                                    {shortcuts.SELECT_TOOL.TARGET_LAYER}
+                                    {this._translate("SELECT_TOOL.TARGET_LAYER")}
                                 </span>
                                 <span className="keyboard-shortcut__instr">
                                     {targetLayerInstruction}

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     var os = require("adapter").os;
 
     var collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         Datalist = require("jsx!js/jsx/shared/Datalist"),
         headlights = require("js/util/headlights"),
         Button = require("jsx!js/jsx/shared/Button");
@@ -209,7 +209,9 @@ define(function (require, exports, module) {
             if (id) {
                 var currFilter = this.refs.datalist.getInputValue().split(" "),
                 idString = _.map(id, function (idWord) {
-                    var toRemove = strings.SEARCH.CATEGORIES[idWord] || this.state.safeFilterNameMap[idWord];
+                    var category = nls.localize("strings.SEARCH.CATEGORIES." + idWord),
+                        toRemove = category || this.state.safeFilterNameMap[idWord];
+                        
                     if (toRemove) {
                         return toRemove.toLowerCase().replace(" ", "");
                     }
@@ -485,10 +487,10 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var searchStrings = strings.SEARCH,
+            var searchStrings = nls.localize("strings.SEARCH"),
                 noMatchesOption = {
                     id: PLACEHOLDER_ID,
-                    title: strings.SEARCH.NO_OPTIONS,
+                    title: nls.localize("strings.SEARCH.NO_OPTIONS"),
                     type: "placeholder"
                 };
 

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon");
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         svgUtil = require("js/util/svg"),
         collection = require("js/util/collection"),
         gridSort = require("js/util/gridsort"),
@@ -263,13 +263,13 @@ define(function (require, exports, module) {
 
             var exportButton = serviceBusy ?
                 (<SVGIcon CSSID="loader" viewbox="0 0 16 16" iconPath="" />)
-                : strings.EXPORT.BUTTON_EXPORT;
+                : nls.localize("strings.EXPORT.BUTTON_EXPORT");
 
             return (
                 <div className={panelClassnames}>
                     <TitleHeader
                         className="dialog-header"
-                        title={strings.TITLE_EXPORT} />
+                        title={nls.localize("strings.TITLE_EXPORT")} />
                     <div className="exports-panel__two-column">
                         <div className="exports-panel__asset-list__container">
                             <div className="exports-panel__asset-list__quick-selection">
@@ -279,14 +279,14 @@ define(function (require, exports, module) {
                                         onChange={this._setLayersExportEnabled.bind(this, artboardsSorted)} />
                                 </div>
                                 <div className="checkbox-label">
-                                    {strings.EXPORT.EXPORT_LIST_ALL_ARTBOARDS}
+                                    {nls.localize("strings.EXPORT.EXPORT_LIST_ALL_ARTBOARDS")}
                                 </div>
                                 <div className="column-4"></div>
                                 <CheckBox
                                         className="control-group__vertical"
                                         checked={useArtboardPrefix}
                                         onChange={this._setUseArtboardPrefix} />
-                                    {strings.EXPORT.USE_PREFIX}
+                                    {nls.localize("strings.EXPORT.USE_PREFIX")}
                             </div>
                             <div className="exports-panel__asset-list__list">
                                 {allArtboardsExportComponents}
@@ -301,7 +301,7 @@ define(function (require, exports, module) {
                                         checked={allNonABLayersExportEnabled}
                                         onChange={this._setLayersExportEnabled.bind(this, nonABLayersFiltered)} />
                                 </div>
-                                {strings.EXPORT.EXPORT_LIST_ALL_ASSETS}
+                                {nls.localize("strings.EXPORT.EXPORT_LIST_ALL_ASSETS")}
                             </div>
 
                             <div className="exports-panel__asset-list__list">

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
     var mathUtil = require("js/util/math"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     /**
      * The options for the scale datalist
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
                     </div>
                     <Button
                         className="control-group__vertical button-toggle"
-                        title={strings.TOOLTIPS.EXPORT_REMOVE_ASSET}
+                        title={nls.localize("strings.TOOLTIPS.EXPORT_REMOVE_ASSET")}
                         onClick={this._handleDeleteClick}>
                         <SVGIcon CSSID="delete" />
                     </Button>
@@ -251,22 +251,22 @@ define(function (require, exports, module) {
                 <div className="layer-exports__header" >
                     <div className="formline formline__space-between">
                         <Label
-                            title={strings.EXPORT.TITLE_SCALE}
+                            title={nls.localize("strings.EXPORT.TITLE_SCALE")}
                             size="column-4"
                             className="label__medium__left-aligned scale-title">
-                            {strings.EXPORT.TITLE_SCALE}
+                            {nls.localize("strings.EXPORT.TITLE_SCALE")}
                         </Label>
                         <Label
-                            title={strings.EXPORT.TITLE_SUFFIX}
+                            title={nls.localize("strings.EXPORT.TITLE_SUFFIX")}
                             size="column-8"
                             className="label__medium__left-aligned">
-                            {strings.EXPORT.TITLE_SUFFIX}
+                            {nls.localize("strings.EXPORT.TITLE_SUFFIX")}
                         </Label>
                         <Label
-                            title={strings.EXPORT.TITLE_SETTINGS}
+                            title={nls.localize("strings.EXPORT.TITLE_SETTINGS")}
                             size="column-8"
                             className="label__medium__left-aligned">
-                            {strings.EXPORT.TITLE_SETTINGS}
+                            {nls.localize("strings.EXPORT.TITLE_SETTINGS")}
                         </Label>
                         <div className="column-2"></div>
                     </div>

--- a/src/js/jsx/sections/export/ExportPanel.jsx
+++ b/src/js/jsx/sections/export/ExportPanel.jsx
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         Button = require("jsx!js/jsx/shared/Button"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         ExportAsset = require("js/models/exportasset"),
         synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
@@ -231,14 +231,16 @@ define(function (require, exports, module) {
                     if (supportedLayers.isEmpty()) {
                         // Special case: there are selected layers, but none is supported
                         disabled = true;
-                        containerContents = this._messageComponent(strings.EXPORT.ONLY_UNSUPPORTED_LAYERS_SELECTED);
+                        containerContents = this._messageComponent(
+                            nls.localize("strings.EXPORT.ONLY_UNSUPPORTED_LAYERS_SELECTED")
+                        );
                     } else if (documentExports.getUniformAssetsOnly(supportedLayers).isEmpty()) {
                         if (documentExports.layersHaveSomeAssets(supportedLayers)) {
                             // No uniform assets, but SOME assets, so this is a mixed state
-                            containerContents = this._messageComponent(strings.EXPORT.EXPORT_MIXED);
+                            containerContents = this._messageComponent(nls.localize("strings.EXPORT.EXPORT_MIXED"));
                         } else {
                             // The selected+supported layers have no assets what-so-ever
-                            containerContents = this._messageComponent(strings.EXPORT.NO_ASSETS);
+                            containerContents = this._messageComponent(nls.localize("strings.EXPORT.NO_ASSETS"));
                         }
                     }
                 } else {
@@ -271,7 +273,7 @@ define(function (require, exports, module) {
                     className={sectionClasses}
                     onScroll={this._handleScroll}>
                     <TitleHeader
-                        title={strings.TITLE_EXPORT}
+                        title={nls.localize("strings.TITLE_EXPORT")}
                         visible={this.props.visible}
                         disabled={false}
                         onDoubleClick={this.props.onVisibilityToggle}>
@@ -280,7 +282,7 @@ define(function (require, exports, module) {
                             <Button
                                 className="button-plus"
                                 disabled={disabled}
-                                title={strings.TOOLTIPS.EXPORT_ADD_ASSET}
+                                title={nls.localize("strings.TOOLTIPS.EXPORT_ADD_ASSET")}
                                 onClick={this._addAssetClickHandler}>
                                 <SVGIcon
                                     viewbox="0 0 16 16"
@@ -289,7 +291,7 @@ define(function (require, exports, module) {
                             <Button
                                 className="button-iOS"
                                 disabled={disabled}
-                                title={strings.TOOLTIPS.EXPORT_IOS_PRESETS}
+                                title={nls.localize("strings.TOOLTIPS.EXPORT_IOS_PRESETS")}
                                 onClick={this._addAssetClickHandler.bind(this, "IOS")}>
                                 <SVGIcon
                                     viewbox="0 0 24 16"
@@ -298,7 +300,7 @@ define(function (require, exports, module) {
                             <Button
                                 className="button-xdpi"
                                 disabled={disabled}
-                                title={strings.TOOLTIPS.EXPORT_HDPI_PRESETS}
+                                title={nls.localize("strings.TOOLTIPS.EXPORT_HDPI_PRESETS")}
                                 onClick={this._addAssetClickHandler.bind(this, "HDPI")}>
                                 <SVGIcon
                                     viewbox="0 0 28 16"
@@ -307,7 +309,7 @@ define(function (require, exports, module) {
                             <Button
                                 className="button-plus"
                                 disabled={exportDisabled || disabled}
-                                title={strings.TOOLTIPS.EXPORT_EXPORT_ASSETS}
+                                title={nls.localize("strings.TOOLTIPS.EXPORT_EXPORT_ASSETS")}
                                 onClick={this._exportAssetsClickHandler}>
                                 <SVGIcon
                                     CSSID={exportState.serviceBusy ? "loader" : "export"}

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
         TextInput = require("jsx!js/jsx/shared/TextInput"),
         system = require("js/util/system"),
         svgUtil = require("js/util/svg"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     /**
      * Function for checking whether React component should update
@@ -310,12 +310,14 @@ define(function (require, exports, module) {
             // one region to the other. This is used to make the titles to be different,
             // and hence to force the tooltip to be invalidated.
             var tooltipPadding = _.repeat("\u200b", layerIndex),
-                tooltipTitle = layer.isArtboard ? strings.LAYER_KIND.ARTBOARD : strings.LAYER_KIND[layer.kind],
+                tooltipTitle = layer.isArtboard ?
+                    nls.localize("strings.LAYER_KIND.ARTBOARD") :
+                    nls.localize("strings.LAYER_KIND." + layer.kind),
                 iconID = svgUtil.getSVGClassFromLayer(layer),
                 showHideButton = layer.isBackground ? null : (
                     <ToggleButton
                         disabled={this.props.disabled}
-                        title={strings.TOOLTIPS.SET_LAYER_VISIBILITY + tooltipPadding}
+                        title={nls.localize("strings.TOOLTIPS.SET_LAYER_VISIBILITY") + tooltipPadding}
                         className="face__button_visibility"
                         size="column-2"
                         buttonType={ layer.visible ? "layer-visible" : "layer-not-visible" }
@@ -327,12 +329,12 @@ define(function (require, exports, module) {
 
             if (layer.isSmartObject()) {
                 if (layer.smartObject.linkMissing) {
-                    tooltipTitle += " : " + strings.LAYER_KIND_ALERTS.LINK_MISSING;
+                    tooltipTitle += " : " + nls.localize("strings.LAYER_KIND_ALERTS.LINK_MISSING");
                     iconClassModifier = "face__kind__error";
                 }
 
                 if (layer.smartObject.linkChanged) {
-                    tooltipTitle += " : " + strings.LAYER_KIND_ALERTS.LINK_CHANGED;
+                    tooltipTitle += " : " + nls.localize("strings.LAYER_KIND_ALERTS.LINK_CHANGED");
                     iconClassModifier = "face__kind__warning";
                 }
             }
@@ -378,7 +380,7 @@ define(function (require, exports, module) {
                         </span>
                         <ToggleButton
                             disabled={this.props.disabled}
-                            title={strings.TOOLTIPS.LOCK_LAYER + tooltipPadding}
+                            title={nls.localize("strings.TOOLTIPS.LOCK_LAYER") + tooltipPadding}
                             className="face__button_locked"
                             size="column-2"
                             buttonType={layer.locked ? "toggle-lock" : "toggle-unlock"}

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
     var TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         LayerFace = require("jsx!./LayerFace"),
         DummyLayerFace = require("jsx!./DummyLayerFace"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         synchronization = require("js/util/synchronization");
 
@@ -633,7 +633,7 @@ define(function (require, exports, module) {
                     className={sectionClasses}
                     onScroll={this._handleScroll}>
                     <TitleHeader
-                        title={strings.TITLE_PAGES}
+                        title={nls.localize("strings.TITLE_PAGES")}
                         visible={this.props.visible}
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle}>

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
         
     var headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var TitleHeader = require("jsx!js/jsx/shared/TitleHeader"),
         LibraryList = require("jsx!./LibraryList"),
@@ -143,7 +143,7 @@ define(function (require, exports, module) {
                 containerContents = (
                     <div className="libraries__content panel__info">
                         <div className="panel__info__body">
-                            {strings.LIBRARIES.NO_CONNECTION}
+                            {nls.localize("strings.LIBRARIES.NO_CONNECTION")}
                         </div>
                     </div>
                 );
@@ -200,7 +200,7 @@ define(function (require, exports, module) {
                     onMouseLeave={this.props.onMouseLeaveDroppable}>
                     {dropOverlay}
                     <TitleHeader
-                        title={strings.TITLE_LIBRARIES}
+                        title={nls.localize("strings.TITLE_LIBRARIES")}
                         visible={this.props.visible}
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle} />

--- a/src/js/jsx/sections/libraries/Library.jsx
+++ b/src/js/jsx/sections/libraries/Library.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
 
     var os = require("adapter").os,
         synchronization = require("js/util/synchronization"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         ui = require("js/util/ui"),
         librariesAction = require("js/actions/libraries");
 
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
 
             var components;
             if (name === "brush") {
-                var brushDescription = strings.LIBRARIES.BRUSHES_UNSUPPORTED;
+                var brushDescription = nls.localize("strings.LIBRARIES.BRUSHES_UNSUPPORTED");
 
                 components = (<div className="libraries__asset-brush">{brushDescription}</div>);
             } else {
@@ -255,32 +255,39 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var library = this.props.library;
+            var library = this.props.library,
+                introURL = nls.localize("strings.LIBRARIES.INTRO_URL");
 
             if (!library || library.elements.length === 0) {
                 return (
                     <div className={classnames("libraries__content panel__info", this.props.className)}>
                         <div className="panel__info__title">
-                            {strings.LIBRARIES.INTRO_TITLE}
+                            {nls.localize("strings.LIBRARIES.INTRO_TITLE")}
                         </div>
                         <div className="panel__info__body">
-                            {strings.LIBRARIES.INTRO_BODY}
+                            {nls.localize("strings.LIBRARIES.INTRO_BODY")}
                         </div>
                         <div className="panel__info__link">
-                            <a href="#" onClick={ui.openURL.bind(null, strings.LIBRARIES.INTRO_URL)}>
-                                {strings.LIBRARIES.INTRO_LINK_TITLE}
+                            <a href="#" onClick={ui.openURL.bind(null, introURL)}>
+                                {nls.localize("strings.LIBRARIES.INTRO_LINK_TITLE")}
                             </a>
                         </div>
                     </div>
                 );
             }
 
-            var colorAssets = this._renderAssets("color", strings.LIBRARIES.COLORS, Color),
-                colorThemeAssets = this._renderAssets("colortheme", strings.LIBRARIES.COLOR_THEMES, ColorTheme),
-                charStyleAssets = this._renderAssets("characterstyle", strings.LIBRARIES.CHAR_STYLES, CharacterStyle),
-                layerStyleAssets = this._renderAssets("layerstyle", strings.LIBRARIES.LAYER_STYLES, LayerStyle),
-                graphicAssets = this._renderAssets("graphic", strings.LIBRARIES.GRAPHICS, Graphic),
-                brushAssets = this._renderAssets("brush", strings.LIBRARIES.BRUSHES);
+            var colorAssets = this._renderAssets("color",
+                    nls.localize("strings.LIBRARIES.COLORS"), Color),
+                colorThemeAssets = this._renderAssets("colortheme",
+                    nls.localize("strings.LIBRARIES.COLOR_THEMES"), ColorTheme),
+                charStyleAssets = this._renderAssets("characterstyle",
+                    nls.localize("strings.LIBRARIES.CHAR_STYLES"), CharacterStyle),
+                layerStyleAssets = this._renderAssets("layerstyle",
+                    nls.localize("strings.LIBRARIES.LAYER_STYLES"), LayerStyle),
+                graphicAssets = this._renderAssets("graphic",
+                    nls.localize("strings.LIBRARIES.GRAPHICS"), Graphic),
+                brushAssets = this._renderAssets("brush",
+                    nls.localize("strings.LIBRARIES.BRUSHES"));
             
             var classNames = classnames("libraries__content", this.props.className, {
                 "libraries__content-drag": this.state.hasDraggedItem

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         Document = require("js/models/document");
     
     var SplitButton = require("jsx!js/jsx/shared/SplitButton"),
@@ -193,36 +193,39 @@ define(function (require, exports, module) {
         render: function () {
             var addFillButton = this._createColorButton(function (layer) {
                 return !layer.fill ? null :
-                    { color: layer.fill.color, title: strings.TOOLTIPS.ADD_FILL_COLOR };
+                    { color: layer.fill.color, title: nls.localize("strings.TOOLTIPS.ADD_FILL_COLOR") };
             });
 
             var addStrokeButton = this._createColorButton(function (layer) {
                 return !layer.stroke ? null :
-                    { color: layer.stroke.color, title: strings.TOOLTIPS.ADD_STROKE_COLOR };
+                    { color: layer.stroke.color, title: nls.localize("strings.TOOLTIPS.ADD_STROKE_COLOR") };
             });
 
             var addTextColorButton = this._createColorButton(function (layer) {
                 return !layer.isTextLayer() ? null :
-                    { color: layer.text.firstCharacterStyle.color, title: strings.TOOLTIPS.ADD_TEXT_COLOR };
+                    {
+                        color: layer.text.firstCharacterStyle.color,
+                        title: nls.localize("strings.TOOLTIPS.ADD_TEXT_COLOR")
+                    };
             });
 
             return (
                 <div className={"libraries-bar " + this.props.className}>
                     <ul className="button-radio libraries-bar__section__left">
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ADD_GRAPHIC}
+                            title={nls.localize("strings.TOOLTIPS.ADD_GRAPHIC")}
                             iconId="libraries-addGraphic"
                             onClick={this.addGraphic}
                             disabled={!this._canAddGraphic()}
                              />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ADD_CHARACTER_STYLE}
+                            title={nls.localize("strings.TOOLTIPS.ADD_CHARACTER_STYLE")}
                             onClick={this.addCharacterStyle}
                             iconId="libraries-addCharStyle"
                             disabled={!this._canAddCharacterStyle()}
                             />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ADD_LAYER_STYLE}
+                            title={nls.localize("strings.TOOLTIPS.ADD_LAYER_STYLE")}
                             iconId="libraries-addLayerStyle"
                             onClick={this.addLayerStyle}
                             disabled={!this._canAddLayerStyle()}
@@ -234,11 +237,11 @@ define(function (require, exports, module) {
 
                     <ul className="button-radio libraries-bar__section__right">
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.SEARCH_ADOBE_STOCK}
+                            title={nls.localize("strings.TOOLTIPS.SEARCH_ADOBE_STOCK")}
                             iconId="libraries-stock"
                             onClick={this._handleStockButtonClicked}/>
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.SYNC_LIBRARIES}
+                            title={nls.localize("strings.TOOLTIPS.SYNC_LIBRARIES")}
                             iconId={this.props.isSyncing ? "loader" : "libraries-cc"}
                             iconPath={this.props.isSyncing ? "" : null}
                             onClick={this._handleSyncLibraries}

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
         
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         headlights = require("js/util/headlights");
 
     var Datalist = require("jsx!js/jsx/shared/Datalist"),
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
                         id: "divider"
                     },
                     {
-                        title: strings.LIBRARIES.CREATE_LIBRARY,
+                        title: nls.localize("strings.LIBRARIES.CREATE_LIBRARY"),
                         searchable: false,
                         id: _CREATE_LIBRARY
                     }
@@ -166,11 +166,13 @@ define(function (require, exports, module) {
 
             if (selectedLibrary) {
                 var deleteLibraryText = selectedLibrary.collaboration === _INCOMING_LIBRARY ?
-                        strings.LIBRARIES.LEAVE_LIBRARY : strings.LIBRARIES.DELETE_LIBRARY;
+                        nls.localize("strings.LIBRARIES.LEAVE_LIBRARY") :
+                        nls.localize("strings.LIBRARIES.DELETE_LIBRARY");
 
                 options = options.concat([
                     {
-                        title: strings.LIBRARIES.RENAME_LIBRARY.replace("%s", selectedLibrary.name),
+                        title: nls.localize("strings.LIBRARIES.RENAME_LIBRARY")
+                            .replace("%s", selectedLibrary.name),
                         searchable: false,
                         id: _RENAME_LIBRARY
                     },
@@ -283,16 +285,20 @@ define(function (require, exports, module) {
             }
 
             var collaborationMapBody = {};
-            collaborationMapBody[_OUTGOING_LIBRARY] = strings.LIBRARIES.DELETE_SHARED_LIBRARY_CONFIRM;
-            collaborationMapBody[_INCOMING_LIBRARY] = strings.LIBRARIES.LEAVE_LIBRARY_CONFIRM;
-            collaborationMapBody[_REGULAR_LIBRARY] = strings.LIBRARIES.DELETE_LIBRARY_CONFIRM;
+            collaborationMapBody[_OUTGOING_LIBRARY] = nls.localize("strings.LIBRARIES.DELETE_SHARED_LIBRARY_CONFIRM");
+            collaborationMapBody[_INCOMING_LIBRARY] = nls.localize("strings.LIBRARIES.LEAVE_LIBRARY_CONFIRM");
+            collaborationMapBody[_REGULAR_LIBRARY] = nls.localize("strings.LIBRARIES.DELETE_LIBRARY_CONFIRM");
 
             var selectedLibrary = this.props.selected,
                 body = collaborationMapBody[selectedLibrary.collaboration].replace("%s", selectedLibrary.name),
-                cancelBtn = strings.LIBRARIES.BTN_CANCEL,
+                cancelBtn = nls.localize("strings.LIBRARIES.BTN_CANCEL"),
                 isIncomingLibrary = selectedLibrary.collaboration === _INCOMING_LIBRARY,
-                confirmBtn = isIncomingLibrary ? strings.LIBRARIES.BTN_LEAVE : strings.LIBRARIES.BTN_DELETE,
-                title = isIncomingLibrary ? strings.LIBRARIES.LEAVE_LIBRARY : strings.LIBRARIES.DELETE_LIBRARY;
+                confirmBtn = isIncomingLibrary ?
+                    nls.localize("strings.LIBRARIES.BTN_LEAVE") :
+                    nls.localize("strings.LIBRARIES.BTN_DELETE"),
+                title = isIncomingLibrary ?
+                    nls.localize("strings.LIBRARIES.LEAVE_LIBRARY") :
+                    nls.localize("strings.LIBRARIES.DELETE_LIBRARY");
 
             return (<LibraryDialog
                 title={title}
@@ -348,18 +354,18 @@ define(function (require, exports, module) {
                     disabled={this.props.disabled} />
                 <SplitButtonList className="libraries__split-button-list">
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.LIBRARY_SHARE}
+                        title={nls.localize("strings.TOOLTIPS.LIBRARY_SHARE")}
                         iconId="libraries-collaborate"
                         className={isSharedLibrary && "libraries__split-button-collaborate"}
                         disabled={!selectedLibrary}
                         onClick={this._handleLibraryButtonClicked.bind(this, "share-library", collaborateLink)} />
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.LIBRARY_SEND_LINK}
+                        title={nls.localize("strings.TOOLTIPS.LIBRARY_SEND_LINK")}
                         iconId="libraries-share"
                         disabled={!selectedLibrary}
                         onClick={this._handleLibraryButtonClicked.bind(this, "share-public-link", shareLink)} />
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.LIBRARY_VIEW_ON_WEBSITE}
+                        title={nls.localize("strings.TOOLTIPS.LIBRARY_VIEW_ON_WEBSITE")}
                         iconId="libraries-viewonsite"
                         disabled={!selectedLibrary}
                         onClick={this._handleLibraryButtonClicked.bind(this, "view-online", libraryLink)} />
@@ -382,7 +388,9 @@ define(function (require, exports, module) {
 
             var isInRenameMode = command === _RENAME_LIBRARY,
                 inputDefaultValue = isInRenameMode ? this.props.selected.name : "",
-                confirmBtnText = isInRenameMode ? strings.LIBRARIES.BTN_RENAME : strings.LIBRARIES.BTN_CREATE;
+                confirmBtnText = isInRenameMode ?
+                    nls.localize("strings.LIBRARIES.BTN_RENAME") :
+                    nls.localize("strings.LIBRARIES.BTN_CREATE");
 
             return (<div className="libraries__bar__top__content libraries__bar__top__content-input">
                 <TextInput
@@ -392,11 +400,11 @@ define(function (require, exports, module) {
                     continuous={true}
                     className="libraires__bar__input"
                     value={inputDefaultValue}
-                    placeholderText={strings.LIBRARIES.LIBRARY_NAME}
+                    placeholderText={nls.localize("strings.LIBRARIES.LIBRARY_NAME")}
                     onKeyDown={this._handleLibraryNameInputKeydown}/>
                 <div className="libraries__bar__btn-cancel"
                      onClick={this._handleCancelCommand}>
-                    {strings.LIBRARIES.BTN_CANCEL}
+                    {nls.localize("strings.LIBRARIES.BTN_CANCEL")}
                 </div>
                 <div className="libraries__bar__btn-confirm"
                      onClick={this._handleConfirmCommand}>

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         _ = require("lodash"),
         classnames = require("classnames");
 
-    var strings = require("i18n!nls/strings");
+    var nls = require("js/util/nls");
 
     var LibraryDialog = require("jsx!js/jsx/sections/libraries/LibraryDialog"),
         TextInput = require("jsx!js/jsx/shared/TextInput"),
@@ -206,15 +206,15 @@ define(function (require, exports, module) {
                             {subTitle}
                         </div>
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.LIBRARY_SEND_LINK}
+                            title={nls.localize("strings.TOOLTIPS.LIBRARY_SEND_LINK")}
                             iconId="libraries-share"
                             onClick={this._handleElementButtonClicked.bind(this, "share-public-link", shareLink)} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.LIBRARY_VIEW_ON_WEBSITE}
+                            title={nls.localize("strings.TOOLTIPS.LIBRARY_VIEW_ON_WEBSITE")}
                             iconId="libraries-viewonsite"
                             onClick={this._handleElementButtonClicked.bind(this, "view-online", elementLink)} />
                          <SplitButtonItem
-                            title={strings.TOOLTIPS.LIBRARY_DELETE}
+                            title={nls.localize("strings.TOOLTIPS.LIBRARY_DELETE")}
                             iconId="delete"
                             onClick={this._handleDelete} />
                     </SplitButtonList>
@@ -238,10 +238,10 @@ define(function (require, exports, module) {
             }
 
             if (this.state.deleting) {
-                var dialogTitle = strings.LIBRARIES.DELETE_ASSET.replace("%s", element.name),
-                    body = strings.LIBRARIES.DELETE_ASSET_CONFIRM.replace("%s", element.name),
-                    cancelBtn = strings.LIBRARIES.BTN_CANCEL,
-                    confirmBtn = strings.LIBRARIES.BTN_DELETE;
+                var dialogTitle = nls.localize("strings.LIBRARIES.DELETE_ASSET").replace("%s", element.name),
+                    body = nls.localize("strings.LIBRARIES.DELETE_ASSET_CONFIRM").replace("%s", element.name),
+                    cancelBtn = nls.localize("strings.LIBRARIES.BTN_CANCEL"),
+                    confirmBtn = nls.localize("strings.LIBRARIES.BTN_DELETE");
 
                 deleteConfirmationDialog = (
                     <LibraryDialog

--- a/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/CharacterStyle.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         librariesUtil = require("js/util/libraries"),
         headlights = require("js/util/headlights");
 
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
                     subTitle={subtitle}
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-character-style"
-                         title={strings.LIBRARIES.CLICK_TO_APPLY}
+                         title={nls.localize("strings.LIBRARIES.CLICK_TO_APPLY")}
                          onClick={this._handleApply}>
                         <AssetPreviewImage
                             element={this.props.element}

--- a/src/js/jsx/sections/libraries/assets/Color.jsx
+++ b/src/js/jsx/sections/libraries/assets/Color.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         _ = require("lodash");
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         ColorModel = require("js/models/color"),
         headlights = require("js/util/headlights");
 
@@ -119,7 +119,7 @@ define(function (require, exports, module) {
                     key={element.id}>
                     <div className="libraries__asset__preview"
                          style={{ background: hexValue }}
-                         title={strings.LIBRARIES.CLICK_TO_APPLY}
+                         title={nls.localize("strings.LIBRARIES.CLICK_TO_APPLY")}
                          onClick={this._handleApply}/>
                 </AssetSection>
             );

--- a/src/js/jsx/sections/libraries/assets/Graphic.jsx
+++ b/src/js/jsx/sections/libraries/assets/Graphic.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         classnames = require("classnames");
         
     var libraryUtil = require("js/util/libraries"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         headlights = require("js/util/headlights");
         
     var Draggable = require("jsx!js/jsx/shared/Draggable"),
@@ -129,11 +129,11 @@ define(function (require, exports, module) {
                 previewTitle;
             
             if (!this.state.renditionPath) {
-                previewTitle = strings.TOOLTIPS.LIBRARY_EMPTY_GRAPHIC;
+                previewTitle = nls.localize("strings.TOOLTIPS.LIBRARY_EMPTY_GRAPHIC");
             } else if (libraryUtil.isEditableGraphic(element)) {
-                previewTitle = strings.TOOLTIPS.LIBRARY_EDITABLE_GRAPHIC;
+                previewTitle = nls.localize("strings.TOOLTIPS.LIBRARY_EDITABLE_GRAPHIC");
             } else {
-                previewTitle = strings.TOOLTIPS.LIBRARY_NONEDITABLE_GRAPHIC;
+                previewTitle = nls.localize("strings.TOOLTIPS.LIBRARY_NONEDITABLE_GRAPHIC");
             }
 
             var classNames = classnames({

--- a/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
+++ b/src/js/jsx/sections/libraries/assets/LayerStyle.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         headlights = require("js/util/headlights");
 
     var AssetSection = require("jsx!./AssetSection"),
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
                     key={element.id}>
                     <div className="libraries__asset__preview libraries__asset__preview-layer-style"
                          onClick={this._handleApply}
-                         title={strings.LIBRARIES.CLICK_TO_APPLY}>
+                         title={nls.localize("strings.LIBRARIES.CLICK_TO_APPLY")}>
                         <AssetPreviewImage element={this.props.element}/>
                     </div>
                 </AssetSection>

--- a/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
+++ b/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader");
 
     var templatesJSON = require("text!static/templates.json"),
@@ -54,13 +54,14 @@ define(function (require, exports, module) {
 
         render: function () {
             var templateLinks = templates.map(function (template, index) {
+                    var name = nls.localize("strings.TEMPLATES." + template.id);
                     return (
                         <li
                             key={index}
                             className="link-list__item"
                             onClick={this._openTemplate.bind(this, template)}>
 
-                            <span>{strings.TEMPLATES[template.id]}</span>
+                            <span>{name}</span>
                             <span>{template.width} x {template.height}</span>
                         </li>
                     );
@@ -68,7 +69,7 @@ define(function (require, exports, module) {
 
             return (
                 <section className="artboard-presets section section__active">
-                    <TitleHeader title={strings.NO_DOC.ARTBOARD_PRESETS_TITLE} />
+                    <TitleHeader title={nls.localize("strings.NO_DOC.ARTBOARD_PRESETS_TITLE")} />
                     <div className="section-container artboard-launcher__body">
                         <ul className="link-list__list">
                             {templateLinks}

--- a/src/js/jsx/sections/nodoc/RecentFiles.jsx
+++ b/src/js/jsx/sections/nodoc/RecentFiles.jsx
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable");
 
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         pathUtil = require("js/util/path"),
         TitleHeader = require("jsx!js/jsx/shared/TitleHeader");
 
@@ -76,13 +76,13 @@ define(function (require, exports, module) {
             if (recentFilesLimited.isEmpty()) {
                 return (
                     <section className="recent-files section section__active">
-                        <TitleHeader title={strings.NO_DOC.RECENT_FILES_TITLE} />
+                        <TitleHeader title={nls.localize("strings.NO_DOC.RECENT_FILES_TITLE")} />
                     </section>
                );
             } else {
                 return (
                     <section className="recent-files section section__active">
-                        <TitleHeader title={strings.NO_DOC.RECENT_FILES_TITLE} />
+                        <TitleHeader title={nls.localize("strings.NO_DOC.RECENT_FILES_TITLE")} />
                         <div className="section-container">
                             <ul className="link-list__list">
                                 {recentFilelinks}

--- a/src/js/jsx/sections/style/AppearancePanel.jsx
+++ b/src/js/jsx/sections/style/AppearancePanel.jsx
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
         VectorFill = require("jsx!./VectorFill"),
         Type = require("jsx!./Type"),
         VectorAppearance = require("jsx!./VectorAppearance"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         collection = require("js/util/collection");
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
                     className={sectionClasses}
                     onScroll={this._handleScroll}>
                     <TitleHeader
-                        title={strings.TITLE_APPEARANCE}
+                        title={nls.localize("strings.TITLE_APPEARANCE")}
                         visible={this.props.visible}
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle}>
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
                             onDoubleClick={this._blockInput}>
                             <Button
                                 className={copyStyleClasses}
-                                title={strings.STYLE.COPY}
+                                title={nls.localize("strings.STYLE.COPY")}
                                 disabled={copyStyleDisabled}
                                 onClick={this._handleStyleCopy}>
                                 <SVGIcon
@@ -236,7 +236,7 @@ define(function (require, exports, module) {
                             </Button>
                             <Button
                                 className={pasteStyleClasses}
-                                title={strings.STYLE.PASTE}
+                                title={nls.localize("strings.STYLE.PASTE")}
                                 disabled={pasteStyleDisabled}
                                 onClick={this._handleStylePaste}>
                                 <SVGIcon

--- a/src/js/jsx/sections/style/BlendMode.jsx
+++ b/src/js/jsx/sections/style/BlendMode.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
 
     var Datalist = require("jsx!js/jsx/shared/Datalist"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     /**
@@ -42,133 +42,133 @@ define(function (require, exports, module) {
     var _blendModes = Immutable.OrderedMap({
         "normal": {
             id: "normal",
-            title: strings.STYLE.BLEND.NORMAL
+            title: nls.localize("strings.STYLE.BLEND.NORMAL")
         },
         "dissolve": {
             id: "dissolve",
-            title: strings.STYLE.BLEND.DISSOLVE
+            title: nls.localize("strings.STYLE.BLEND.DISSOLVE")
         },
         "darken": {
             id: "darken",
-            title: strings.STYLE.BLEND.DARKEN
+            title: nls.localize("strings.STYLE.BLEND.DARKEN")
         },
         "lighten": {
             id: "lighten",
-            title: strings.STYLE.BLEND.LIGHTEN
+            title: nls.localize("strings.STYLE.BLEND.LIGHTEN")
         },
         "screen": {
             id: "screen",
-            title: strings.STYLE.BLEND.SCREEN
+            title: nls.localize("strings.STYLE.BLEND.SCREEN")
         },
         "overlay": {
             id: "overlay",
-            title: strings.STYLE.BLEND.OVERLAY
+            title: nls.localize("strings.STYLE.BLEND.OVERLAY")
         },
         "multiply": {
             id: "multiply",
-            title: strings.STYLE.BLEND.MULTIPLY
+            title: nls.localize("strings.STYLE.BLEND.MULTIPLY")
         },
         "colorBurn": {
             id: "colorBurn",
-            title: strings.STYLE.BLEND.COLORBURN
+            title: nls.localize("strings.STYLE.BLEND.COLORBURN")
         },
         "linearBurn": {
             id: "linearBurn",
-            title: strings.STYLE.BLEND.LINEARBURN
+            title: nls.localize("strings.STYLE.BLEND.LINEARBURN")
         },
         "darkerColor": {
             id: "darkerColor",
-            title: strings.STYLE.BLEND.DARKERCOLOR
+            title: nls.localize("strings.STYLE.BLEND.DARKERCOLOR")
         },
         // WE ONLY SHOW PASSTHROUGH IF SELECTION IS ALL GROUPS
         "passThrough": {
             id: "passThrough",
-            title: strings.STYLE.BLEND.PASSTHROUGH
+            title: nls.localize("strings.STYLE.BLEND.PASSTHROUGH")
         },
         // WE DON'T SHOW ANYTHING BELOW THIS LINE AS AN OPTION
         "colorDodge": {
             id: "colorDodge",
-            title: strings.STYLE.BLEND.COLORDODGE,
+            title: nls.localize("strings.STYLE.BLEND.COLORDODGE"),
             hidden: true
         },
         "linearDodge": {
             id: "linearDodge",
-            title: strings.STYLE.BLEND.LINEARDODGE,
+            title: nls.localize("strings.STYLE.BLEND.LINEARDODGE"),
             hidden: true
         },
         "lighterColor": {
             id: "lighterColor",
-            title: strings.STYLE.BLEND.LIGHTERCOLOR,
+            title: nls.localize("strings.STYLE.BLEND.LIGHTERCOLOR"),
             hidden: true
         },
         "softLight": {
             id: "softLight",
-            title: strings.STYLE.BLEND.SOFTLIGHT,
+            title: nls.localize("strings.STYLE.BLEND.SOFTLIGHT"),
             hidden: true
         },
         "hardLight": {
             id: "hardLight",
-            title: strings.STYLE.BLEND.HARDLIGHT,
+            title: nls.localize("strings.STYLE.BLEND.HARDLIGHT"),
             hidden: true
         },
         "vividLight": {
             id: "vividLight",
-            title: strings.STYLE.BLEND.VIVIDLIGHT,
+            title: nls.localize("strings.STYLE.BLEND.VIVIDLIGHT"),
             hidden: true
         },
         "linearLight": {
             id: "linearLight",
-            title: strings.STYLE.BLEND.LINEARLIGHT,
+            title: nls.localize("strings.STYLE.BLEND.LINEARLIGHT"),
             hidden: true
         },
         "pinLight": {
             id: "pinLight",
-            title: strings.STYLE.BLEND.PINLIGHT,
+            title: nls.localize("strings.STYLE.BLEND.PINLIGHT"),
             hidden: true
         },
         "hardMix": {
             id: "hardMix",
-            title: strings.STYLE.BLEND.HARDMIX,
+            title: nls.localize("strings.STYLE.BLEND.HARDMIX"),
             hidden: true
         },
         "difference": {
             id: "difference",
-            title: strings.STYLE.BLEND.DIFFERENCE,
+            title: nls.localize("strings.STYLE.BLEND.DIFFERENCE"),
             hidden: true
         },
         "exclusion": {
             id: "exclusion",
-            title: strings.STYLE.BLEND.EXCLUSION,
+            title: nls.localize("strings.STYLE.BLEND.EXCLUSION"),
             hidden: true
         },
         "blendSubtraction": {
             id: "blendSubtraction",
-            title: strings.STYLE.BLEND.SUBTRACT,
+            title: nls.localize("strings.STYLE.BLEND.SUBTRACT"),
             hidden: true
         },
         "blendDivide": {
             id: "blendDivide",
-            title: strings.STYLE.BLEND.DIVIDE,
+            title: nls.localize("strings.STYLE.BLEND.DIVIDE"),
             hidden: true
         },
         "hue": {
             id: "hue",
-            title: strings.STYLE.BLEND.HUE,
+            title: nls.localize("strings.STYLE.BLEND.HUE"),
             hidden: true
         },
         "saturation": {
             id: "saturation",
-            title: strings.STYLE.BLEND.SATURATION,
+            title: nls.localize("strings.STYLE.BLEND.SATURATION"),
             hidden: true
         },
         "color": {
             id: "color",
-            title: strings.STYLE.BLEND.COLOR,
+            title: nls.localize("strings.STYLE.BLEND.COLOR"),
             hidden: true
         },
         "luminosity": {
             id: "luminosity",
-            title: strings.STYLE.BLEND.LUMINOSITY,
+            title: nls.localize("strings.STYLE.BLEND.LUMINOSITY"),
             hidden: true
         }
     });
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
             var modes = this.props.modes,
                 mode = collection.uniformValue(modes),
                 title = _blendModes.has(mode) ? _blendModes.get(mode).title :
-                    (modes.size > 1 ? strings.TRANSFORM.MIXED : mode),
+                    (modes.size > 1 ? nls.localize("strings.TRANSFORM.MIXED") : mode),
                 allGroups = this.props.allGroups,
                 // Remove Pass Through option if any of the layers are not a group
                 modesToShow = _blendModes.update("passThrough", function (item) {

--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights");
 
@@ -164,9 +164,9 @@ define(function (require, exports, module) {
                     "effect-list__color-overlay__disabled": this.props.readOnly
                 });
 
-            var colorOverlayColorTooltip = strings.TOOLTIPS.SET_COLOR_OVERLAY_COLOR,
-                colorOverlayToggleTooltip = strings.TOOLTIPS.TOGGLE_COLOR_OVERLAY,
-                colorOverlayDeleteTooltip = strings.TOOLTIPS.DELETE_COLOR_OVERLAY;
+            var colorOverlayColorTooltip = nls.localize("strings.TOOLTIPS.SET_COLOR_OVERLAY_COLOR"),
+                colorOverlayToggleTooltip = nls.localize("strings.TOOLTIPS.TOGGLE_COLOR_OVERLAY"),
+                colorOverlayDeleteTooltip = nls.localize("strings.TOOLTIPS.DELETE_COLOR_OVERLAY");
 
             // Dialog IDs
             var blendModelistID = "color-overlay-blendmodes-" + this.props.index + "-" + this.props.document.id,
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
             } else {
                 colorOverlayContent = (
                     <div className="effect-list__list-container__mixed">
-                        <i>{strings.STYLE.COLOR_OVERLAY.MIXED}</i>
+                        <i>{nls.localize("strings.STYLE.COLOR_OVERLAY.MIXED")}</i>
                     </div>
                 );
             }
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
                         <h3 className="section-title__subtitle">
-                            {strings.STYLE.COLOR_OVERLAY.TITLE}
+                            {nls.localize("strings.STYLE.COLOR_OVERLAY.TITLE")}
                         </h3>
                     </header>
                     <div className="effect-list__list-container">

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
         ColorOverlayList = require("jsx!./ColorOverlayList"),
         StrokeList = require("jsx!./StrokeList"),
         LayerEffect = require("js/models/effects/layereffect"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
         synchronization = require("js/util/synchronization"),
@@ -285,7 +285,7 @@ define(function (require, exports, module) {
                     className={sectionClasses}
                     onScroll={this._handleScroll}>
                     <TitleHeader
-                        title={strings.TITLE_EFFECTS}
+                        title={nls.localize("strings.TITLE_EFFECTS")}
                         visible={this.props.visible}
                         disabled={this.props.disabled}
                         onDoubleClick={this.props.onVisibilityToggle}>
@@ -293,7 +293,7 @@ define(function (require, exports, module) {
                             onDoubleClick={this._blockInput}>
                             <Button
                                 className={addStyleClasses}
-                                title={strings.TOOLTIPS.ADD_EFFECT}
+                                title={nls.localize("strings.TOOLTIPS.ADD_EFFECT")}
                                 disabled={addStyleDisabled}
                                 onClick={this._toggleEffectPopover}>
                                 <SVGIcon
@@ -301,7 +301,7 @@ define(function (require, exports, module) {
                             </Button>
                             <Button
                                 className={copyStyleClasses}
-                                title={strings.STYLE.COPY}
+                                title={nls.localize("strings.STYLE.COPY")}
                                 disabled={copyStyleDisabled}
                                 onClick={this._handleStyleCopy}>
                                 <SVGIcon
@@ -310,7 +310,7 @@ define(function (require, exports, module) {
                             </Button>
                             <Button
                                 className={pasteStyleClasses}
-                                title={strings.STYLE.PASTE}
+                                title={nls.localize("strings.STYLE.PASTE")}
                                 disabled={pasteStyleDisabled}
                                 onClick={this._handleStylePaste}>
                                 <SVGIcon
@@ -330,22 +330,22 @@ define(function (require, exports, module) {
                             <li className={strokeMenuClasses}
                                 onClick={canAddStroke &&
                                     this._handleEffectListClick.bind(this, LayerEffect.STROKE)}>
-                                {strings.STYLE.STROKE_EFFECT.TITLE_SINGLE}
+                                {nls.localize("strings.STYLE.STROKE_EFFECT.TITLE_SINGLE")}
                             </li>
                             <li className={colorOverlayMenuClasses}
                                 onClick={canAddColorOverlay &&
                                     this._handleEffectListClick.bind(this, LayerEffect.COLOR_OVERLAY)}>
-                                {strings.STYLE.COLOR_OVERLAY.TITLE_SINGLE}
+                                {nls.localize("strings.STYLE.COLOR_OVERLAY.TITLE_SINGLE")}
                             </li>
                             <li className={innerShadowMenuClasses}
                                 onClick={canAddInnerShadow &&
                                     this._handleEffectListClick.bind(this, LayerEffect.INNER_SHADOW)}>
-                                {strings.STYLE.INNER_SHADOW.TITLE_SINGLE}
+                                {nls.localize("strings.STYLE.INNER_SHADOW.TITLE_SINGLE")}
                             </li>
                             <li className={dropShadowMenuClasses}
                                 onClick={canAddDropShadow &&
                                     this._handleEffectListClick.bind(this, LayerEffect.DROP_SHADOW)}>
-                                {strings.STYLE.DROP_SHADOW.TITLE_SINGLE}
+                                {nls.localize("strings.STYLE.DROP_SHADOW.TITLE_SINGLE")}
                             </li>
                         </ul>
                     </Dialog>

--- a/src/js/jsx/sections/style/Fill.jsx
+++ b/src/js/jsx/sections/style/Fill.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
 
     var ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         headlights = require("js/util/headlights"),
         collection = require("js/util/collection");
 
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
                     id={colorInputID}
                     className="fill"
                     context={collection.pluck(this.props.layers, "id")}
-                    title={strings.TOOLTIPS.SET_FILL_COLOR}
+                    title={nls.localize("strings.TOOLTIPS.SET_FILL_COLOR")}
                     editable={!this.props.disabled}
                     defaultValue={fill.colors}
                     onChange={this._colorChanged}
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
 
             return (
                 <ToggleButton
-                    title={strings.TOOLTIPS.TOGGLE_FILL}
+                    title={nls.localize("strings.TOOLTIPS.TOGGLE_FILL")}
                     name="toggleFillEnabled"
                     buttonType="layer-not-visible"
                     selected={this.props.fill.enabledFlags}

--- a/src/js/jsx/sections/style/LayerBlendMode.jsx
+++ b/src/js/jsx/sections/style/LayerBlendMode.jsx
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
 
     var BlendMode = require("jsx!./BlendMode"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         collection = require("js/util/collection");
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
                     listID={listID}
                     modes={modes}
                     handleChange={this._handleChange}
-                    mixedTitle={strings.TRANSFORM.MIXED}
+                    mixedTitle={nls.localize("strings.TRANSFORM.MIXED")}
                     allGroups={allGroups} />
             );
         }

--- a/src/js/jsx/sections/style/Radius.jsx
+++ b/src/js/jsx/sections/style/Radius.jsx
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
         Range = require("jsx!js/jsx/shared/Range"),
         Coalesce = require("js/jsx/mixin/Coalesce"),
         math = require("js/util/math"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     var Radius = React.createClass({
@@ -106,8 +106,8 @@ define(function (require, exports, module) {
                     <Label
                         className="label__medium__left-aligned"
                         size="column-4"
-                        title={strings.TOOLTIPS.SET_RADIUS}>
-                        {strings.TRANSFORM.RADIUS}
+                        title={nls.localize("strings.TOOLTIPS.SET_RADIUS")}>
+                        {nls.localize("strings.TRANSFORM.RADIUS")}
                     </Label>
                     <div className="control-group__vertical">
                         <NumberInput

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -34,7 +34,7 @@ define(function (require, exports) {
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         synchronization = require("js/util/synchronization");
 
     var Label = require("jsx!js/jsx/shared/Label"),
@@ -294,29 +294,51 @@ define(function (require, exports) {
                     "effect-list__shadow__disabled": this.props.readOnly
                 });
 
-            var shadowXPositionTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_X_POSITION,
-                     strings.TOOLTIPS.SET_INNER_SHADOW_X_POSITION),
-                shadowYPositionTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_Y_POSITION,
-                     strings.TOOLTIPS.SET_INNER_SHADOW_Y_POSITION),
-                shadowColorTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_COLOR,
-                    strings.TOOLTIPS.SET_INNER_SHADOW_COLOR),
-                shadowBlurTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_BLUR,
-                    strings.TOOLTIPS.SET_INNER_SHADOW_BLUR),
-                shadowSpreadTooltip = this._stringHelper(strings.TOOLTIPS.SET_DROP_SHADOW_SPREAD,
-                    strings.TOOLTIPS.SET_INNER_SHADOW_SPREAD),
-                shadowToggleTooltip = this._stringHelper(strings.TOOLTIPS.TOGGLE_DROP_SHADOW,
-                    strings.TOOLTIPS.TOGGLE_INNER_SHADOW),
-                shadowDeleteTooltip = this._stringHelper(strings.TOOLTIPS.DELETE_DROP_SHADOW,
-                    strings.TOOLTIPS.DELETE_INNER_SHADOW);
+            var shadowXPositionTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.SET_DROP_SHADOW_X_POSITION"),
+                    nls.localize("strings.TOOLTIPS.SET_INNER_SHADOW_X_POSITION")
+                ),
+                shadowYPositionTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.SET_DROP_SHADOW_Y_POSITION"),
+                    nls.localize("strings.TOOLTIPS.SET_INNER_SHADOW_Y_POSITION")
+                ),
+                shadowColorTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.SET_DROP_SHADOW_COLOR"),
+                    nls.localize("strings.TOOLTIPS.SET_INNER_SHADOW_COLOR")
+                ),
+                shadowBlurTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.SET_DROP_SHADOW_BLUR"),
+                    nls.localize("strings.TOOLTIPS.SET_INNER_SHADOW_BLUR")
+                ),
+                shadowSpreadTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.SET_DROP_SHADOW_SPREAD"),
+                    nls.localize("strings.TOOLTIPS.SET_INNER_SHADOW_SPREAD")
+                ),
+                shadowToggleTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.TOGGLE_DROP_SHADOW"),
+                    nls.localize("strings.TOOLTIPS.TOGGLE_INNER_SHADOW")
+                ),
+                shadowDeleteTooltip = this._stringHelper(
+                    nls.localize("strings.TOOLTIPS.DELETE_DROP_SHADOW"),
+                    nls.localize("strings.TOOLTIPS.DELETE_INNER_SHADOW")
+                );
 
-            var shadowXPosition = this._stringHelper(strings.STYLE.DROP_SHADOW.X_POSITION,
-                    strings.STYLE.INNER_SHADOW.X_POSITION),
-                shadowYPosition = this._stringHelper(strings.STYLE.DROP_SHADOW.Y_POSITION,
-                    strings.STYLE.INNER_SHADOW.Y_POSITION),
-                shadowBlur = this._stringHelper(strings.STYLE.DROP_SHADOW.BLUR,
-                    strings.STYLE.INNER_SHADOW.BLUR),
-                shadowSpread = this._stringHelper(strings.STYLE.DROP_SHADOW.SPREAD,
-                    strings.STYLE.INNER_SHADOW.SPREAD);
+            var shadowXPosition = this._stringHelper(
+                    nls.localize("strings.STYLE.DROP_SHADOW.X_POSITION"),
+                    nls.localize("strings.STYLE.INNER_SHADOW.X_POSITION")
+                ),
+                shadowYPosition = this._stringHelper(
+                    nls.localize("strings.STYLE.DROP_SHADOW.Y_POSITION"),
+                    nls.localize("strings.STYLE.INNER_SHADOW.Y_POSITION")
+                ),
+                shadowBlur = this._stringHelper(
+                    nls.localize("strings.STYLE.DROP_SHADOW.BLUR"),
+                    nls.localize("strings.STYLE.INNER_SHADOW.BLUR")
+                ),
+                shadowSpread = this._stringHelper(
+                    nls.localize("strings.STYLE.DROP_SHADOW.SPREAD"),
+                    nls.localize("strings.STYLE.INNER_SHADOW.SPREAD")
+                );
 
             var type = this.props.type,
                 blendModelistID = "shadow-blendmodes-" + type + this.props.index + "-" + this.props.document.id,
@@ -475,7 +497,7 @@ define(function (require, exports) {
             } else {
                 shadowsContent = (
                     <div className="effect-list__list-container__mixed">
-                        <i>{strings.STYLE.DROP_SHADOW.MIXED}</i>
+                        <i>{nls.localize("strings.STYLE.DROP_SHADOW.MIXED")}</i>
                     </div>
                 );
             }
@@ -484,7 +506,7 @@ define(function (require, exports) {
                 <div className="effect-list__container ">
                     <header className="section-header section-header__no-padding">
                         <h3 className="section-title__subtitle">
-                            {strings.STYLE.DROP_SHADOW.TITLE}
+                            {nls.localize("strings.STYLE.DROP_SHADOW.TITLE")}
                         </h3>
                     </header>
                     <div className="effect-list__list-container">
@@ -544,7 +566,7 @@ define(function (require, exports) {
             } else {
                 shadowsContent = (
                     <div className="effect-list__list-container__mixed">
-                        <i>{strings.STYLE.INNER_SHADOW.MIXED}</i>
+                        <i>{nls.localize("strings.STYLE.INNER_SHADOW.MIXED")}</i>
                     </div>
                 );
             }
@@ -553,7 +575,7 @@ define(function (require, exports) {
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
                         <h3 className="section-title__subtitle">
-                            {strings.STYLE.INNER_SHADOW.TITLE}
+                            {nls.localize("strings.STYLE.INNER_SHADOW.TITLE")}
                         </h3>
                     </header>
                     <div className="effect-list__list-container">

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights");
 
@@ -279,7 +279,7 @@ define(function (require, exports, module) {
             
             var toggleVisibilityButton = this.props.disabled ? null : (
                 <ToggleButton
-                    title={strings.TOOLTIPS.TOGGLE_STROKE}
+                    title={nls.localize("strings.TOOLTIPS.TOGGLE_STROKE")}
                     name="toggleStrokeEnabled"
                     buttonType="layer-not-visible"
                     disabled={this.props.disabled}
@@ -295,7 +295,7 @@ define(function (require, exports, module) {
                             id={colorInputID}
                             className="stroke"
                             context={collection.pluck(this.state.layers, "id")}
-                            title={strings.TOOLTIPS.SET_STROKE_COLOR}
+                            title={nls.localize("strings.TOOLTIPS.SET_STROKE_COLOR")}
                             editable={!this.props.disabled}
                             defaultValue={stroke.colors}
                             onChange={this._colorChanged}

--- a/src/js/jsx/sections/style/StrokeAlignment.jsx
+++ b/src/js/jsx/sections/style/StrokeAlignment.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     var SplitButton = require("jsx!js/jsx/shared/SplitButton"),
         SplitButtonList = SplitButton.SplitButtonList,
         SplitButtonItem = SplitButton.SplitButtonItem,
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     /**
@@ -44,15 +44,15 @@ define(function (require, exports, module) {
     var _alignmentModes = Immutable.OrderedMap({
         "INSIDE": {
             id: "INSIDE",
-            title: strings.STYLE.STROKE.ALIGNMENT_MODES.INSIDE
+            title: nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.INSIDE")
         },
         "CENTER": {
             id: "CENTER",
-            title: strings.STYLE.STROKE.ALIGNMENT_MODES.CENTER
+            title: nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.CENTER")
         },
         "OUTSIDE": {
             id: "OUTSIDE",
-            title: strings.STYLE.STROKE.ALIGNMENT_MODES.OUTSIDE
+            title: nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.OUTSIDE")
         }
     });
 
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
             var alignments = this.props.alignments,
                 alignment = collection.uniformValue(alignments),
                 alignmentTitle = _alignmentModes.has(alignment) ? _alignmentModes.get(alignment).title :
-                    (alignments.size > 1 ? strings.TRANSFORM.MIXED : alignment),
+                    (alignments.size > 1 ? nls.localize("strings.TRANSFORM.MIXED") : alignment),
                 insideValue = this.props.insideValue || "INSIDE",
                 centerValue = this.props.centerValue || "CENTER",
                 outsideValue = this.props.outsideValue || "OUTSIDE";
@@ -104,21 +104,21 @@ define(function (require, exports, module) {
             return (
                 <SplitButtonList size="column-9" className={this.props.className}>
                     <SplitButtonItem
-                        title={strings.STYLE.STROKE.ALIGNMENT_MODES.INSIDE}
+                        title={nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.INSIDE")}
                         iconId="stroke-inner"
                         selected={alignment === insideValue}
                         onClick={this._handleChange.bind(this, insideValue)}
                         className={"split-button__item__fixed"}
                         disabled={this.props.disabled} />
                     <SplitButtonItem
-                        title={strings.STYLE.STROKE.ALIGNMENT_MODES.CENTER}
+                        title={nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.CENTER")}
                         iconId="stroke-middle"
                         selected={alignment === centerValue}
                         className={"split-button__item__fixed"}
                         onClick={this._handleChange.bind(this, centerValue)}
                         disabled={this.props.disabled} />
                     <SplitButtonItem
-                        title={strings.STYLE.STROKE.ALIGNMENT_MODES.OUTSIDE}
+                        title={nls.localize("strings.STYLE.STROKE.ALIGNMENT_MODES.OUTSIDE")}
                         iconId="stroke-outer"
                         selected={alignment === outsideValue}
                         className={"split-button__item__fixed"}

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
     var LayerEffect = require("js/models/effects/layereffect"),
         StrokeEffect = require("js/models/effects/stroke"),
         collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         headlights = require("js/util/headlights"),
         synchronization = require("js/util/synchronization");
 
@@ -208,11 +208,11 @@ define(function (require, exports, module) {
                     "effect-list__stroke__disabled": this.props.readOnly
                 });
                 
-            var strokeColorTooltip = strings.TOOLTIPS.SET_STROKE_EFFECT_COLOR,
-                strokeToggleTooltip = strings.TOOLTIPS.TOGGLE_STROKE_EFFECT,
-                strokeDeleteTooltip = strings.TOOLTIPS.DELETE_STROKE_EFFECT,
-                strokeSizeTooltip = strings.TOOLTIPS.SET_STROKE_EFFECT_SIZE,
-                strokeSizeLabel = strings.STYLE.STROKE_EFFECT.SIZE;
+            var strokeColorTooltip = nls.localize("strings.TOOLTIPS.SET_STROKE_EFFECT_COLOR"),
+                strokeToggleTooltip = nls.localize("strings.TOOLTIPS.TOGGLE_STROKE_EFFECT"),
+                strokeDeleteTooltip = nls.localize("strings.TOOLTIPS.DELETE_STROKE_EFFECT"),
+                strokeSizeTooltip = nls.localize("strings.TOOLTIPS.SET_STROKE_EFFECT_SIZE"),
+                strokeSizeLabel = nls.localize("strings.STYLE.STROKE_EFFECT.SIZE");
 
             // Dialog IDs
             var blendModelistID = "stroke-blendmodes-" + this.props.index + "-" + this.props.document.id,
@@ -336,7 +336,7 @@ define(function (require, exports, module) {
             } else {
                 strokesContent = (
                     <div className="effect-list__list-container__mixed">
-                        <i>{strings.STYLE.STROKE_EFFECT.MIXED}</i>
+                        <i>{nls.localize("strings.STYLE.STROKE_EFFECT.MIXED")}</i>
                     </div>
                 );
             }
@@ -345,7 +345,7 @@ define(function (require, exports, module) {
                 <div className="effect-list__container">
                     <header className="section-header section-header__no-padding">
                         <h3 className="section-title__subtitle">
-                            {strings.STYLE.STROKE_EFFECT.TITLE}
+                            {nls.localize("strings.STYLE.STROKE_EFFECT.TITLE")}
                         </h3>
                     </header>
                     <div className="effect-list__list-container">

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
         ColorInput = require("jsx!js/jsx/shared/ColorInput"),
         SplitButtonList = SplitButton.SplitButtonList,
         SplitButtonItem = SplitButton.SplitButtonItem,
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         Color = require("js/models/color"),
         collection = require("js/util/collection"),
         unit = require("js/util/unit"),
@@ -299,7 +299,7 @@ define(function (require, exports, module) {
                     return layer.kind === layer.layerKinds.TEXT;
                 });
 
-            if (leading === strings.STYLE.TYPE.AUTO_LEADING) {
+            if (leading === nls.localize("strings.STYLE.TYPE.AUTO_LEADING")) {
                 leading = -1;
             }
 
@@ -464,7 +464,7 @@ define(function (require, exports, module) {
                 trackings = collection.pluck(characterStyles, "tracking"),
                 leadings = characterStyles.map(function (characterStyle) {
                     if (!characterStyle || characterStyle.leading === -1) {
-                        return strings.STYLE.TYPE.AUTO_LEADING;
+                        return nls.localize("strings.STYLE.TYPE.AUTO_LEADING");
                     } else {
                         return characterStyle.leading;
                     }
@@ -506,7 +506,7 @@ define(function (require, exports, module) {
                         // Font is missing
                         var uniformValue = collection.uniformValue(postScriptNames);
                         if (uniformValue === null) {
-                            placeholderText = "[" + strings.STYLE.TYPE.MIXED + "]";
+                            placeholderText = "[" + nls.localize("strings.STYLE.TYPE.MIXED") + "]";
                         } else {
                             placeholderText = "[" + postScriptFamilyName + "]";
                         }
@@ -514,10 +514,10 @@ define(function (require, exports, module) {
                     if (postScriptStyleName) {
                         styleTitle = this._getPostScriptFontStyle(postScriptStyleName);
                     } else {
-                        styleTitle = strings.STYLE.TYPE.MIXED_STYLE;
+                        styleTitle = nls.localize("strings.STYLE.TYPE.MIXED_STYLE");
                     }
                 } else {
-                    familyName = strings.STYLE.TYPE.MIXED;
+                    familyName = nls.localize("strings.STYLE.TYPE.MIXED");
                     styleTitle = null;
                 }
             } else {
@@ -551,7 +551,7 @@ define(function (require, exports, module) {
                     .toList();
 
             var typeOverlay = function (colorTiny) {
-                if (familyName === strings.STYLE.TYPE.MIXED) {
+                if (familyName === nls.localize("strings.STYLE.TYPE.MIXED")) {
                     var fillStyle = {
                         height: "100%",
                         width: "100%",
@@ -589,7 +589,7 @@ define(function (require, exports, module) {
                 typefaceListID = "typefaces-" + this.props.document.id,
                 weightListID = "weights-" + this.props.document.id,
                 fillClassNames = classnames("formline", {
-                    "mixed-faces": familyName === strings.STYLE.TYPE.MIXED
+                    "mixed-faces": familyName === nls.localize("strings.STYLE.TYPE.MIXED")
                 }),
                 fillBlendFormline;
 
@@ -610,7 +610,7 @@ define(function (require, exports, module) {
                                 ref="color"
                                 className="color-picker__type"
                                 context={collection.pluck(this.props.document.layers.selected, "id")}
-                                title={strings.TOOLTIPS.SET_TYPE_COLOR}
+                                title={nls.localize("strings.TOOLTIPS.SET_TYPE_COLOR")}
                                 editable={!this.props.disabled}
                                 defaultValue={colors}
                                 opaque={this.state.opaque}
@@ -629,8 +629,8 @@ define(function (require, exports, module) {
                             <Label
                                 size="column-4"
                                 className={"label__medium__left-aligned"}
-                                title={strings.TOOLTIPS.SET_OPACITY}>
-                                {strings.STYLE.OPACITY}
+                                title={nls.localize("strings.TOOLTIPS.SET_OPACITY")}>
+                                {nls.localize("strings.STYLE.OPACITY")}
                             </Label>
                             <Opacity
                                 document={this.props.document}
@@ -690,35 +690,35 @@ define(function (require, exports, module) {
                                     className={"split-button__item__fixed"}
                                     selected={alignment === "left"}
                                     onClick={this._handleAlignmentChange.bind(this, textLayer.alignmentTypes.LEFT)}
-                                    title={strings.TOOLTIPS.ALIGN_TYPE_LEFT} />
+                                    title={nls.localize("strings.TOOLTIPS.ALIGN_TYPE_LEFT")} />
                                 <SplitButtonItem
                                     disabled={locked}
                                     iconId="text-center"
                                     className={"split-button__item__fixed"}
                                     selected={alignment === "center"}
                                     onClick={this._handleAlignmentChange.bind(this, textLayer.alignmentTypes.CENTER)}
-                                    title={strings.TOOLTIPS.ALIGN_TYPE_CENTER} />
+                                    title={nls.localize("strings.TOOLTIPS.ALIGN_TYPE_CENTER")} />
                                 <SplitButtonItem
                                     disabled={locked}
                                     iconId="text-right"
                                     className={"split-button__item__fixed"}
                                     selected={alignment === "right"}
                                     onClick={this._handleAlignmentChange.bind(this, textLayer.alignmentTypes.RIGHT)}
-                                    title={strings.TOOLTIPS.ALIGN_TYPE_RIGHT} />
+                                    title={nls.localize("strings.TOOLTIPS.ALIGN_TYPE_RIGHT")} />
                                 <SplitButtonItem
                                     disabled={locked || !box}
                                     iconId="text-justified"
                                     className={"split-button__item__fixed"}
                                     selected={alignment === "justifyAll"}
                                     onClick={this._handleAlignmentChange.bind(this, textLayer.alignmentTypes.JUSTIFY)}
-                                    title={strings.TOOLTIPS.ALIGN_TYPE_JUSTIFIED} />
+                                    title={nls.localize("strings.TOOLTIPS.ALIGN_TYPE_JUSTIFIED")} />
                             </SplitButtonList>
                         </div>
                         <div className="control-group">
                             <Label
                                 size="column-2"
                                 disabled={locked}
-                                title={strings.TOOLTIPS.SET_LETTERSPACING}>
+                                title={nls.localize("strings.TOOLTIPS.SET_LETTERSPACING")}>
                                 <SVGIcon CSSID="text-tracking" />
                             </Label>
                             <NumberInput
@@ -734,7 +734,7 @@ define(function (require, exports, module) {
                             <Label
                                 size="column-2"
                                 disabled={locked}
-                                title={strings.TOOLTIPS.SET_LINESPACING}>
+                                title={nls.localize("strings.TOOLTIPS.SET_LINESPACING")}>
                                 <SVGIcon CSSID="text-leading" />
                             </Label>
                             <NumberInput
@@ -744,7 +744,7 @@ define(function (require, exports, module) {
                                 min={toPixels(MIN_LEADING_PTS)}
                                 max={toPixels(MAX_LEADING_PTS)}
                                 disabled={locked}
-                                special={strings.STYLE.TYPE.AUTO_LEADING}
+                                special={nls.localize("strings.STYLE.TYPE.AUTO_LEADING")}
                                 onChange={this._handleLeadingChange}
                                 valueType="size" />
                         </div>

--- a/src/js/jsx/sections/style/UnsupportedEffectList.jsx
+++ b/src/js/jsx/sections/style/UnsupportedEffectList.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
 
     var ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var UnsupportedEffectList = React.createClass({
         mixins: [FluxMixin],
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
                 
                 effectsContent = (
                     <div className="effect-list__list-container__mixed">
-                        {strings.STYLE.UNSUPPORTED_EFFECTS.MIXED}
+                        {nls.localize("strings.STYLE.UNSUPPORTED_EFFECTS.MIXED")}
                     </div>
                 );
             } else {
@@ -97,9 +97,11 @@ define(function (require, exports, module) {
                     
                     return effects.map(function (effect, effectIndex) {
                         var effectStringKey = _.snakeCase(effectType).toUpperCase(),
-                            effectName = strings.STYLE.UNSUPPORTED_EFFECTS.NAMES[effectStringKey],
-                            toggleBtnTitle = strings.TOOLTIPS.TOGGLE_LAYER_EFFECT.replace("%s", effectName),
-                            deleteBtnTitle = strings.TOOLTIPS.DELETE_LAYER_EFFECT.replace("%s", effectName);
+                            effectName = nls.localize("strings.STYLE.UNSUPPORTED_EFFECTS.NAMES." + effectStringKey),
+                            toggleBtnTitle = nls.localize("strings.TOOLTIPS.TOGGLE_LAYER_EFFECT")
+                                .replace("%s", effectName),
+                            deleteBtnTitle = nls.localize("strings.TOOLTIPS.DELETE_LAYER_EFFECT")
+                                .replace("%s", effectName);
                             
                         return {
                             type: effectType,
@@ -167,7 +169,7 @@ define(function (require, exports, module) {
                 <div className="unsupported-effect-list effect-list__container">
                     <header className="section-header section-header__no-padding">
                         <h3 className="section-title__subtitle">
-                            {strings.STYLE.UNSUPPORTED_EFFECTS.TITLE}
+                            {nls.localize("strings.STYLE.UNSUPPORTED_EFFECTS.TITLE")}
                         </h3>
                     </header>
                     {effectsContent}

--- a/src/js/jsx/sections/style/Vector.jsx
+++ b/src/js/jsx/sections/style/Vector.jsx
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
     var React = require("react");
 
     var Gutter = require("jsx!js/jsx/shared/Gutter"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         Combine = require("jsx!./Combine"),
         Radius = require("jsx!./Radius");
 
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
                 <div>
                     <header className="sub-header">
                         <h3>
-                            {strings.STYLE.VECTOR.TITLE}
+                            {nls.localize("strings.STYLE.VECTOR.TITLE")}
                         </h3>
                         <Gutter />
                         <hr className="sub-header-rule" />

--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         FillColor = Fill.FillColor,
         FillVisiblity = Fill.FillVisibility,
         Label = require("jsx!js/jsx/shared/Label"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         classnames = require("classnames");
 
@@ -152,8 +152,8 @@ define(function (require, exports, module) {
                         <Label
                             size="column-4"
                             className={opacityLabelClasses}
-                            title={strings.TOOLTIPS.SET_OPACITY}>
-                            {strings.STYLE.OPACITY}
+                            title={nls.localize("strings.TOOLTIPS.SET_OPACITY")}>
+                            {nls.localize("strings.STYLE.OPACITY")}
                         </Label>
                         <Opacity
                             document={this.props.document}

--- a/src/js/jsx/sections/transform/AlignDistribute.jsx
+++ b/src/js/jsx/sections/transform/AlignDistribute.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     var SplitButton = require("jsx!js/jsx/shared/SplitButton"),
         SplitButtonList = SplitButton.SplitButtonList,
         SplitButtonItem = SplitButton.SplitButtonItem,
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var AlignDistribute = React.createClass({
         mixins: [FluxMixin],
@@ -204,49 +204,49 @@ define(function (require, exports, module) {
                 <div className="header-alignment">
                     <SplitButtonList>
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.DISTRIBUTE_HORIZONTALLY}
+                            title={nls.localize("strings.TOOLTIPS.DISTRIBUTE_HORIZONTALLY")}
                             className="button-align-distribute"
                             iconId="distribute-horizontally"
                             disabled={distributeDisabled}
                             onClick={this._distributeX} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.DISTRIBUTE_VERTICALLY}
+                            title={nls.localize("strings.TOOLTIPS.DISTRIBUTE_VERTICALLY")}
                             className="button-align-distribute"
                             iconId="distribute-vertically"
                             disabled={distributeDisabled}
                             onClick={this._distributeY} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_LEFT}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_LEFT")}
                             className="button-align-distribute"
                             iconId="align-left"
                             disabled={alignDisabled}
                             onClick={this._alignLeft} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_CENTER}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_CENTER")}
                             className="button-align-distribute"
                             iconId="align-center"
                             disabled={alignDisabled}
                             onClick={this._alignHCenter} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_RIGHT}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_RIGHT")}
                             className="button-align-distribute"
                             iconId="align-right"
                             disabled={alignDisabled}
                             onClick={this._alignRight} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_TOP}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_TOP")}
                             className="button-align-distribute"
                             iconId="align-top"
                             disabled={alignDisabled}
                             onClick={this._alignTop} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_MIDDLE}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_MIDDLE")}
                             className="button-align-distribute"
                             iconId="align-middle"
                             disabled={alignDisabled}
                             onClick={this._alignVCenter} />
                         <SplitButtonItem
-                            title={strings.TOOLTIPS.ALIGN_BOTTOM}
+                            title={nls.localize("strings.TOOLTIPS.ALIGN_BOTTOM")}
                             className="button-align-distribute"
                             iconId="align-bottom"
                             disabled={alignDisabled}

--- a/src/js/jsx/sections/transform/Combine.jsx
+++ b/src/js/jsx/sections/transform/Combine.jsx
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     var SplitButton = require("jsx!js/jsx/shared/SplitButton"),
         SplitButtonList = SplitButton.SplitButtonList,
         SplitButtonItem = SplitButton.SplitButtonItem,
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     var Combine = React.createClass({
@@ -98,25 +98,25 @@ define(function (require, exports, module) {
                         disabled={disabled}
                         onClick={this._combineUnion}
                         onFocus={this.props.onFocus}
-                        title={strings.TOOLTIPS.UNITE_SHAPE} />
+                        title={nls.localize("strings.TOOLTIPS.UNITE_SHAPE")} />
                     <SplitButtonItem
                         iconId="xor-subtract"
                         disabled={disabled}
                         onClick={this._combineSubtract}
                         onFocus={this.props.onFocus}
-                        title={strings.TOOLTIPS.SUBTRACT_SHAPE} />
+                        title={nls.localize("strings.TOOLTIPS.SUBTRACT_SHAPE")} />
                     <SplitButtonItem
                         iconId="xor-intersect"
                         disabled={disabled}
                         onClick={this._combineIntersect}
                         onFocus={this.props.onFocus}
-                        title={strings.TOOLTIPS.INTERSECT_SHAPE} />
+                        title={nls.localize("strings.TOOLTIPS.INTERSECT_SHAPE")} />
                     <SplitButtonItem
                         iconId="xor-difference"
                         disabled={disabled}
                         onClick={this._combineDifference}
                         onFocus={this.props.onFocus}
-                        title={strings.TOOLTIPS.DIFFERENCE_SHAPE} />
+                        title={nls.localize("strings.TOOLTIPS.DIFFERENCE_SHAPE")} />
                 </SplitButtonList>
             );
         }

--- a/src/js/jsx/sections/transform/Flip.jsx
+++ b/src/js/jsx/sections/transform/Flip.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         SplitButtonList = SplitButton.SplitButtonList,
         SplitButtonItem = SplitButton.SplitButtonItem,
         headlights = require("js/util/headlights"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var Flip = React.createClass({
         mixins: [FluxMixin],
@@ -168,19 +168,19 @@ define(function (require, exports, module) {
             return (
                 <SplitButtonList className="button-radio__fixed" size="column-10">
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.FLIP_HORIZONTAL}
+                        title={nls.localize("strings.TOOLTIPS.FLIP_HORIZONTAL")}
                         iconId="flip-horizontal"
                         selected={false}
                         disabled={flipDisabled}
                         onClick={this._flipX} />
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.FLIP_VERTICAL}
+                        title={nls.localize("strings.TOOLTIPS.FLIP_VERTICAL")}
                         iconId="flip-vertical"
                         selected={false}
                         disabled={flipDisabled}
                         onClick={this._flipY} />
                     <SplitButtonItem
-                        title={strings.TOOLTIPS.SWAP_POSITION}
+                        title={nls.localize("strings.TOOLTIPS.SWAP_POSITION")}
                         iconId="swap"
                         selected={false}
                         disabled={swapDisabled}

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     var Gutter = require("jsx!js/jsx/shared/Gutter"),
         Label = require("jsx!js/jsx/shared/Label"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         uiUtil = require("js/util/ui");
 
@@ -148,10 +148,10 @@ define(function (require, exports, module) {
             return (
                 <div className="control-group__horizontal">
                     <Label
-                        title={strings.TOOLTIPS.SET_X_POSITION}
+                        title={nls.localize("strings.TOOLTIPS.SET_X_POSITION")}
                         className="label__medium__left-aligned"
                         size="column-1">
-                        {strings.TRANSFORM.X}
+                        {nls.localize("strings.TRANSFORM.X")}
                     </Label>
                     <NumberInput
                         disabled={disabled}
@@ -164,10 +164,10 @@ define(function (require, exports, module) {
                     <Gutter
                         size="column-4" />
                     <Label
-                        title={strings.TOOLTIPS.SET_Y_POSITION}
+                        title={nls.localize("strings.TOOLTIPS.SET_Y_POSITION")}
                         className="label__medium__left-aligned"
                         size="column-1">
-                        {strings.TRANSFORM.Y}
+                        {nls.localize("strings.TRANSFORM.Y")}
                     </Label>
                     <NumberInput
                         disabled={disabled}

--- a/src/js/jsx/sections/transform/Rotate.jsx
+++ b/src/js/jsx/sections/transform/Rotate.jsx
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     var NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         Label = require("jsx!js/jsx/shared/Label"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var Rotate = React.createClass({
         mixins: [FluxMixin],
@@ -149,7 +149,7 @@ define(function (require, exports, module) {
                 <div className="control-group">
                     <Label
                         size="column-3"
-                        title={strings.TOOLTIPS.SET_ROTATION}>
+                        title={nls.localize("strings.TOOLTIPS.SET_ROTATION")}>
                         <SVGIcon CSSID="rotation" />
                     </Label>
                     <NumberInput

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Label = require("jsx!js/jsx/shared/Label"),
         NumberInput = require("jsx!js/jsx/shared/NumberInput"),
         ToggleButton = require("jsx!js/jsx/shared/ToggleButton"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     var MAX_LAYER_SIZE = 32000,
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
                     <ToggleButton
                         size="column-4"
                         buttonType={disconnectedClass}
-                        title={strings.TOOLTIPS.LOCK_PROPORTIONAL_TRANSFORM}
+                        title={nls.localize("strings.TOOLTIPS.LOCK_PROPORTIONAL_TRANSFORM")}
                         selected={proportional}
                         selectedButtonType = {connectedClass}
                         onClick={this._handleProportionChange} />
@@ -203,10 +203,10 @@ define(function (require, exports, module) {
             return (
                 <div className="control-group__horizontal">
                     <Label
-                        title={strings.TOOLTIPS.SET_WIDTH}
+                        title={nls.localize("strings.TOOLTIPS.SET_WIDTH")}
                         className="label__medium__left-aligned"
                         size="column-1">
-                        {strings.TRANSFORM.W}
+                        {nls.localize("strings.TRANSFORM.W")}
                     </Label>
                     <NumberInput
                         disabled={disabled}
@@ -221,8 +221,8 @@ define(function (require, exports, module) {
                     <Label
                         size="column-1"
                         className="label__medium__left-aligned"
-                        title={strings.TOOLTIPS.SET_HEIGHT}>
-                        {strings.TRANSFORM.H}
+                        title={nls.localize("strings.TOOLTIPS.SET_HEIGHT")}>
+                        {nls.localize("strings.TRANSFORM.H")}
                     </Label>
                     <div className="column-6">
                     <NumberInput

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
         Rotate = require("jsx!./Rotate"),
         Combine = require("jsx!./Combine"),
         Flip = require("jsx!./Flip"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var TransformPanel = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("ui")],
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
                     });
                 };
 
-            var referencePointTooltip = strings.TOOLTIPS.REFERENCE_POINT_TOOL;
+            var referencePointTooltip = nls.localize("strings.TOOLTIPS.REFERENCE_POINT_TOOL");
 
             return (
                 <section className={sectionClasses}>

--- a/src/js/jsx/shared/Carousel.jsx
+++ b/src/js/jsx/shared/Carousel.jsx
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     var synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         SVGIcon = require("jsx!js/jsx/shared/SVGIcon"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     /**
     * Storing the English file names manually otherwise in different languages, the SVGs cannot be found
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
                                 onClick={this._gotoItem.bind(this, idx, this.state.index)}>
                                 <SVGIcon
                                     CSSID={ICON_NAMES[idx]} />
-                                <h3>{strings.FIRST_LAUNCH.SLIDES[idx].TITLE}</h3>
+                                <h3>{nls.localize("strings.FIRST_LAUNCH.SLIDES." + idx + ".TITLE")}</h3>
                             </a>
                         );
                     }
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
                     <a
                         className="carousel__slide-button__continue"
                         onClick={this._gotoItem.bind(this, 1, 0)}>
-                        {strings.FIRST_LAUNCH.CONTINUE}
+                        {nls.localize("strings.FIRST_LAUNCH.CONTINUE")}
                     </a>
                 );
             }

--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         Dialog = require("jsx!js/jsx/shared/Dialog"),
         ColorPicker = require("jsx!js/jsx/shared/ColorPicker"),
         Color = require("js/models/color"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         collection = require("js/util/collection");
 
     /**
@@ -337,7 +337,7 @@ define(function (require, exports, module) {
                     label = colorTiny.toString(this.state.format);
                 }
             } else {
-                label = strings.TRANSFORM.MIXED;
+                label = nls.localize("strings.TRANSFORM.MIXED");
                 mixed = true;
 
                 // The colors aren't completely uniform, but maybe the opaque colors are?

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
         Gutter = require("jsx!js/jsx/shared/Gutter"),
         headlights = require("js/util/headlights");
     
-    var strings = require("i18n!nls/strings");
+    var nls = require("js/util/nls");
 
     /**
      * The list of valid color expression types.
@@ -728,7 +728,7 @@ define(function (require, exports, module) {
                 <div className="color-picker__rgbhsb">
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.RGB_MODEL.R}
+                            {nls.localize("strings.COLOR_PICKER.RGB_MODEL.R")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -740,7 +740,7 @@ define(function (require, exports, module) {
                     </div>
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.RGB_MODEL.G}
+                            {nls.localize("strings.COLOR_PICKER.RGB_MODEL.G")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -752,7 +752,7 @@ define(function (require, exports, module) {
                     </div>
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.RGB_MODEL.B}
+                            {nls.localize("strings.COLOR_PICKER.RGB_MODEL.B")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -764,7 +764,7 @@ define(function (require, exports, module) {
                     </div>
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.HSB_MODEL.H}
+                            {nls.localize("strings.COLOR_PICKER.HSB_MODEL.H")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -776,7 +776,7 @@ define(function (require, exports, module) {
                     </div>
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.HSB_MODEL.S}
+                            {nls.localize("strings.COLOR_PICKER.HSB_MODEL.S")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -788,7 +788,7 @@ define(function (require, exports, module) {
                     </div>
                     <div className="formline">
                         <Label>
-                            {strings.COLOR_PICKER.HSB_MODEL.B}
+                            {nls.localize("strings.COLOR_PICKER.HSB_MODEL.B")}
                         </Label>
                         <NumberInput
                             disabled={this.props.disabled}
@@ -1075,8 +1075,8 @@ define(function (require, exports, module) {
                     </div>
                     <div className="slider_label">
                         <Label
-                            title={strings.COLOR_PICKER.OPACITY}>
-                            {strings.COLOR_PICKER.OPACITY}
+                            title={nls.localize("strings.COLOR_PICKER.OPACITY")}>
+                            {nls.localize("strings.COLOR_PICKER.OPACITY")}
                         </Label>
                         <NumberInput
                             size="column-5"

--- a/src/js/jsx/shared/Range.jsx
+++ b/src/js/jsx/shared/Range.jsx
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Immutable = require("immutable");
 
     var collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
 
     var Range = React.createClass({
         propTypes: {
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
 
             return (
                 <div
-                    title={strings.TOOLTIPS.SET_RADIUS_SLIDER}
+                    title={nls.localize("strings.TOOLTIPS.SET_RADIUS_SLIDER")}
                     className={size}>
                     <input
                         {...this.props}

--- a/src/js/jsx/shared/TitleHeader.jsx
+++ b/src/js/jsx/shared/TitleHeader.jsx
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         classnames = require("classnames");
 
     var TitleHeader = React.createClass({
@@ -43,9 +43,9 @@ define(function (require, exports, module) {
 
             if (this.props.onDoubleClick && !this.props.disabled) {
                 if (this.props.visible) {
-                    workingTitle += strings.TOOLTIPS.SECTION_COLLAPSE;
+                    workingTitle += nls.localize("strings.TOOLTIPS.SECTION_COLLAPSE");
                 } else {
-                    workingTitle += strings.TOOLTIPS.SECTION_EXPAND;
+                    workingTitle += nls.localize("strings.TOOLTIPS.SECTION_EXPAND");
                 }
             }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,7 +31,7 @@ define(function (require, exports) {
     var MainCl = require("jsx!js/jsx/Main"),
         FluxController = require("./fluxcontroller"),
         log = require("js/util/log"),
-        strings = require("i18n!nls/strings"),
+        nls = require("js/util/nls"),
         global = require("js/util/global");
 
     /**
@@ -58,7 +58,7 @@ define(function (require, exports) {
         if (global.debug) {
             shutdown();
         } else {
-            var dialogMessage = strings.ERR.UNRECOVERABLE;
+            var dialogMessage = nls.localize("strings.ERR.UNRECOVERABLE");
             adapter.abort({ message: dialogMessage }, function (err) {
                 var message = err instanceof Error ? (err.stack || err.message) : err;
 

--- a/src/js/models/menuitem.js
+++ b/src/js/models/menuitem.js
@@ -103,14 +103,14 @@ define(function (require, exports, module) {
 
     /**
      * Get a localized label for the given menu entry ID
-     * Helper to nls.localize, prepending "menus." to the menu item ID
+     * Helper to nls.localize, prepending "menu." to the menu item ID
      *
      * @private
      * @param {string} id
      * @return {string|Object.<string, string>}
      */
     var _getLabelForEntry = function (id) {
-        return nls.localize("menus." + id);
+        return nls.localize("menu." + id);
     };
 
     /**

--- a/src/js/models/menuitem.js
+++ b/src/js/models/menuitem.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
 
     var UI = require("adapter").ps.ui;
 
-    var menuLabels = require("i18n!nls/menu"),
+    var nls = require("js/util/nls"),
         keyutil = require("js/util/key"),
         global = require("js/util/global");
     
@@ -103,24 +103,14 @@ define(function (require, exports, module) {
 
     /**
      * Get a localized label for the given menu entry ID
+     * Helper to nls.localize, prepending "menus." to the menu item ID
      *
      * @private
      * @param {string} id
      * @return {string|Object.<string, string>}
      */
     var _getLabelForEntry = function (id) {
-        var parts = id.split("."),
-            labels = menuLabels;
-
-        parts.forEach(function (part) {
-            if (!labels.hasOwnProperty(part)) {
-                throw new Error("Missing label for menu entry: " + id);
-            }
-
-            labels = labels[part];
-        });
-
-        return labels;
+        return nls.localize("menus." + id);
     };
 
     /**

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
         mathUtil = require("js/util/math"),
         pathUtil = require("js/util/path"),
         collection = require("js/util/collection"),
-        strings = require("i18n!nls/strings");
+        nls = require("js/util/nls");
     
     /**
      * Strings for labeling search options
@@ -57,8 +57,8 @@ define(function (require, exports, module) {
      * @const
      * @type {object} 
     */
-    var CATEGORIES = strings.SEARCH.CATEGORIES,
-        HEADERS = strings.SEARCH.HEADERS;
+    var CATEGORIES = nls.localize("strings.SEARCH.CATEGORIES"),
+        HEADERS = nls.localize("strings.SEARCH.HEADERS");
 
     /**
      * Unique identifier for the Search Dialog

--- a/src/js/util/libraries.js
+++ b/src/js/util/libraries.js
@@ -28,7 +28,7 @@ define(function (require, exports) {
     var tinycolor = require("tinycolor"),
         _ = require("lodash");
         
-    var strings = require("i18n!nls/strings"),
+    var nls = require("js/util/nls"),
         libraryActions = require("js/actions/libraries");
     
     var _REPRESENTATION_TO_EXTENSION_MAP;
@@ -106,12 +106,12 @@ define(function (require, exports) {
                     var leading;
                     
                     if (style && style.adbeAutoLeading) {
-                        leading = strings.LIBRARIES.LEADING_AUTO;
+                        leading = nls.localize("strings.LIBRARIES.LEADING_AUTO");
                     } else if (style && style.lineHeight && style.lineHeight.value) {
                         leading = (Math.round(style.lineHeight.value * 100) / 100) + style.lineHeight.type;
                     }
                     
-                    return leading ? strings.LIBRARIES.LEADING.replace("%s", leading) : null;
+                    return leading ? nls.localize("strings.LIBRARIES.LEADING").replace("%s", leading) : null;
                 
                 case "tracking":
                     var tracking;
@@ -122,7 +122,7 @@ define(function (require, exports) {
                         tracking = style.letterSpacing.value * 1000;
                     }
                     
-                    return tracking ? strings.LIBRARIES.TRACKING.replace("%s", tracking) : null;
+                    return tracking ? nls.localize("strings.LIBRARIES.TRACKING").replace("%s", tracking) : null;
                 
             }
         });

--- a/src/js/util/nls.js
+++ b/src/js/util/nls.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -24,13 +24,19 @@
 define(function (require, exports) {
     "use strict";
 
-    var log = require("js/util/log");
+    var objectUtil = require("js/util/object");
 
-    var dictionaries = {
+    /**
+     * All the dictionaries we use for our strings
+     *
+     * @private
+     * @type {Object}
+     */
+    var _dictionaries = {
         strings: require("i18n!nls/strings"),
-        menus: require("i18n!nls/menu"),
-        macShortcuts: require("i18n!nls/shortcuts-mac"),
-        winShortcuts: require("i18n!nls/shortcuts-win")
+        menu: require("i18n!nls/menu"),
+        "shortcuts-mac": require("i18n!nls/shortcuts-mac"),
+        "shortcuts-win": require("i18n!nls/shortcuts-win")
     };
         
     /**
@@ -38,23 +44,16 @@ define(function (require, exports) {
      * which will help us replace it easily later on
      *
      * @param {string} key of the format [file].[dot-separated-key]
-     *
      * @return {string|Object} Translated, or fallen-back string, or the sub-tree for the ID
      */
     var localize = function (key) {
-        var value = dictionaries;
+        var value = objectUtil.getPath(_dictionaries, key);
 
-        key.split(".").some(function (part) {
-            if (value.hasOwnProperty(part)) {
-                value = value[part];
-            } else {
-                value = null;
-                log.warn("Translation not found for: " + key);
-                return true;
-            }
-        });
-
-        return value;
+        if (!value) {
+            throw new Error("Translation not found for: " + key);
+        } else {
+            return value;
+        }
     };
 
     exports.localize = localize;

--- a/src/js/util/nls.js
+++ b/src/js/util/nls.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var log = require("js/util/log");
+
+    var dictionaries = {
+        strings: require("i18n!nls/strings"),
+        menus: require("i18n!nls/menu"),
+        macShortcuts: require("i18n!nls/shortcuts-mac"),
+        winShortcuts: require("i18n!nls/shortcuts-win")
+    };
+        
+    /**
+     * Thin wrapper around i18n so it's centralized
+     * which will help us replace it easily later on
+     *
+     * @param {string} key of the format [file].[dot-separated-key]
+     *
+     * @return {string|Object} Translated, or fallen-back string, or the sub-tree for the ID
+     */
+    var localize = function (key) {
+        var value = dictionaries;
+
+        key.split(".").some(function (part) {
+            if (value.hasOwnProperty(part)) {
+                value = value[part];
+            } else {
+                value = null;
+                log.warn("Translation not found for: " + key);
+                return true;
+            }
+        });
+
+        return value;
+    };
+
+    exports.localize = localize;
+});

--- a/src/js/util/shortcuts.js
+++ b/src/js/util/shortcuts.js
@@ -27,8 +27,8 @@ define(function (require, exports, module) {
     var system = require("./system"),
         nls = require("js/util/nls");
 
-    var macShortcuts = nls.localize("macShortcuts"),
-        winShortcuts = nls.localize("winShortcuts");
+    var macShortcuts = nls.localize("shortcuts-mac"),
+        winShortcuts = nls.localize("shortcuts-win");
 
     module.exports = system.isMac ? macShortcuts : winShortcuts;
 });

--- a/src/js/util/shortcuts.js
+++ b/src/js/util/shortcuts.js
@@ -25,8 +25,10 @@ define(function (require, exports, module) {
     "use strict";
 
     var system = require("./system"),
-        macShortcuts = require("i18n!nls/shortcuts-mac"),
-        winShortcuts = require("i18n!nls/shortcuts-win");
+        nls = require("js/util/nls");
+
+    var macShortcuts = nls.localize("macShortcuts"),
+        winShortcuts = nls.localize("winShortcuts");
 
     module.exports = system.isMac ? macShortcuts : winShortcuts;
 });


### PR DESCRIPTION
 - Change all i18n!nls/... requires to use js/util/nls
 - All translated strings are now quote wrapped and are passed to nls.localize method


Another side effect of the webpack efforts, centralizing our localization code will help me replace it easier later on.

Usage is pretty similar, instead of requiring the dictionary with `i18n!` prefix, we now use `js/util/nls.localize` function to grab the localized string/tree at any point. 

It touches A LOT of files.. but it should be fairly clean.
