### PR TITLE
undo/redo menu commands use preserveFocus

### DIFF
--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -144,10 +144,16 @@
         },
         "UNDO": {
             "$action": "edit.undo",
+            "$payload": {
+                "preserveFocus": true
+            },
             "$enable-rule": "have-document,earlier-history"
         },
         "REDO": {
             "$action": "edit.redo",
+            "$payload": {
+                "preserveFocus": true
+            },
             "$enable-rule": "have-document,later-history"
         },
         "SELECT_ALL": {


### PR DESCRIPTION
For the undo and redo menu commands, supply the "preserveFocus" switch in the payload.  This seems like a better experience, and addresses #3154.  I can't find any downside to this.

Better experience: For example, change the Width of a rectangle using the number input, then undo.  Retaining focus in the input seems natural

The bug fix: Previously when changing to a negative value of width (which clamps to 0.1), undoing it would cause a setSize AND an undo to be performed in rapid succession.