### PR TITLE
Prioritize initializing the recent files list when there are no open documents

### DIFF
--- a/src/js/actions/application.js
+++ b/src/js/actions/application.js
@@ -78,7 +78,11 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var afterStartup = function () {
-        var updateRecentFilesPromise = this.transfer(updateRecentFiles),
+        var appStore = this.flux.store("application"),
+            recentFilesInitialized = appStore.getState().recentFilesInitialized,
+            updateRecentFilesPromise = recentFilesInitialized ?
+                Promise.resolve() :
+                this.transfer(updateRecentFiles),
             setRulerUnitsPromise = descriptor.playObject(ruler.setRulerUnits("rulerPixels"));
 
         return Promise.join(setRulerUnitsPromise, updateRecentFilesPromise);

--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -323,9 +323,12 @@ define(function (require, exports) {
             .then(function (documentIDs) {
                 if (documentIDs.length === 0) {
                     this.dispatch(events.application.INITIALIZED, { item: "activeDocument" });
-                    // Updates menu items in cases of no document
-                    this.dispatch(events.menus.UPDATE_MENUS);
-                    return;
+                    return this.transfer("application.updateRecentFiles")
+                        .bind(this)
+                        .then(function () {
+                            // Updates menu items in cases of no document
+                            this.dispatch(events.menus.UPDATE_MENUS);
+                        });
                 }
 
                 var currentRef = documentLib.referenceBy.current;
@@ -369,7 +372,7 @@ define(function (require, exports) {
     initActiveDocument.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC, locks.JS_APP],
-        transfers: [historyActions.queryCurrentHistory, "layers.deselectAll"]
+        transfers: [historyActions.queryCurrentHistory, "layers.deselectAll", "application.updateRecentFiles"]
     };
 
     /**


### PR DESCRIPTION
Currently, we always wait until `application.afterStartup` to initialize the recent files list. But, this initialization blocks the no-doc UI because it relies on that list. This PR changes `documents.initActiveDocument` to transfer to `application.afterStartup` when there are no open documents. This effectively prioritizes loading the recent files list when loading the no-doc UI. This helps get the UI completely drawn slightly faster in this case.

CC @placegraphichere 