### PR TITLE
Point to the right internal variable in documentindex

### DIFF
--- a/src/js/models/documentindex.js
+++ b/src/js/models/documentindex.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
                 nextDocumentIndex = 0;
             }
 
-            return this._documentIDs.get(nextDocumentIndex);
+            return this.openDocumentIDs.get(nextDocumentIndex);
         },
 
         /**
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
                 nextDocumentIndex = this.openDocumentIDs.size - 1;
             }
 
-            return this._documentIDs.get(nextDocumentIndex);
+            return this.openDocumentIDs.get(nextDocumentIndex);
         }
     }));
 


### PR DESCRIPTION
When we broke it apart, we must have missed a private variable name, causing the errors. 

Addresses #3268 