### PR TITLE
Menu bug-fix grab bag

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -745,11 +745,13 @@ define(function (require, exports) {
     /**
      * Activate the given already-open document
      *
-     * @param {Document} document
+     * @param {Document|number} documentSpec
      * @return {Promise}
      */
-    var selectDocument = function (document) {
-        var documentID = document.id,
+    var selectDocument = function (documentSpec) {
+        var flux = this.flux,
+            documentID = typeof documentSpec === "number" ? documentSpec : documentSpec.id,
+            document = flux.stores.document.getDocument(documentID),
             documentRef = documentLib.referenceBy.id(documentID);
 
         this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
@@ -773,7 +775,7 @@ define(function (require, exports) {
                 return this.transfer(toolActions.changeVectorMaskMode, false);
             })
             .then(function () {
-                var toolStore = this.flux.store("tool");
+                var toolStore = flux.store("tool");
 
                 if (toolStore.getCurrentTool() === toolStore.getToolByID("superselectVector")) {
                     return this.transfer(toolActions.select, toolStore.getToolByID("newSelect"));

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -296,6 +296,8 @@ define(function (require, exports) {
             return;
         }
 
+        descriptor = descriptor.toObject();
+
         var action = _resolveAction.call(this, descriptor.$action),
             $payload = descriptor.$payload,
             $dontLog = descriptor.$dontLog || false,
@@ -442,7 +444,10 @@ define(function (require, exports) {
 
             if (appMenu !== null) {
                 var menuDescriptor = appMenu.getMenuDescriptor();
-                ui.installMenu(menuDescriptor);
+                ui.installMenu(menuDescriptor)
+                    .catch(function (err) {
+                        log.warn("Failed to install menu: ", err, menuDescriptor);
+                    });
             }
         }.bind(this);
 

--- a/src/js/models/menushortcut.js
+++ b/src/js/models/menushortcut.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Immutable = require("immutable"),
+        _ = require("lodash");
+
+    /**
+     * A model of a menu item's keybaord shortcut.
+     *
+     * @constructor
+     */
+    var MenuShortcut = Immutable.Record({
+        /**
+         * @type {?number}
+         */
+        modifiers: null,
+
+        /**
+         * @type {?number}
+         */
+        keyCode: null,
+
+        /**
+         * @type {?string}
+         */
+        keyChar: null
+    });
+
+    /**
+     * Export a menu shortcut descriptor compatible with the Spaces adapter menu API.
+     *
+     * @return {object}
+     */
+    MenuShortcut.prototype.exportDescriptor = function () {
+        return _.omit(this.toObject(), _.isNull);
+    };
+
+    module.exports = MenuShortcut;
+});


### PR DESCRIPTION
This PR contains various menu fixes and cleanups. In particular: 

1. The maps (`rootMap` and `submenuMap`) are now derived properties, which reduces complexity and at least a few bugs by obviating their maintenance.
2. Many instances of mutable object references have been purged in favor strict immutability. In particular, there is now an immutable `MenuShortcut` model, instances of which may be referenced by `MenuItem` instances.
3. The `checked` property of `MenuItem` is now properly a boolean. Previously its range also variously, erroneously included 0, 1, "on" and "off".
4. Descriptor export has been tidied up so that unnecessary cruft is not submitted to the adapter when installing new menu definitions.
5. The open-document `MenuItem` instances no longer refer directly to document models; instead only their IDs are referenced.

As a result, state changes that should not affect the state of the menu now properly result in structurally equal `MenuBar` instances, which results in significantly fewer menu-installation adapter calls. This may help avoid a bug in which the menu is corrupted if it is open while installing a new menu because we'll do that less frequently.

---

As @tomwmcrae pointed out, many of these bugs are caused by Immutable record "type" violations. It sure would be great if there were a way to do dynamic (not static) type checks when in debug mode to ensure that our Immutable record constructors were being applied to models with valid types at instantiation time. There is some discussion of a hypothetical feature along those lines here: facebook/immutable-js#546. 
