### PR TITLE
Color Picker and Color Swatch UI improvements

### DIFF
--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
 
             return (
                 <div className={colorOverlayClasses}>
-                    <div className="formline formline__no-padding">
+                    <div className="formline formline__no-padding formline__space-between">
                         <div className="control-group control-group__vertical">
                             <ColorInput
                                 id={colorInputID}

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -346,7 +346,7 @@ define(function (require, exports) {
 
             return (
                 <div className={shadowClasses}>
-                    <div className="formline formline__no-padding">
+                    <div className="formline formline__no-padding formline__space-between">
                         <div className="control-group control-group__vertical">
                             <ColorInput
                                 id={colorInputID}

--- a/src/js/jsx/sections/style/Stroke.jsx
+++ b/src/js/jsx/sections/style/Stroke.jsx
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
                     size="column-2" />);
 
             return (
-                <div className="formline">
+                <div className="formline formline__space-between">
                     <div className="control-group__vertical">
                         <ColorInput
                             id={colorInputID}

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
 
             return (
                 <div className={strokesClasses}>
-                    <div className="formline formline__no-padding">
+                    <div className="formline formline__no-padding formline__space-between">
                         <div className="control-group control-group__vertical">
                             <ColorInput
                                 id={colorInputID}

--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
                     fill={this.state.fill} />);
             
             return (
-                <div className="formline">
+                <div className="formline formline__space-between">
                     <div className="control-group__vertical vector-fill">
                         <FillColor
                             disabled={!this.props.uniformLayerKind}

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -328,7 +328,7 @@ define(function (require, exports, module) {
             if (this.props.hasOwnProperty("color")) {
                 // this is an alpha slider
                 var bgColor = tinycolor(this.props.color.toJS()).toHexString(),
-                    bgGradient = "linear-gradient(to right, rgba(1, 1, 1, 0) 0%, " + bgColor + " 100%)";
+                    bgGradient = "linear-gradient(to right, rgba(1, 1, 1, 0) 5%, " + bgColor + " 95%)";
 
                 overlay = (
                     <div className="color-picker-slider__track-overlay" style={{
@@ -634,7 +634,7 @@ define(function (require, exports, module) {
                     backgroundColor: colortiny ? colortiny.toRgbString() : "transparent"
                 },
                 label = this._computeLabel(colortiny);
-                
+
             return (
                 <div
                     className="color-picker__colortype">

--- a/src/nls/root/strings.json
+++ b/src/nls/root/strings.json
@@ -313,7 +313,7 @@
             "GRADIENT": "Gradient",
             "PATTERN": "Pattern"
         },
-        "OPACITY": "Opacity"
+        "OPACITY": "A"
     },
     "TRANSFORM": {
         "X": "X",

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -140,14 +140,14 @@
 .formline {
     display: flex;
     align-items: center;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
     width: @panel-column-width - 2*@properties-padding;
 }
 
 .formline__no-padding {
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;    
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;    
 }
 
 .formline:first-child {
@@ -155,7 +155,7 @@
 }
 
 .formline__padded-first-child:first-child {
-    padding-top: 0.75rem;
+    padding-top: 0.8rem;
 }
 
 .formline__bottom-align {

--- a/src/style/shared/color-input.less
+++ b/src/style/shared/color-input.less
@@ -25,11 +25,11 @@
     display: flex;
     justify-content: flex-start;
     align-content: center;
-    margin-right: 0.8rem;
-    margin-top: 0.7rem;
+    margin-right: 0.6rem;
+    margin-top: 0.8rem;
 }
 
-.color-input {    
+.color-input {
     .fill__preview,
     .stroke__preview {
         height: 100%;
@@ -63,7 +63,7 @@
     flex-grow: 0;
     flex-shrink: 0;
     border-radius: 0.5rem;
-    .background-checkerboard(25);
+    .background-checkerboard(32);
     overflow: hidden;
     position: relative;
 
@@ -85,8 +85,8 @@
 }
 
 .color-input__swatch__color {
-    width: 3.4rem;
-    height: 3.4rem;
+    width: 3.2rem;
+    height: 3.2rem;
     display: flex;
     align-items: center;
     flex-grow: 0;

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -47,6 +47,8 @@
  * THE SOFTWARE.
  */
 
+@slider-radius: 1.2rem;
+
 .color-picker {
     // HACK: remove this before integration
     top: 0;
@@ -90,7 +92,7 @@
 .color-picker {
     left: 0rem;
     width: 30.2rem;
-    height: 30.4rem;
+    height: 28.4rem;
     max-height: 36rem;
     display: flex;
     flex-direction: column;
@@ -137,10 +139,10 @@
 
 .color-picker-map {
     position: absolute;
-    top: 5.6rem;
-    left: 5.6rem;
-    height: 17rem;
-    width: 16.2rem;
+    top: 6.8rem;
+    left: 6.8rem;
+    height: 14.6rem;
+    width: 13.8rem;
     -webkit-user-select: none;
 
     &.color-picker-map__dark .color-picker-map__pointer {
@@ -153,11 +155,11 @@
 
     .color-picker-map__pointer {
         position: absolute;
-        margin-left: -0.8rem;
-        margin-bottom: -0.8rem;
+        margin-left: -1rem;
+        margin-bottom: -1rem;
         
-        width: 1.6rem;
-        height: 1.6rem;
+        width: 2rem;
+        height: 2rem;
         
         background: none;
         border-radius: 100%;
@@ -169,7 +171,9 @@
         position: absolute;
         height: 17rem;
         width: 16.2rem;
-        border-radius: 0.4rem;
+        top: -1.2rem;
+        left: -1.2rem;
+        border-radius: @slider-radius;
     }
 
     .color-picker-map__background:before,
@@ -181,18 +185,19 @@
         left: 0;
         bottom: 0;
         right: 0;
+        position: absolute;
         height: 17rem;
         width: 16.2rem;
-        border-radius: 0.4rem;
+        border-radius: @slider-radius;
         box-shadow:0 0 0 @hairline @bg-border;
     }
 
     .color-picker-map__background:after {
-        background: linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%);
+        background: linear-gradient(to bottom, rgba(0,0,0,0) 5%,rgba(0,0,0,1) 95%);
     }
 
     .color-picker-map__background:before {
-        background: linear-gradient(to right, rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%);
+        background: linear-gradient(to right, rgba(255,255,255,1) 5%,rgba(255,255,255,0) 95%);
     }
 }
 
@@ -249,8 +254,8 @@
         width: 2.4rem;
         height: 2.4rem;
         background: @item;
-        border-radius: 0.4rem;
-        
+        border-radius: 0.2rem;
+        .background-checkerboard(24);
         &.empty {
             background: url(../img/ico-color-picker-no-color.svg) no-repeat;
         }
@@ -272,6 +277,7 @@
 
 .color-picker__colortype__thumb__overlay {
     border-radius: 0.2rem;
+    box-shadow: 0 0 0 0.1rem @bg-border;;
 }
 
 // Color Sliders
@@ -282,13 +288,14 @@
     -webkit-backface-visibility: hidden;
 
     &.color-picker-slider__vertical {
+        top: 1.4rem;
         width: 2.4rem;
-        height: 17rem;
+        height: 14.6rem;
         
         .color-picker-slider__track,
         .color-picker-slider__track-overlay {
             position: absolute;
-            top: 0;
+            top: -1.4rem;
             bottom: 0;
             left: 0;
             width: 2.4rem;
@@ -297,29 +304,29 @@
         }
         .color-picker-slider__pointer {
             bottom: 50%;
-            left: .4rem;
+            left: .2rem;
             margin-bottom: -0.8rem
         }
     }
 
     &.color-picker-slider__horizontal {
-        left: 0;
+        left: 1rem;
         right: 0;
         height: 2.4rem;
-        width: 26.8rem;
+        width: 17.8rem;
         
         .color-picker-slider__track,
         .color-picker-slider__track-overlay {
             position: absolute;
-            left: 0;
+            left: -1rem;
             right: 0;
             top: 0;
             height: 2.4rem;
-            width: 26.8rem;
+            width: 20.2rem;
             margin-top: 0rem;
         }
         .color-picker-slider__pointer {
-            top: .4rem;
+            top: .2rem;
             left: 50%;
             margin-left: -0.8rem;
         }
@@ -327,7 +334,7 @@
 
     .color-picker-slider__track,
     .color-picker-slider__track-overlay {    
-        border-radius: 0.4rem;
+        border-radius: @slider-radius;
         box-shadow:0 0 0 @hairline @bg-border;
         &:before {
             content: "";
@@ -338,14 +345,14 @@
             height: 100%;
             background-color: white;
             z-index: -1;
-            border-radius: .5rem;
+            border-radius: @slider-radius;
         }
     }
 
     .color-picker-slider__pointer {
         position: absolute;
-        width: 1.6rem;
-        height: 1.6rem;
+        width: 2rem;
+        height: 2rem;
         background: none;
         margin: 0;
         border-radius: 100%;
@@ -357,16 +364,18 @@
 // Label for Color picker opacity slider 
 .color-picker .slider_label {
     position: absolute;
-    top: 23.7rem;
-    left: 1.6rem;
-    width: 26.8rem;
+    top: 24.3rem;
+    right: 0;
+    width: 7rem;
     display: flex;
-    justify-content: space-between;
+    padding: 0 .2rem;
     label {
         font-size: @text-medium;
         display: inline-block;
         vertical-align: baseline;
         line-height: 1.8rem;
+        text-align: right;
+        width: 1rem;
     }
     input[type='text'] {
         font-size: @text-medium;
@@ -391,33 +400,33 @@
 
     .color-picker-slider__horizontal > .color-picker-slider__track {
         background: linear-gradient(to bottom,
-            #FF0000 0%,
-            #FF0099 10%,
-            #CD00FF 20%,
-            #3200FF 30%,
-            #0066FF 40%,
+            #FF0000 5%,
+            #FF0099 14%,
+            #CD00FF 23%,
+            #3200FF 32%,
+            #0066FF 41%,
             #00FFFD 50%,
-            #00FF66 60%,
-            #35FF00 70%,
-            #CDFF00 80%,
-            #FF9900 90%,
-            #FF0000 100%
+            #00FF66 59%,
+            #35FF00 68%,
+            #CDFF00 77%,
+            #FF9900 86%,
+            #FF0000 95%
         );
     }
 
     .color-picker-slider__vertical > .color-picker-slider__track {
         background: linear-gradient(to bottom,
-            #FF0000 0%,
-            #FF0099 10%,
-            #CD00FF 20%,
-            #3200FF 30%,
-            #0066FF 40%,
+            #FF0000 5%,
+            #FF0099 14%,
+            #CD00FF 23%,
+            #3200FF 32%,
+            #0066FF 41%,
             #00FFFD 50%,
-            #00FF66 60%,
-            #35FF00 70%,
-            #CDFF00 80%,
-            #FF9900 90%,
-            #FF0000 100%
+            #00FF66 59%,
+            #35FF00 68%,
+            #CDFF00 77%,
+            #FF9900 86%,
+            #FF0000 95%
         );
     }
 }
@@ -426,12 +435,13 @@
     position: absolute;
     left: 1.6rem;
     right: 1.6rem;
-    top: 26.4rem;
+    top: 24.2rem;
     height: 2.4rem;
-    width: 26.8rem;
-    border-radius: .4rem;
+    width: 20.2rem;
+    border-radius: calc(@slider-radius + 0.2rem);
     .color-picker-slider__horizontal > .color-picker-slider__track,
     .color-picker-slider__vertical > .color-picker-slider__track {
         .background-checkerboard(16);
+        box-shadow: 0 0 .2rem @bg-border;
     }
 }

--- a/src/style/shared/colors-medium.less
+++ b/src/style/shared/colors-medium.less
@@ -62,7 +62,7 @@
 
 @mid-bg-alt: mix(@item-active, @bg-alt, 70%);
 @black: mix(black, @bg-alt, 80%);
-@color-checkerboard: @item-hover;
+@color-checkerboard: @icon-active;
 @color-preview-background: white;
 @color-clear: fade(@item-active, 0%);
 @transparent-black: rgba(0, 0, 0, 0.0);


### PR DESCRIPTION
Color Picker sliders now housed entirely inside slider
- looks better, feels better, I think it is better
- Gradients have been adjusted to compensate for slider circle being inside the bar
- Opacity has been moved and tweaked to read inline with the other values and save space

Several Design Tweaks to Color swatch and Panels

- Swatch sizes are based around 8 grid (3.2rem instead of 3.4)
- Transparency background tiling improved (2x2 instead of off size)
- Alignment of colors, stroke, effects now go full-column so eyeball aligns with other left side icons (trash, download for example in other panels)
- Small change to box-shadow on the color swatch rounded corners to reduce white edges
- removed any 100th decimal point for rem sizes for reduced 1/2px possibilities

An incremental improvement to the UI 

---

new:
![screen shot 2015-11-23 at 6 20 44 pm](https://cloud.githubusercontent.com/assets/3229167/11354178/313a2e38-920f-11e5-9dab-8034f205b7cc.png)

---

Old
![screen shot 2015-11-23 at 6 21 12 pm](https://cloud.githubusercontent.com/assets/3229167/11354182/39df6fc6-920f-11e5-802e-31287c56cc99.png)
