### PR TITLE
Don't ignore 0 policy IDs during tool swap

### DIFF
--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -211,11 +211,11 @@ define(function (require, exports, module) {
             this._previousTool = this._currentTool;
             this._currentTool = tool;
 
-            if (payload.keyboardPolicyListID) {
+            if (payload.keyboardPolicyListID !== undefined) {
                 this._currentKeyboardPolicyID = payload.keyboardPolicyListID;
             }
 
-            if (payload.pointerPolicyListID) {
+            if (payload.pointerPolicyListID !== undefined) {
                 this._currentPointerPolicyID = payload.pointerPolicyListID;
             }
 


### PR DESCRIPTION
Addresses #3318 

Tool store was not saving the initial superselect tool's "send to browser" policy, since the ID was 0, so it was sticking and preventing other tools that relied on sending mouse events to Photoshop.