### PR TITLE
Remove a hack around photoshop placeEvent during multiple object placement

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -44,7 +44,6 @@ define(function (require, exports) {
         preferencesActions = require("./preferences"),
         menu = require("./menu"),
         ui = require("./ui"),
-        synchronization = require("js/util/synchronization"),
         events = require("../events"),
         locks = require("js/locks"),
         pathUtil = require("js/util/path"),
@@ -1098,26 +1097,10 @@ define(function (require, exports) {
         }.bind(this);
         descriptor.addListener("paste", _pasteHandler);
 
-        // A debounced version of the place event handler action
-        var debouncedPlaceEvent = synchronization.debounce(this.flux.actions.documents.handlePlaceEvent, this, 200);
-
         // This event is triggered when a new smart object layer is placed,
         // e.g., by dragging an image into an open document.
         _placeEventHandler = function (event) {
-            var layerID = event.ID;
-
-            // If an ID was not supplied, this is one of the first N-1 of N placements (probably via OS drag)
-            // we debounce so as to only call updateDocument once.
-            // This also forces the final placeEvent (which includes an ID)
-            // to occur first, which is desirable so that it won't try
-            // to add the new layer after it is already loaded via the udpateDocument.
-            // This allows effecient handling of single place events, but also tolerant of multi-object placements
-            // despite the core bug that prevents ID from being included in the first N-1 events.
-            if (!layerID) {
-                debouncedPlaceEvent(event);
-            } else {
-                this.flux.actions.documents.handlePlaceEvent(event);
-            }
+            this.flux.actions.documents.handlePlaceEvent(event);
         }.bind(this);
         descriptor.addListener("placeEvent", _placeEventHandler);
 


### PR DESCRIPTION
This is related to watson 4074678 which is fixed as of playground-dev-mac 885.  When dragging two files from the OS into photoshop, previously only one of the subsequent `placeEvent` events would contain the layer ID.  We had a hack in place to fall back on updateDocument in this case. Now the layerID should be included by photoshop, so this PR removes the hack.

Note that in debug mode with post condition validation enabled, placing multiple objects will fail validation of the first N-1 events.  This is a false positive that can be ignored.