### PR TITLE
Correctly check for inequality in transform matrices during policy reset

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -862,7 +862,7 @@ define(function (require, exports) {
                         newxUiTransformMatrix = uiStore.getCurrentTransformMatrix();
                     
                     if (!Immutable.is(documentLayerBounds, nextDocumentLayerBounds) ||
-                        uiTransformMatrix !== newxUiTransformMatrix) {
+                        !_.isEqual(uiTransformMatrix, newxUiTransformMatrix)) {
                         documentLayerBounds = nextDocumentLayerBounds;
                         uiTransformMatrix = newxUiTransformMatrix;
                         throttledResetBorderPolicies();


### PR DESCRIPTION
```
> [0,1] === [0,1]
< false
```

So we should use `_.isEqual` instead to check equality.

Doesn't really address #3328, but that one is a lot hairier than it looks. 