### PR TITLE
Faster tool activation

### DIFF
--- a/src/js/actions/tool/pen.js
+++ b/src/js/actions/tool/pen.js
@@ -92,6 +92,7 @@ define(function (require, exports) {
         } else {
             selectVectorMask = descriptor.playObject(vectorMaskLib.dropPathSelection());
         }
+
         return Promise.join(setPromise, selectVectorMask, disableSuppressionPromise,
             backspacePromise, deletePromise);
     };

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -439,6 +439,11 @@ define(function (require, exports) {
             deselectHandlerPromise = Promise.resolve();
         }
 
+        // Dispatch partial event ASAP so that the toolbar can redraw immediately
+        var dispatchPromise = this.dispatchAsync(events.tool.SELECT_TOOL_START, {
+            tool: nextTool
+        });
+
         return Promise.join(removeTransformPolicyPromise, deselectHandlerPromise)
             .bind(this)
             .then(function () {
@@ -470,9 +475,9 @@ define(function (require, exports) {
                 var resetCursorPromise = adapterOS.resetCursor(),
                     swapPoliciesPromise = this.transfer(swapPolicies, nextTool);
 
-                return Promise.join(swapPoliciesPromise, selectHandlerPromise, resetCursorPromise,
+                return Promise.join(swapPoliciesPromise, selectHandlerPromise, resetCursorPromise, dispatchPromise,
                     function (result) {
-                        this.dispatch(events.tool.SELECT_TOOL, result);
+                        this.dispatch(events.tool.SELECT_TOOL_END, result);
                     }.bind(this));
             });
     };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -106,7 +106,8 @@ define(function (require, exports, module) {
             }
         },
         tool: {
-            SELECT_TOOL: "selectTool",
+            SELECT_TOOL_START: "selectToolStart",
+            SELECT_TOOL_END: "selectToolEnd",
             MODAL_STATE_CHANGE: "modalStateChange",
             VECTOR_MASK_MODE_CHANGE: "vectorMaskModeChange",
             VECTOR_MASK_POLICY_CHANGE: "vectorMaskPolicyChange"

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -112,7 +112,8 @@ define(function (require, exports, module) {
         initialize: function () {
             this.bindActions(
                 events.RESET, this._handleReset,
-                events.tool.SELECT_TOOL, this._handleSelectTool,
+                events.tool.SELECT_TOOL_START, this._handleSelectTool,
+                events.tool.SELECT_TOOL_END, this._handleSelectTool,
                 events.tool.MODAL_STATE_CHANGE, this._handleModalStateChange,
                 events.tool.VECTOR_MASK_MODE_CHANGE, this._handleVectorMaskModeChange,
                 events.tool.VECTOR_MASK_POLICY_CHANGE, this._handleVectorMaskPolicyChange
@@ -202,15 +203,21 @@ define(function (require, exports, module) {
 
         /**
          * @private
-         * @param {{tool: Tool, keyboardPolicyListID: number, pointerPolicyListID: number}} payload
+         * @param {{tool: Tool, keyboardPolicyListID: number=, pointerPolicyListID: number=}} payload
          */
         _handleSelectTool: function (payload) {
             var tool = payload.tool;
 
             this._previousTool = this._currentTool;
             this._currentTool = tool;
-            this._currentKeyboardPolicyID = payload.keyboardPolicyListID;
-            this._currentPointerPolicyID = payload.pointerPolicyListID;
+
+            if (payload.keyboardPolicyListID) {
+                this._currentKeyboardPolicyID = payload.keyboardPolicyListID;
+            }
+
+            if (payload.pointerPolicyListID) {
+                this._currentPointerPolicyID = payload.pointerPolicyListID;
+            }
 
             this.emit("change");
         },


### PR DESCRIPTION
This PR splits the tool-change dispatch into two parts:

1. an early, optimistic part that causes the view to re-render; and
2. a later part that contains the installed policy IDs.

This significantly improves perceived tool-activation time. Addresses #3313.