### PR TITLE
Fix REMOVE_SHORTCUT handler

### DIFF
--- a/src/js/stores/shortcut.js
+++ b/src/js/stores/shortcut.js
@@ -107,9 +107,11 @@ define(function (require, exports, module) {
                 }
             });
 
-            if (found > 0) {
-                this._shortcuts.splice(found, 1);
+            if (found < 0) {
+                throw new Error("Failed to remove shortcut: unknown ID " + id);
             }
+
+            this._shortcuts.splice(found, 1);
         },
 
         /**


### PR DESCRIPTION
This fixes an awful off-by-one bug in the shortcut store's `REMOVE_SHORTCUT` handler that was preventing the most recently installed shortcut from ever being uninstalled. 

Addresses #3311.