### PR TITLE
Add min/max for opacity slider input

### DIFF
--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -771,7 +771,7 @@ define(function (require, exports, module) {
                             value={Math.round(hsv.h)}
                             onChange={this._handleHSVChange.bind(this, "h")}
                             min={0}
-                            max={359}
+                            max={360}
                             size="column-5" />
                     </div>
                     <div className="formline">
@@ -1082,6 +1082,8 @@ define(function (require, exports, module) {
                             size="column-5"
                             placeholder="100"
                             ref="opacity"
+                            min={0}
+                            max={100}
                             value={Math.round(color.a * 100)}
                             onKeyDown={this._handleKeyDown}
                             onChange={this._handleTransparencyInput}/>


### PR DESCRIPTION
- Fix for issue #3254 
- also increased max for hue to 360, not 359. Which is standard even though 0 and 360 are the same thing