### PR TITLE
Cleanup of TextInput definition and usage

### DIFF
--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -182,9 +182,6 @@ define(function (require, exports, module) {
                     <div className="control-group__vertical">
                         <TextInput
                             value={exportAsset.suffix}
-                            singleClick={true}
-                            editable={true}
-                            live={true}
                             onChange={this._handleUpdateSuffix}
                             size="column-8" />
                     </div>

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -653,10 +653,9 @@ define(function (require, exports, module) {
                                         title={layer.name + tooltipPadding}
                                         className="face__name"
                                         ref="layerName"
-                                        type="text"
+                                        doubleClickToEdit={true}
                                         value={layer.name}
-                                        editable={!this.props.disabled && nameEditable}
-                                        preventHorizontalScrolling={true}
+                                        disabled={this.props.disabled || !nameEditable}
                                         onKeyDown={this._skipToNextLayerName}
                                         onChange={this._handleLayerNameChange}>
                                     </TextInput>

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -395,10 +395,7 @@ define(function (require, exports, module) {
             return (<div className="libraries__bar__top__content libraries__bar__top__content-input">
                 <TextInput
                     ref="libraryNameInput"
-                    type="text"
-                    live={true}
-                    continuous={true}
-                    className="libraires__bar__input"
+                    className="libraries__bar__input"
                     value={inputDefaultValue}
                     placeholderText={nls.localize("strings.LIBRARIES.LIBRARY_NAME")}
                     onKeyDown={this._handleLibraryNameInputKeydown}/>

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -195,10 +195,9 @@ define(function (require, exports, module) {
                         <div className="libraries__asset__title">
                             <TextInput
                                 ref="input"
-                                editable={true}
+                                doubleClickToEdit={true}
                                 title={title}
                                 value={this.props.displayName}
-                                preventHorizontalScrolling={true}
                                 onClick={this._handleTitleClicked}
                                 onDoubleClick={this._handleStartEditingTitle}
                                 onChange={this._handleRename}
@@ -224,10 +223,9 @@ define(function (require, exports, module) {
                     <div className="libraries__asset__title">
                         <TextInput
                             ref="input"
-                            editable={true}
+                            doubleClickToEdit={true}
                             title={title}
                             value={this.props.displayName}
-                            preventHorizontalScrolling={true}
                             onClick={this._handleTitleClicked}
                             onDoubleClick={this._handleStartEditingTitle}
                             onChange={this._handleRename}

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -649,10 +649,8 @@ define(function (require, exports, module) {
                     <Gutter/>
                     <TextInput
                         ref="input"
-                        live={this.props.editable}
-                        editable={this.props.editable}
+                        disabled={!this.props.editable}
                         value={label}
-                        singleClick={true}
                         onKeyDown={this._handleKeyDown}
                         onChange={this._handleInputChanged}
                         onFocus={this._handleFocus}

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -724,9 +724,7 @@ define(function (require, exports, module) {
                     <TextInput
                         ref="textInput"
                         disabled={this.props.disabled}
-                        editable={!this.props.disabled}
                         size={size}
-                        live={true}
                         continuous={true}
                         value={title}
                         placeholderText={this.props.placeholderText}

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -158,7 +158,7 @@
             }
         }
 
-        .libraires__bar__input {
+        .libraries__bar__input {
             font-size: @text-medium;
             flex-grow: 1;
             color: @item-hover;


### PR DESCRIPTION
1. Removed property expansion in rendering the inputs
2. `singleClick` and `live` seemingly accomplished the same goal. I renamed the property `doubleClickToEdit`, which is more informative than either of the other two, and set the default to `false`, since we only use this property in LayerFace and Library Assets
3. `TextInput` does not use or need the `type` property. Removed
4. `editable` and `disabled` also seemed to accomplish the same goal. Also, confusing with the `live` property. Condensed everything down to `disabled`
5. `preventHorizontalScrolling` is used by elements with `doubleClickToEdit={true}`. I set this to default to `true`, as it doesn't harm anything and then allows us to not have 2 dependent properties that must be set in the usage of TextInput (not preventing horizontal scrolling is the exception)
6. Fixed a typo in a CSS class name

I'm going to update the specs, but high level, here are places where TextInput is used:
* Export panel, suffix field
* Layers panel, layer name
* Libraries panel, creating a new library name input and asset names
* Color panel, color string input
* Datalists, all of them, including Search Bar
