### PR TITLE
Listen to tool store as well for border policy renewal, and short circuit tools.select on same tool

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -419,14 +419,10 @@ define(function (require, exports) {
         var toolStore = this.flux.store("tool"),
             currentTool = toolStore.getCurrentTool();
 
-        // If same tool is being selected, make this a no-op
-        if (currentTool === nextTool) {
-            return Promise.resolve();
-        }
-
         // Remove the border policy if it's been set at some point
+        // But not if we're resetting the same tool
         var removeTransformPolicyPromise;
-        if (_currentTransformPolicyID) {
+        if (_currentTransformPolicyID && currentTool !== nextTool) {
             var policyID = _currentTransformPolicyID;
             _currentTransformPolicyID = null;
             removeTransformPolicyPromise = this.transfer(policy.removePointerPolicies, policyID, true);
@@ -879,8 +875,8 @@ define(function (require, exports) {
                         newTool = toolStore.getCurrentTool();
                     
                     if (!Immutable.is(documentLayerBounds, nextDocumentLayerBounds) ||
-                        !_.isEqual(uiTransformMatrix, newxUiTransformMatrix ||
-                        activeTool !== newTool) {
+                            !_.isEqual(uiTransformMatrix, newxUiTransformMatrix) ||
+                            activeTool !== newTool) {
                         documentLayerBounds = nextDocumentLayerBounds;
                         uiTransformMatrix = newxUiTransformMatrix;
                         activeTool = newTool;


### PR DESCRIPTION
This is a bug I found while working on some other bug. On `tools.select`, we uninstall the active border policies. But we never re-install them with the new tool.

At first I tried listening to the tool store for change events, but this bug happens when you press V *while* in select tool already, so there is no difference in tool store that we can pick up on.

And I think it's reasonable for `superselectTool.select` to transfer to resetBorderPolicies. I know refactoring of all resetBorderPolicies into a listener was made to speed up our actions, but this is one place where it is necessary to call it directly, and it doesn't block anything else.