### PR TITLE
Make dropdown list starts filtering for the first input character

### DIFF
--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -153,15 +153,17 @@ define(function (require, exports, module) {
          */
         _handleChange: function (event) {
             var nextValue = event.target.value;
+
             this.setState({
                 value: nextValue,
                 editing: true,
                 selectDisabled: true
             });
 
-            if (this.state.editing && !this.props.doubleClickToEdit && this.props.continuous) {
+            if (!this.props.doubleClickToEdit && this.props.continuous) {
                 this.props.onChange(event, nextValue);
             }
+
             // Only used by Datalist
             this.props.onDOMChange(event);
         },


### PR DESCRIPTION
Fix for issue #3324 

`setState` is asynchronous, and it is not safe to read the state immediately after writting to it. In this case, `this.state.editing` (in line 162 ) may remian unchanged until the last `setState` get processed. Also, I don't think we need to check `this.state.editing` there as it is always set to true in this function, so I simply remove the checker to fix the issue. 