### PR TITLE
Change Scrim SCU to skip isDropTarget when false

### DIFF
--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -210,7 +210,8 @@ define(function (require, exports, module) {
                 return false;
             }
             
-            if (this.state.isDropTarget === nextState.isDropTarget) {
+            // Only skip if it's currently a dropTarget and will continue to be
+            if (this.state.isDropTarget && nextState.isDropTarget) {
                 return false;
             }
 


### PR DESCRIPTION
This must have slipped through the cracks during the drag&drop work. Scrim SCU never re-updated itself due to fact that both isDropTarget and nextProps.dropTarget being false. Now it will return false there if and only if both are true.

Addresses #3312, #3251, and bunch of other dupes.