### PR TITLE
Idle initialization of the font list and unselected layers

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -798,7 +798,7 @@ define(function (require, exports) {
                 initialized = fontState.initialized;
 
             if (initialized) {
-                return this.flux.actions.type.initFontList(true);
+                return this.whenIdle("type.initFontList", true);
             } else {
                 return Promise.resolve();
             }
@@ -809,6 +809,22 @@ define(function (require, exports) {
         return Promise.resolve();
     };
     beforeStartup.action = {
+        reads: [],
+        writes: [],
+        modal: []
+    };
+
+    /**
+     * Initialize the font list when idle.
+     *
+     * @return {Promise}
+     */
+    var afterStartup = function () {
+        this.whenIdle("type.initFontList");
+
+        return Promise.resolve();
+    };
+    afterStartup.action = {
         reads: [],
         writes: [],
         modal: []
@@ -851,5 +867,6 @@ define(function (require, exports) {
     exports.applyTextStyle = applyTextStyle;
 
     exports.beforeStartup = beforeStartup;
+    exports.afterStartup = afterStartup;
     exports.onReset = onReset;
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -149,7 +149,8 @@ define(function (require, exports) {
     // warnings. When that improves, we should enable this and then fix the
     // sources of the warnings.
     Promise.config({
-        warnings: false
+        warnings: false,
+        cancellation: true
     });
 
     if (global.debug) {

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -299,6 +299,16 @@ define(function (require, exports, module) {
         },
 
         /**
+         * The subset of Layer models that have not yet been fully initialized.
+         * @type {Immutable.List.<Layer>}
+         */
+        "uninitialized": function () {
+            return this.all.filterNot(function (layer) {
+                return layer.initialized;
+            }, this);
+        },
+
+        /**
          * Child-encompassing bounds objects for all the selected layers.
          * @type {Immutable.List.<Bounds>}
          */


### PR DESCRIPTION
This PR adds infrastructure for idle task execution:

1. Action receivers now have a `whenIdle` method, which enqueues the given action once the queue and JavaScript engine are idle.
2. Unselected layers of activated documents are now initialized when idle instead of at first-selection time. (Note that this does not yet initialize not-yet-activated documents.) The action `layers.initializeLayersBackground` calls `initializeLayers` on 50 uninitialized layers for a given document, and then calls itself again when idle if there are still uninitialized layers.
3. The font list is initialized when idle instead of first-text-layer-selection time.

The scenarios in which this makes a noticeable performance impact are not terribly common (selecting a big range of layers that have never been selected previously), but I thought it would be good to get feedback on the approach before going much further.
 