### PR TITLE
Upgrade to bluebird 3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "bluebird": "~2.9.34",
+    "bluebird": "~3.0.5",
     "classnames": "~2.1.3",
     "d3": "~3.5.6",
     "eventEmitter": "~4.2.11",

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -283,7 +283,7 @@ define(function (require, exports) {
                 currentLibrary.beginOperation();
                 newElement = currentLibrary.createElement(firstLayer.name, ELEMENT_GRAPHIC_TYPE);
 
-                return Promise.fromNode(function (done) {
+                return Promise.fromCallback(function (done) {
                     var representation = newElement.createRepresentation(representationType, "primary");
 
                     representation.updateContentFromPath(paths.exportedLayerPath, false, done);
@@ -292,7 +292,7 @@ define(function (require, exports) {
                 }).finally(function () {
                     currentLibrary.endOperation();
                 }).then(function () {
-                    return Promise.fromNode(function (done) {
+                    return Promise.fromCallback(function (done) {
                         newElement.getPrimaryRepresentation().getContentPath(done);
                     });
                 });
@@ -393,7 +393,7 @@ define(function (require, exports) {
                 representation.setValue("characterstyle", "data", typeData);
                     
                 return Promise
-                    .fromNode(function (done) {
+                    .fromCallback(function (done) {
                         imageRepresentation.updateContentFromPath(tempPreviewPath, false, done);
                     })
                     .then(function () {
@@ -457,12 +457,12 @@ define(function (require, exports) {
 
                 newElement = currentLibrary.createElement(currentLayer.name, ELEMENT_LAYERSTYLE_TYPE);
 
-                return Promise.fromNode(function (done) {
+                return Promise.fromCallback(function (done) {
                         var representation = newElement.createRepresentation(REP_LAYERSTYLE_TYPE, "primary");
                         representation.updateContentFromPath(stylePath, false, done);
                     })
                     .then(function () {
-                        return Promise.fromNode(function (done) {
+                        return Promise.fromCallback(function (done) {
                             var rendition = newElement.createRepresentation(REP_PNG_TYPE, "rendition");
                             rendition.updateContentFromPath(tempPreviewPath, false, done);
                         });
@@ -597,7 +597,7 @@ define(function (require, exports) {
                         tempFilePath = paths.tempBasePath + pathUtil.sep + tempFilename;
                         tempPreviewPath = tempFilePath.replace(".psd", "p.png");
 
-                        return Promise.fromNode(function (done) {
+                        return Promise.fromCallback(function (done) {
                             element.getPrimaryRepresentation().getContentPath(done);
                         });
                     })
@@ -696,7 +696,7 @@ define(function (require, exports) {
             this.dispatch(events.libraries.UPDATING_GRAPHIC_CONTENT, { documentID: documentID, element: element });
 
             updateGraphicPromise = Promise
-                .fromNode(function (done) {
+                .fromCallback(function (done) {
                     library.beginOperation();
 
                     // If the element we're editing was deleted, we recreate it as a new element, so the changes
@@ -823,7 +823,7 @@ define(function (require, exports) {
         location.y = uiStore.zoomWindowToCanvas(location.y) / pixelRatio;
 
         return Promise
-            .fromNode(function (done) {
+            .fromCallback(function (done) {
                 var representation = _findPlacableGraphicRepresentation(element);
 
                 representation.getContentPath(done);
@@ -929,7 +929,7 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
-        return Promise.fromNode(function (done) {
+        return Promise.fromCallback(function (done) {
                 representation.getContentPath(done);
             })
             .bind(this)
@@ -1127,7 +1127,7 @@ define(function (require, exports) {
             id: library.id
         };
 
-        return Promise.fromNode(function (done) {
+        return Promise.fromCallback(function (done) {
                 libraryCollection.removeLibrary(library, done);
             })
             .bind(this)

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -797,7 +797,7 @@ define(function (require, exports) {
                 element = CCLibraries.resolveElementReference(reference),
                 representation = element.getPrimaryRepresentation();
 
-            return Promise.fromNode(function (cb) {
+            return Promise.fromCallback(function (cb) {
                 representation.getContentPath(cb);
             }).then(function (path) {
                 return path;

--- a/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
                 renditionSize = element.type === librariesAction.ELEMENT_GRAPHIC_TYPE ?
                     librariesAction.RENDITION_GRAPHIC_SIZE : librariesAction.RENDITION_DEFAULT_SIZE;
 
-            Promise.fromNode(function (cb) {
+            Promise.fromCallback(function (cb) {
                 element.getRenditionPath(renditionSize, cb);
             })
             .bind(this)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -145,6 +145,13 @@ define(function (require, exports) {
         return _controller;
     };
 
+    // TODO: Currently it is VERY hard to pinpoint the origin of Bluebird
+    // warnings. When that improves, we should enable this and then fix the
+    // sources of the warnings.
+    Promise.config({
+        warnings: false
+    });
+
     if (global.debug) {
         Promise.longStackTraces();
         Promise.onPossiblyUnhandledRejection(function (err) {


### PR DESCRIPTION
This is a backward-incompatible upgrade from Bluebird 2.x to 3.x. Details here: http://bluebirdjs.com/docs/new-in-bluebird-3.html

This should be reviewed and merged with adobe-photoshop/spaces-adapter#169.

Note that Bluebird 3 contains many new warnings, most of which seem useful and relevant. However, the source of these warnings is currently very hard to pin down (see petkaantonov/bluebird#861), so I've disabled the warnings for now. When the warnings are a little easier to deal with, we should of course address their causes and enable the warnings. For now I've only made the minimal required changes because I'd like to use some of the cancellation features of version 3 in a separate branch.