### PR TITLE
beforeStartup/afterStartup cleanup

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -1119,8 +1119,8 @@ define(function (require, exports) {
         return this.transfer(initActiveDocument);
     };
     beforeStartup.action = {
-        reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC],
+        reads: [],
+        writes: [],
         transfers: [initActiveDocument]
     };
 

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -2657,6 +2657,23 @@ define(function (require, exports) {
         }.bind(this);
         descriptor.addListener("delete", _deleteHandler);
 
+        return Promise.resolve();
+    };
+    beforeStartup.action = {
+        reads: [],
+        writes: []
+    };
+
+    /**
+     * Send info about layers to search store
+     *
+     * @private
+     * @return {Promise}
+     */
+    var afterStartup = function () {
+        searchActions.registerAllLayerSearch.call(this);
+        searchActions.registerCurrentLayerSearch.call(this);
+
         var deleteFn = function () {
             // Note: shortcuts are executed iff some CEF element does not have focus.
             // In particular, this means that if is no active element but there _is_
@@ -2672,31 +2689,25 @@ define(function (require, exports) {
             }
         }.bind(this);
 
-        var backspacePromise = this.transfer(shortcuts.addShortcut, OS.eventKeyCode.BACKSPACE, {}, deleteFn),
-            deletePromise = this.transfer(shortcuts.addShortcut, OS.eventKeyCode.DELETE, {}, deleteFn);
+        var shortcutSpecs = [
+            {
+                key: OS.eventKeyCode.BACKSPACE,
+                modifiers: {},
+                fn: deleteFn
+            },
+            {
+                key: OS.eventKeyCode.DELETE,
+                modifiers: {},
+                fn: deleteFn
+            }
+        ];
 
-        return Promise.join(backspacePromise, deletePromise);
-    };
-    beforeStartup.action = {
-        reads: [],
-        writes: [locks.JS_SHORTCUT, locks.JS_POLICY, locks.PS_APP],
-        transfers: [shortcuts.addShortcut]
-    };
-
-    /**
-     * Send info about layers to search store
-     *
-     * @private
-     * @return {Promise}
-     */
-    var afterStartup = function () {
-        searchActions.registerAllLayerSearch.call(this);
-        searchActions.registerCurrentLayerSearch.call(this);
-        return Promise.resolve();
+        return this.transfer(shortcuts.addShortcuts, shortcutSpecs);
     };
     afterStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        transfers: [shortcuts.addShortcuts]
     };
 
     /**


### PR DESCRIPTION
What it says! The UI is perfectly usable before these are registered, so it doesn't seem important to delay rendering it until they're registered. Seems to shave 50-100ms off the time-to-UI.

===
Actually, this turned into a more general `beforeStartup`-to-`afterStartup` cleanup, as well as a cleanup of `tools.initTool` and `selectTool`. According to my measurements, this reduces the time to a fully ready to UI by ~700ms.