### PR TITLE
Tap for newHistoryState in libraries.applyLayerStyle

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -933,7 +933,7 @@ define(function (require, exports) {
                 representation.getContentPath(done);
             })
             .bind(this)
-            .then(function () {
+            .tap(function () {
                 return this.transfer(historyActions.newHistoryState, currentDocument.id,
                     nls.localize("strings.ACTIONS.APPLY_LAYER_STYLE"));
             })


### PR DESCRIPTION
We needed the path coming from `representation.getContentPath` to be passed to the next handler. So now we tap to create a new history state instead of `then`ing to it.