### PR TITLE
Ignore adjustment layers when calculating layer bounds

### DIFF
--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -162,9 +162,10 @@ define(function (require, exports, module) {
             boundsObject = objUtil.getPath(descriptor, "pathBounds.pathBounds");
         } else {
             switch (layerKind) {
-                // Photoshop's group bounds are not useful, so ignore them.
+                // Photoshop's group / adjustment bounds are not useful, so ignore them.
                 case Layer.KINDS.GROUP:
                 case Layer.KINDS.GROUPEND:
+                case Layer.KINDS.ADJUSTMENT:
                     return null;
                 case Layer.KINDS.TEXT:
                     boundsObject = descriptor.boundingBox;


### PR DESCRIPTION
Fix for issue #3212 

Adjustment layers add effects to the layers below them and do not have a visual area, so their bounds should be ignored when calculating bounds of selected layers. Othwerise it will result in incorrect bounds (which is larger than the actual bounds) and break the transform feature.