### PR TITLE
Load guides lazily if they're not initially visible

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -191,16 +191,22 @@ define(function (require, exports) {
      * Get an array of guide descriptors for the given document descriptor.
      *
      * @private
-     * @param {object} doc Document descriptor
+     * @param {object|number} docSpec Document descriptor or document ID
      * @return {Promise.<Array.<object>>}
      */
-    var _getGuidesForDocument = function (doc) {
-        var docRef = documentLib.referenceBy.id(doc.documentID),
-            numberOfGuides = doc.numberOfGuides;
+    var _getGuidesForDocument = function (docSpec) {
+        var documentID;
+        if (typeof docSpec === "object") {
+            if (docSpec.numberOfGuides === 0) {
+                return Promise.resolve();
+            }
 
-        if (numberOfGuides === 0) {
-            return Promise.resolve([]);
+            documentID = docSpec.documentID;
+        } else {
+            documentID = docSpec;
         }
+
+        var docRef = documentLib.referenceBy.id(documentID);
 
         return guideActions._getGuidesForDocumentRef(docRef);
     };
@@ -328,15 +334,19 @@ define(function (require, exports) {
                     return;
                 }
 
-                var currentRef = documentLib.referenceBy.current;
-                return _getDocumentByRef(currentRef)
+                var currentRef = documentLib.referenceBy.current,
+                    documentPromise = _getDocumentByRef(currentRef),
+                    deselectPromise = descriptor.playObject(selectionLib.deselectAll());
+
+                return documentPromise
                     .bind(this)
                     .then(function (currentDoc) {
                         var currentDocLayersPromise = _getLayersForDocument(currentDoc),
                             historyPromise = this.transfer(historyActions.queryCurrentHistory,
                                 currentDoc.documentID, true),
-                            guidesPromise = _getGuidesForDocument(currentDoc),
-                            deselectPromise = descriptor.playObject(selectionLib.deselectAll());
+                            // Load guides lazily if they're not currently visible
+                            guidesVisible = currentDoc.guidesVisibility,
+                            guidesPromise = guidesVisible ? _getGuidesForDocument(currentDoc) : Promise.resolve();
 
                         return Promise.join(currentDocLayersPromise,
                             historyPromise,
@@ -345,7 +355,7 @@ define(function (require, exports) {
                             function (payload, historyPayload, guidesPayload) {
                                 payload.current = true;
                                 payload.history = historyPayload;
-                                payload.guides = guidesPayload;
+                                payload.guides = guidesPayload || (guidesVisible && []);
                                 this.dispatch(events.document.DOCUMENT_UPDATED, payload);
                                 this.dispatch(events.application.INITIALIZED, { item: "activeDocument" });
                             }.bind(this))
@@ -399,13 +409,15 @@ define(function (require, exports) {
                     historyPromise = current ?
                         this.transfer(historyActions.queryCurrentHistory, doc.documentID, true) :
                         Promise.resolve(null),
-                    guidesPromise = current ? _getGuidesForDocument(doc) : Promise.resolve();
+                    // Load guides lazily if they're not currently visible
+                    guidesVisible = current && doc.guidesVisibility,
+                    guidesPromise = guidesVisible ? _getGuidesForDocument(doc) : Promise.resolve();
 
                 return Promise.join(layersPromise, historyPromise, guidesPromise,
                     function (payload, historyPayload, guidesPayload) {
                         payload.current = current;
                         payload.history = historyPayload;
-                        payload.guides = guidesPayload;
+                        payload.guides = guidesPayload || (guidesVisible && []);
                         return this.dispatchAsync(events.document.DOCUMENT_UPDATED, payload);
                     }.bind(this));
             });
@@ -863,8 +875,23 @@ define(function (require, exports) {
         }
 
         var newVisibility = !document.guidesVisible,
-            dispatchPromise = this.dispatchAsync(events.document.GUIDES_VISIBILITY_CHANGED,
-                { documentID: document.id, guidesVisible: newVisibility });
+            guideInitPromise;
+
+        if (newVisibility && !document.guides) {
+            guideInitPromise = _getGuidesForDocument(document.id);
+        } else {
+            guideInitPromise = Promise.resolve();
+        }
+
+        var dispatchPromise = guideInitPromise
+            .bind(this)
+            .then(function (guides) {
+                this.dispatch(events.document.GUIDES_VISIBILITY_CHANGED, {
+                    documentID: document.id,
+                    guidesVisible: newVisibility,
+                    guides: guides
+                });
+            });
 
         var playObject = documentLib.setGuidesVisibility(newVisibility),
             playPromise = descriptor.playObject(playObject);

--- a/src/js/models/document.js
+++ b/src/js/models/document.js
@@ -151,8 +151,10 @@ define(function (require, exports, module) {
         model.smartGuidesVisible = documentDescriptor.smartGuidesVisibility;
         model.bounds = Bounds.fromDocumentDescriptor(documentDescriptor);
         model.layers = layerDescriptors && LayerStructure.fromDescriptors(documentDescriptor, layerDescriptors);
-        model.guides = guideDescriptors ? Guide.fromDescriptors(documentDescriptor, guideDescriptors) :
-            Immutable.List();
+
+        if (guideDescriptors) {
+            model.guides = Guide.fromDescriptors(documentDescriptor, guideDescriptors);
+        }
 
         if (documentDescriptor.format) {
             model.format = documentDescriptor.format;

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
                 !document.unsupported,
             "have-guides":
                 (document !== null) &&
-                !document.guides.isEmpty(),
+                (document.guides && !document.guides.isEmpty()),
             "export-enabled":
                 (document !== null) && exportEnabled,
             "psd-document":

--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -282,15 +282,24 @@ define(function (require, exports, module) {
          * Update the visibility of a document's guides or smart guides
          *
          * @private
-         * @param {{documentID: number, guidesVisible: boolean, smartGuidesVisible: boolean=}} payload
+         * @param {object} payload
+         * @param {number} payload.documentID
+         * @param {boolean} payload.guidesVisible
+         * @param {boolean} payload.smartGuidesVisible
+         * @param {Array.<object>=} payload.guides
          */
         _updateDocumentGuidesVisibility: function (payload) {
             var documentID = payload.documentID,
                 props = _.pick(payload, ["guidesVisible", "smartGuidesVisible"]),
                 document = this._openDocuments[documentID],
-                nextDocument = document.merge(props);
+                nextDocument = document.merge(props),
+                guides = payload.guides;
 
-            this.setDocument(nextDocument);
+            this.setDocument(nextDocument, false, !!guides);
+
+            if (guides) {
+                this._handleGuidesUpdated(payload);
+            }
         },
 
         /**
@@ -1069,10 +1078,10 @@ define(function (require, exports, module) {
          * Updates the overall guides information of the document
          *
          * @private
-         * @param {{document: Document, guides: Array.<object>}} payload
+         * @param {{document: Document=, documentID: number=, guides: Array.<object>}} payload
          */
         _handleGuidesUpdated: function (payload) {
-            var document = payload.document,
+            var document = payload.document || this._openDocuments[payload.documentID],
                 guideDescriptors = payload.guides,
                 nextGuides = Guide.fromDescriptors(document, guideDescriptors),
                 nextDocument = document.set("guides", nextGuides);


### PR DESCRIPTION
This PR delays loading guide information until the guides are first made visible. This is a minor performance optimization. Addresses #3231.