### PR TITLE
Set the correct border policy change handler, SCOPES

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -853,8 +853,12 @@ define(function (require, exports) {
             uiTransformMatrix;
 
         var throttledResetBorderPolicies =
-            synchronization.throttle(this.flux.actions.tools.resetBorderPolicies, this, 100),
-            _borderPolicyChangeHandler = function () {
+            synchronization.throttle(this.flux.actions.tools.resetBorderPolicies, this, 100);
+            
+        _borderPolicyChangeHandler = function () {
+                if (!this.controller.active) {
+                    return;
+                }
                 var currentDocument = appStore.getCurrentDocument();
 
                 if (currentDocument) {


### PR DESCRIPTION
This is the victim of bad indentation and bad scope.

`tools.beforeStartup` was setting a local `_borderPolicyChangeHandler` variable, instead of the file scoped one. So during onReset, we would call `removeListener` on various stores with an `undefined` handler, which would cause the store to drop ALL the listeners, turning the app unresponsive after a reset.

Addresses #3338