### PR TITLE
Async load CCLibraries API using scriptjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,8 @@
     "mathjs": "~2.2.0",
     "react": "~0.13.3",
     "spaces-adapter": "https://github.com/adobe-photoshop/spaces-adapter.git#^0.27.0",
-    "tinycolor": "~1.2.1"
+    "tinycolor": "~1.2.1",
+    "scriptjs": "~2.5.8"
   },
   "devDependencies": {
     "qunit": "~1.19.0",

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -27,7 +27,7 @@ define(function (require, exports) {
     var Promise = require("bluebird"),
         Immutable = require("immutable"),
         _ = require("lodash"),
-        CCLibraries = require("file://shared/libs/cc-libraries-api.min.js");
+        $S = require("scriptjs");
 
     var descriptor = require("adapter").ps.descriptor,
         docAdapter = require("adapter").lib.document,
@@ -57,6 +57,13 @@ define(function (require, exports) {
         preferencesActions = require("./preferences"),
         LibrarySyncStatus = require("js/models/library_sync_status");
 
+    /**
+     * The external CC Libraries API is loaded here asynchronously, used in beforeStartup
+     *
+     * @type {Promise}
+     */
+    var apiLoadPromise = Promise.promisify($S)("file://shared/libs/cc-libraries-api.min.js");
+        
     /**
      * For image elements, their extensions signify their representation type
      *
@@ -1187,7 +1194,8 @@ define(function (require, exports) {
      * @private
      */
     var handleLibrariesLoaded = function () {
-        var libraryCollection = (CCLibraries.getLoadedCollections() || [])[0];
+        var ccLibraries = this.flux.store("library").getLibrariesAPI(),
+            libraryCollection = (ccLibraries.getLoadedCollections() || [])[0];
 
         if (!libraryCollection) {
             searchActions.registerLibrarySearch.call(this, []);
@@ -1239,59 +1247,69 @@ define(function (require, exports) {
     var _toolModalStateChangedHandler;
 
     var beforeStartup = function () {
-        var dependencies = {
-            // Photoshop on startup will grab the port of the CC Library process and expose it to us
-            vulcanCall: function (requestType, requestPayload, responseType, callback) {
-                descriptor.getProperty("application", "designSpaceLibrariesInfo")
-                    .then(function (imsInfo) {
-                        var port = imsInfo.port;
+        apiLoadPromise.bind(this)
+            .then(function () {
+                /* global ccLibraries */
+                // There is now a ccLibraries object in this scope
+                // So we emit that to the store
+                this.dispatch(events.libraries.LIBRARIES_API_LOADED, ccLibraries);
 
-                        callback(JSON.stringify({ port: port }));
-                    });
-            },
-            // Enable and log CC Libraries analytic events
-            // https://git.corp.adobe.com/pages/ProjectCentral/cc-libraries-api-js/tutorial-analytics_example.html
-            analytics: {
-                reportEvent: function (event, properties) {
-                    // elementType: color, characterstyle, layerstyle, graphic
-                    // ("image" type is replaced with "graphic" to keep naming consistency)
-                    var elementType = properties.elementType === "image" ? "graphic" : properties.elementType;
-                    
-                    switch (event) {
-                        case "createLibrary":
-                            headlights.logEvent("libraries", "library", "create");
-                            break;
-                        case "deleteLibrary":
-                            headlights.logEvent("libraries", "library", "delete");
-                            break;
-                        case "createElement":
-                            headlights.logEvent("libraries", "element", ["create", elementType].join("-"));
-                            break;
-                        case "deleteElement":
-                            headlights.logEvent("libraries", "element", ["delete", elementType].join("-"));
-                            break;
-                        case "updateElement":
-                            // updateType: info (rename), representation (update content)
-                            headlights.logEvent("libraries", "element",
-                                ["update", elementType, properties.updateType].join("-"));
-                            break;
+                var dependencies = {
+                    // Photoshop on startup will grab the port of the CC Library process and expose it to us
+                    vulcanCall: function (requestType, requestPayload, responseType, callback) {
+                        descriptor.getProperty("application", "designSpaceLibrariesInfo")
+                            .then(function (imsInfo) {
+                                var port = imsInfo.port;
+
+                                callback(JSON.stringify({ port: port }));
+                            });
+                    },
+                    // Enable and log CC Libraries analytic events
+                    // jscs:disable
+                    // https://git.corp.adobe.com/pages/ProjectCentral/cc-libraries-api-js/tutorial-analytics_example.html
+                    // jscs:enable
+                    analytics: {
+                        reportEvent: function (event, properties) {
+                            // elementType: color, characterstyle, layerstyle, graphic
+                            // ("image" type is replaced with "graphic" to keep naming consistency)
+                            var elementType = properties.elementType === "image" ? "graphic" : properties.elementType;
+                            
+                            switch (event) {
+                                case "createLibrary":
+                                    headlights.logEvent("libraries", "library", "create");
+                                    break;
+                                case "deleteLibrary":
+                                    headlights.logEvent("libraries", "library", "delete");
+                                    break;
+                                case "createElement":
+                                    headlights.logEvent("libraries", "element", ["create", elementType].join("-"));
+                                    break;
+                                case "deleteElement":
+                                    headlights.logEvent("libraries", "element", ["delete", elementType].join("-"));
+                                    break;
+                                case "updateElement":
+                                    // updateType: info (rename), representation (update content)
+                                    headlights.logEvent("libraries", "element",
+                                        ["update", elementType, properties.updateType].join("-"));
+                                    break;
+                            }
+                        }
                     }
-                }
-            }
-        };
+                };
 
-        // SHARED_LOCAL_STORAGE flag forces websocket use
-        CCLibraries.configure(dependencies, {
-            SHARED_LOCAL_STORAGE: true,
-            ELEMENT_TYPE_FILTERS: [
-                ELEMENT_COLOR_TYPE,
-                ELEMENT_GRAPHIC_TYPE,
-                ELEMENT_CHARACTERSTYLE_TYPE,
-                ELEMENT_LAYERSTYLE_TYPE,
-                ELEMENT_BRUSH_TYPE,
-                ELEMENT_COLORTHEME_TYPE
-            ]
-        });
+                // SHARED_LOCAL_STORAGE flag forces websocket use
+                ccLibraries.configure(dependencies, {
+                    SHARED_LOCAL_STORAGE: true,
+                    ELEMENT_TYPE_FILTERS: [
+                        ELEMENT_COLOR_TYPE,
+                        ELEMENT_GRAPHIC_TYPE,
+                        ELEMENT_CHARACTERSTYLE_TYPE,
+                        ELEMENT_LAYERSTYLE_TYPE,
+                        ELEMENT_BRUSH_TYPE,
+                        ELEMENT_COLORTHEME_TYPE
+                    ]
+                });
+            });
 
         _toolModalStateChangedHandler = function (event) {
             var isPlacingGraphic = this.flux.store("library").getState().isPlacingGraphic,
@@ -1303,7 +1321,7 @@ define(function (require, exports) {
         }.bind(this);
         descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);
 
-        return Promise.resolve();
+        return apiLoadPromise;
     };
     beforeStartup.action = {
         reads: [locks.JS_PREF],
@@ -1316,10 +1334,12 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var afterStartup = function () {
+        var ccLibraries = this.flux.store("library").getLibrariesAPI();
+
         // Listen to the load event of CC Libraries. The event has two scenarios:
         //     loaded: Libraries data is ready for use. Fired after user sign in creative cloud.
         //     unloaded: Libraries data is cleared. Fired after user sign out creative cloud.
-        CCLibraries.addLoadedCollectionsListener(handleLibrariesLoaded.bind(this));
+        ccLibraries.addLoadedCollectionsListener(handleLibrariesLoaded.bind(this));
         
         // Triger the load event callback manually for initial start up.
         return (handleLibrariesLoaded.bind(this))();

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -25,8 +25,7 @@ define(function (require, exports) {
     "use strict";
 
     var Promise = require("bluebird"),
-        Immutable = require("immutable"),
-        CCLibraries = require("file://shared/libs/cc-libraries-api.min.js");
+        Immutable = require("immutable");
 
     var descriptor = require("adapter").ps.descriptor,
         layerLib = require("adapter").lib.layer,
@@ -696,7 +695,8 @@ define(function (require, exports) {
      *                                         ready to pass into layerActionsUtil.playLayerActions
      */
     var _getGraphicSampleActions = function (document, source, targets, sourcePath) {
-        var soTypes = source.smartObjectTypes,
+        var librariesAPI = this.flux.store("library").getLibrariesAPI(),
+            soTypes = source.smartObjectTypes,
             sourceType = source.smartObjectType(),
             postActionObj = null,
             resultActions = [];
@@ -747,7 +747,7 @@ define(function (require, exports) {
             targets.forEach(function (target) {
                 var targetType = target.smartObjectType(),
                     reference = source.smartObject.link.elementReference,
-                    element = CCLibraries.resolveElementReference(reference),
+                    element = librariesAPI.resolveElementReference(reference),
                     playObjects = [];
 
                 // PS does not allow CLSO to link to another CLSO, so we embed it first as a work around
@@ -780,7 +780,8 @@ define(function (require, exports) {
      * @return {Promise.<string>} [description]
      */
     var _getSourcePath = function (document, source) {
-        var sourceType = source.smartObjectType();
+        var librariesAPI = this.flux.store("library").getLibrariesAPI(),
+            sourceType = source.smartObjectType();
 
         switch (sourceType) {
         case source.smartObjectTypes.EMBEDDED:
@@ -794,7 +795,7 @@ define(function (require, exports) {
             return Promise.resolve(source.smartObject.link._path);
         case source.smartObjectTypes.CLOUD_LINKED:
             var reference = source.smartObject.link.elementReference,
-                element = CCLibraries.resolveElementReference(reference),
+                element = librariesAPI.resolveElementReference(reference),
                 representation = element.getPrimaryRepresentation();
 
             return Promise.fromNode(function (cb) {
@@ -827,7 +828,7 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
-        return _getSourcePath(document, source)
+        return _getSourcePath.call(this, document, source)
             .bind(this)
             .tap(function () {
                 return this.transfer(historyActions.newHistoryState, document.id,
@@ -847,7 +848,7 @@ define(function (require, exports) {
                             suppressHistoryStateNotification: false
                         }
                     },
-                    replaceActions = _getGraphicSampleActions(document, source, targets, path);
+                    replaceActions = _getGraphicSampleActions.call(this, document, source, targets, path);
 
                 return layerActionsUtil.playLayerActions(document, replaceActions, true, options);
             })

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -163,6 +163,7 @@ define(function (require, exports, module) {
             DELETE_DOCUMENT_HISTORY: "deleteDocumentHistory"
         },
         libraries: {
+            LIBRARIES_API_LOADED: "librariesAPILoaded",
             LIBRARIES_LOADED: "librariesLoaded",
             LIBRARIES_UNLOADED: "librariesUnloaded",
             ASSET_CREATED: "libraryAssetCreated",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,16 +101,14 @@ var buildConfigs = languages.map(function (lang) {
             alias: {
                 // Until spaces-adapter is better built and points to it's main.js in it's package.json
                 "adapter": path.join(__dirname, "/bower_components/spaces-adapter/src/main.js"),
+                "scriptjs": path.join(__dirname, "/bower_components/scriptjs/dist/script.js"),
                 // Eventually clean all this up and use "events" that node provides to webpack
                 // But that requires some code changes too (emitEvent => emit)
                 "eventEmitter": path.join(__dirname, "/node_modules/wolfy87-eventemitter/EventEmitter.js"),
                 // TODO: Look into externalizing React, or see if React 0.14 is plausible
                 "react": path.join(__dirname, "/bower_components/react/react-with-addons.js"),
                 // We alias the localization here (@/src/js/util/nls.js)
-                "nls/dictionary.json": path.join(__dirname, "/src/nls/" + lang + ".json"),
-                // Since there is no dynamic loading of these external files
-                // they need to be copied to src/vendor
-                "file://shared": path.join(__dirname, "/src/vendor")
+                "nls/dictionary.json": path.join(__dirname, "/src/nls/" + lang + ".json")
             },
             extensions: ["", ".js", ".jsx", ".json", ".less"]
         },


### PR DESCRIPTION
This solves the problem of having to copy www-shared/libs into src/vendor/libs by using async loader https://github.com/ded/script.js/

We now load it at libraries.beforeStartup asynchronously, and pass it to the library store so it's available through runtime without requiring again.

Another solution for this would be to use scriptjs at init.js and keep a global object, but this seems cleaner.

This is a PR into architecture/webpack, but I wanted to get some eyes on it separately. @iwehrman and @shaoshing in particular.