### PR TITLE
Don't toggle overlays on ui.setTransform

### DIFF
--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -260,11 +260,8 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var setTransform = function (transformObject) {
-        return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false })
+        return descriptor.getProperty("document", "zoom")
             .bind(this)
-            .then(function () {
-                return descriptor.getProperty("document", "zoom");
-            })
             .get("_value")
             .catch(function () {
                 return null;


### PR DESCRIPTION
#3328 was happening, because we would call `ui.setTransform`, which would cause `Scrim.jsx` to unmount all overlays, which would cause the blink.

Looks like the dispatch was added by Ian as a fix for #2714, which is still open for other reasons, but as far as I can tell, the original reason of #2714 the dispatch was supposed to fix no longer happens. So I'm removing that code.

Blah.