### PR TITLE
Color theme switching

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "requirejs": "~2.1.20",
     "requirejs-i18n": "~2.0.6",
     "requirejs-text": "~2.0.14",
-    "spaces-adapter": "https://github.com/adobe-photoshop/spaces-adapter.git#^0.28.0",
+    "spaces-adapter": "https://github.com/adobe-photoshop/spaces-adapter.git#^0.30.0",
     "tinycolor": "~1.2.1"
   },
   "devDependencies": {

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -31,7 +31,8 @@ define(function (require, exports) {
         descriptor = require("adapter").ps.descriptor,
         documentLib = require("adapter").lib.document,
         adapterUI = require("adapter").ps.ui,
-        adapterOS = require("adapter").os;
+        adapterOS = require("adapter").os,
+        appLib = require("adapter").lib.application;
 
     var Bounds = require("js/models/bounds"),
         events = require("js/events"),
@@ -40,7 +41,8 @@ define(function (require, exports) {
         preferences = require("./preferences"),
         synchronization = require("js/util/synchronization"),
         system = require("js/util/system"),
-        headlights = require("js/util/headlights");
+        headlights = require("js/util/headlights"),
+        uiUtil = require("js/util/ui");
 
     /**
      * Tooltip property key that determines the delay until tooltips are shown.
@@ -594,6 +596,29 @@ define(function (require, exports) {
     };
 
     /**
+     * Set the UI color stop.
+     *
+     * @param {{stop: string}} payload
+     * @return {Promise}
+     */
+    var setColorStop = function (payload) {
+        var stop = payload.stop,
+            psStop = appLib.colorStops[stop],
+            setColorStop = appLib.setColorStop(psStop),
+            setColorStopPromise = descriptor.playObject(setColorStop),
+            dispatchPromise = this.dispatchAsync(events.ui.COLOR_STOP_CHANGED, {
+                stop: stop
+            });
+
+        return Promise.join(dispatchPromise, setColorStopPromise);
+    };
+    setColorStop.action = {
+        reads: [],
+        writes: [locks.PS_APP, locks.JS_UI],
+        transfers: []
+    };
+
+    /**
      * Event handlers initialized in beforeStartup.
      *
      * @private
@@ -659,12 +684,21 @@ define(function (require, exports) {
             referencePoint = preferences.get(REFERENCE_POINT_PREFS_KEY, DEFAULT_REFERENCE_POINT),
             setReferencePointPromise = this.transfer(setReferencePoint, referencePoint);
 
-        return Promise.join(osPromise, owlPromise, pathPromise, setReferencePointPromise)
+        // Initialize the UI color stop
+        const colorStopPromise = uiUtil.getPSColorStop()
+            .bind(this)
+            .then(function (stop) {
+                this.dispatch(events.ui.COLOR_STOP_CHANGED, {
+                    stop: stop
+                });
+            });
+
+        return Promise.join(osPromise, owlPromise, pathPromise, setReferencePointPromise, colorStopPromise)
             .return(reset);
     };
     beforeStartup.action = {
         reads: [],
-        writes: [locks.PS_APP],
+        writes: [locks.PS_APP, locks.JS_UI],
         transfers: [setReferencePoint],
         modal: true
     };
@@ -727,6 +761,7 @@ define(function (require, exports) {
     exports.zoomInOut = zoomInOut;
     exports.zoom = zoom;
     exports.setReferencePoint = setReferencePoint;
+    exports.setColorStop = setColorStop;
     exports.handleDisplayConfigurationChanged = handleDisplayConfigurationChanged;
 
     exports.beforeStartup = beforeStartup;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -118,6 +118,7 @@ define(function (require, exports, module) {
             TOGGLE_OVERLAYS: "toggleOverlays",
             SUPERSELECT_MARQUEE: "superselectMarquee",
             REFERENCE_POINT_CHANGED: "referencePointChanged",
+            COLOR_STOP_CHANGED: "colorStopChanged",
             DISPLAY_CHANGED: "displayChanged",
             MOUSE_POSITION_CHANGED: "mousePositionChanged"
         },

--- a/src/js/init-build.js
+++ b/src/js/init-build.js
@@ -29,21 +29,17 @@ define(function (require) {
     var ui = require("./util/ui"),
         main = require("./main");
 
-    var windowReady = new Promise(function (resolve) {
-        if (window.document.readyState === "complete") {
-            resolve();
-        } else {
-            window.addEventListener("load", resolve);
-        }
-    });
-
-    var stylesReady = ui.getPSColorStop()
-        .then(function (stop) {
-            window.document.body.classList.add("color-stop__" + stop);
+    var stylesReady = ui.getPSColorStop(),
+        windowReady = new Promise(function (resolve) {
+            if (window.document.readyState === "complete") {
+                resolve();
+            } else {
+                window.addEventListener("load", resolve);
+            }
         });
 
-    Promise.join(windowReady, stylesReady, function () {
-        main.startup();
+    Promise.join(stylesReady, windowReady, function (stop) {
+        main.startup(stop);
         window.addEventListener("beforeunload", main.shutdown.bind(main));
     });
 });

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -29,21 +29,17 @@ define(function (require) {
     var ui = require("./util/ui"),
         main = require("./main");
 
-    var windowReady = new Promise(function (resolve) {
-        if (window.document.readyState === "complete") {
-            resolve();
-        } else {
-            window.addEventListener("load", resolve);
-        }
-    });
-
-    var stylesReady = ui.getPSColorStop()
-        .then(function (stop) {
-            window.document.body.classList.add("color-stop__" + stop);
+    var stylesReady = ui.getPSColorStop(),
+        windowReady = new Promise(function (resolve) {
+            if (window.document.readyState === "complete") {
+                resolve();
+            } else {
+                window.addEventListener("load", resolve);
+            }
         });
 
-    Promise.join(windowReady, stylesReady, function () {
-        main.startup();
+    Promise.join(stylesReady, windowReady, function (stop) {
+        main.startup(stop);
         window.addEventListener("beforeunload", main.shutdown.bind(main));
     });
 });

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -53,7 +53,11 @@ define(function (require, exports, module) {
         PROPERTIES_COL = "propertiesVisible";
 
     var Main = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("preferences")],
+        mixins: [FluxMixin, StoreWatchMixin("preferences", "ui")],
+
+        propTypes: {
+            initialColorStop: React.PropTypes.string.isRequired
+        },
 
         getInitialState: function () {
             return {
@@ -63,14 +67,17 @@ define(function (require, exports, module) {
         },
 
         getStateFromFlux: function () {
-            var preferences = this.getFlux().store("preferences").getState(),
+            var flux = this.getFlux(),
+                preferences = flux.store("preferences").getState(),
                 propertiesCol = preferences.get(PROPERTIES_COL, true) ? 1 : 0,
                 layersCol = preferences.get(LAYERS_LIBRARY_COL, true) ? 1 : 0,
-                numPanels = propertiesCol + layersCol;
+                numPanels = propertiesCol + layersCol,
+                colorStop = flux.store("ui").getColorStop() || this.props.initialColorStop;
 
             return {
                 numberOfPanels: numPanels,
-                singleColumnModeEnabled: preferences.get("singleColumnModeEnabled", false)
+                singleColumnModeEnabled: preferences.get("singleColumnModeEnabled", false),
+                colorStop: colorStop
             };
         },
 
@@ -78,7 +85,8 @@ define(function (require, exports, module) {
             return this.state.ready !== nextState.ready ||
                 this.state.active !== nextState.active ||
                 this.state.numberOfPanels !== nextState.numberOfPanels ||
-                this.state.singleColumnModeEnabled !== nextState.singleColumnModeEnabled;
+                this.state.singleColumnModeEnabled !== nextState.singleColumnModeEnabled ||
+                this.state.colorStop !== nextState.colorStop;
         },
 
         /**
@@ -149,7 +157,9 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var hasDocument = this.getFlux().store("application").getCurrentDocument();
+            var hasDocument = this.getFlux().store("application").getCurrentDocument(),
+                colorStop = this.state.colorStop || this.props.initialColorStop,
+                stopClass = "color-stop__" + colorStop.toLowerCase();
 
             var className = classnames({
                 main: true,
@@ -159,7 +169,8 @@ define(function (require, exports, module) {
                     !hasDocument || this.state.numberOfPanels === 1 || this.state.singleColumnModeEnabled,
                 "main__both-panel":
                     hasDocument && this.state.numberOfPanels === 2 && !this.state.singleColumnModeEnabled
-            });
+            }, stopClass);
+
             return (
                 <div className={className}>
                     <Guard

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -80,8 +80,10 @@ define(function (require, exports) {
 
     /**
      * Start up the application.
+     *
+     * @param {string} stop The initial UI color stop.
      */
-    var startup = function () {
+    var startup = function (stop) {
         var startTime = Date.now(),
             version = adapter.version;
 
@@ -108,7 +110,8 @@ define(function (require, exports) {
 
         var props = {
             controller: _controller,
-            flux: _controller.flux
+            flux: _controller.flux,
+            initialColorStop: stop
         };
 
         var startupPromises = _controller.start()

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -117,6 +117,7 @@ define(function (require, exports, module) {
                 events.tool.VECTOR_MASK_MODE_CHANGE, this._updateMenuItems,
 
                 events.document.GUIDES_VISIBILITY_CHANGED, this._updateViewMenu,
+                events.ui.COLOR_STOP_CHANGED, this._updateColorStop,
                 events.preferences.SET_PREFERENCE, this._updatePreferencesBasedMenuItems
             );
 
@@ -273,6 +274,23 @@ define(function (require, exports, module) {
             }.bind(this));
         },
         
+        /**
+         * Updates the color theme menu items.
+         * @private
+         */
+        _updateColorStop: function () {
+            this.waitFor(["ui"], function (uiStore) {
+                var colorStop = uiStore.getColorStop(),
+                    oldMenu = this._applicationMenu;
+
+                this._applicationMenu = this._applicationMenu.updateColorThemeItems(colorStop);
+
+                if (!Immutable.is(oldMenu, this._applicationMenu)) {
+                    this.emit("change");
+                }
+            }.bind(this));
+        },
+
         /**
          * Updates the entries reliant on preferences
          * @private

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -156,6 +156,14 @@ define(function (require, exports, module) {
         _referencePoint: null,
 
         /**
+         * UI color stop. Must be one of "ORIGINAL", "LIGHT", "MEDIUM" or "DARK".
+         *
+         * @private
+         * @type {string}
+         */
+        _colorStop: null,
+
+        /**
          * The coordinates of the current mouse position if it's being tracked; otherwise null.
          *
          * @private
@@ -171,6 +179,7 @@ define(function (require, exports, module) {
                 events.ui.SUPERSELECT_MARQUEE, this._handleMarqueeStart,
                 events.ui.TOGGLE_OVERLAYS, this._handleOverlayToggle,
                 events.ui.REFERENCE_POINT_CHANGED, this._handleReferencePointChanged,
+                events.ui.COLOR_STOP_CHANGED, this._handleColorStopChanged,
                 events.ui.DISPLAY_CHANGED, this._handleDisplayChanged,
                 events.ui.MOUSE_POSITION_CHANGED, this._handleMousePositionChanged,
                 events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
@@ -202,6 +211,7 @@ define(function (require, exports, module) {
             this._transformMatrix = null;
             this._inverseTransformMatrix = null;
             this._referencePoint = "lt";
+            this._colorStop = null;
             this._currentMousePosition = null;
         },
         
@@ -555,6 +565,17 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Set the UI color stop.
+         *
+         * @private
+         * @param {{stop: string}} payload
+         */
+        _handleColorStopChanged: function (payload) {
+            this._colorStop = payload.stop;
+            this.emit("change");
+        },
+
+        /**
          * Re-set the root font size when the display changes.
          *
          * @private
@@ -590,6 +611,15 @@ define(function (require, exports, module) {
          */
         getCurrentTransformMatrix: function () {
             return this._transformMatrix;
+        },
+
+        /**
+         * Get the current UI color stop.
+         *
+         * @return {?string} An element of the enum appLib.colorStops
+         */
+        getColorStop: function () {
+            return this._colorStop;
         }
     });
 

--- a/src/js/util/ui.js
+++ b/src/js/util/ui.js
@@ -167,7 +167,7 @@ define(function (require, exports) {
     /**
      * Asynchronously fetch the current PS color stop.
      *
-     * @return {Promise.<string>} Currently resolves to one of "original", "light", "medium" or "dark".
+     * @return {Promise.<string>} Currently resolves to one of "ORIGINAL", "LIGHT", "MEDIUM" or "DARK".
      */
     var getPSColorStop = function () {
         return descriptor.getProperty("application", "kuiBrightnessLevel")
@@ -176,19 +176,19 @@ define(function (require, exports) {
                 var stop;
                 switch (psColorStop) {
                 case "kPanelBrightnessOriginal":
-                    stop = "original";
+                    stop = "ORIGINAL";
                     break;
                 case "kPanelBrightnessLightGray":
-                    stop = "light";
+                    stop = "LIGHT";
                     break;
                 case "kPanelBrightnessMediumGray":
-                    stop = "medium";
+                    stop = "MEDIUM";
                     break;
                 case "kPanelBrightnessDarkGray":
-                    stop = "dark";
+                    stop = "DARK";
                     break;
                 default:
-                    stop = "dark";
+                    stop = "MEDIUM";
                 }
 
                 return stop;

--- a/src/nls/root/menu.json
+++ b/src/nls/root/menu.json
@@ -228,6 +228,13 @@
         "NEXT_DOCUMENT": "Next Document",
         "TOGGLE_TOOLBAR": "Pin Toolbar",
         "TOGGLE_SINGLE_COLUMN_MODE": "Single-Column Mode",
+        "COLOR_THEME": {
+            "$MENU": "Color Theme",
+            "ORIGINAL": "Original",
+            "LIGHT": "Light",
+            "MEDIUM": "Medium",
+            "DARK": "Dark"
+        },
         "PREVIOUS_DOCUMENT": "Previous Document",
         "RETURN_TO_STANDARD": "Return to Standard Photoshop",
         "OPEN_DOCUMENT": "Open Document",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -414,6 +414,37 @@
             "$action": "ui.togglePinnedToolbar",
             "$enable-rule": "always-except-modal"
         },
+        "COLOR_THEME": {
+            "$enable-rule": "always-except-modal",
+            "ORIGINAL": {
+                "$action": "ui.setColorStop",
+                "$enable-rule": "always-except-modal",
+                "$payload": {
+                    "stop": "ORIGINAL"
+                }
+            },
+            "LIGHT": {
+                "$action": "ui.setColorStop",
+                "$enable-rule": "always-except-modal",
+                "$payload": {
+                    "stop": "LIGHT"
+                }
+            },
+            "MEDIUM": {
+                "$action": "ui.setColorStop",
+                "$enable-rule": "always-except-modal",
+                "$payload": {
+                    "stop": "MEDIUM"
+                }
+            },
+            "DARK": {
+                "$action": "ui.setColorStop",
+                "$enable-rule": "always-except-modal",
+                "$payload": {
+                    "stop": "DARK"
+                }
+            }
+        },
         "TOGGLE_SINGLE_COLUMN_MODE": {
             "$action": "ui.toggleSingleColumnMode",
             "$enable-rule": "always-except-modal"

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -652,6 +652,23 @@
                     "separator": true
                 },
                 {
+                    "id": "COLOR_THEME",
+                    "submenu": [
+                        {
+                            "id": "ORIGINAL"
+                        },
+                        {
+                            "id": "LIGHT"
+                        },
+                        {
+                            "id": "MEDIUM"
+                        },
+                        {
+                            "id": "DARK"
+                        }
+                    ]
+                },
+                {
                     "id": "TOGGLE_TOOLBAR"
                 },
                 {

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -616,6 +616,23 @@
                     "separator": true
                 },
                 {
+                    "id": "COLOR_THEME",
+                    "submenu": [
+                        {
+                            "id": "ORIGINAL"
+                        },
+                        {
+                            "id": "LIGHT"
+                        },
+                        {
+                            "id": "MEDIUM"
+                        },
+                        {
+                            "id": "DARK"
+                        }
+                    ]
+                },
+                {
                     "id": "TOGGLE_TOOLBAR"
                 },
                 {

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -22,7 +22,6 @@
  */
 
 @import "./reset.less";
-
 @import "./shared/colors-shared.less";
 
 html {
@@ -51,38 +50,38 @@ input {
 }
 
 @font-face {
-  font-family: 'Adobe Clean';
-  src: url('file://shared/font/AdobeClean-Regular.otf');
-  font-weight: normal;
-  font-style: normal;
+    font-family: 'Adobe Clean';
+    src: url('file://shared/font/AdobeClean-Regular.otf');
+    font-weight: normal;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: 'Adobe Clean';
-  src: url('file://shared/font/AdobeClean-It.otf');
-  font-weight: normal;
-  font-style: italic;
+    font-family: 'Adobe Clean';
+    src: url('file://shared/font/AdobeClean-It.otf');
+    font-weight: normal;
+    font-style: italic;
 }
 
 @font-face {
-  font-family: 'Adobe Clean';
-  src: url('file://shared/font/AdobeClean-Light.otf');
-  font-weight: 200;
-  font-style: normal;
+    font-family: 'Adobe Clean';
+    src: url('file://shared/font/AdobeClean-Light.otf');
+    font-weight: 200;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: 'Adobe Clean';
-  src: url('file://shared/font/AdobeClean-LightIt.otf');
-  font-weight: 200;
-  font-style: italic;
+    font-family: 'Adobe Clean';
+    src: url('file://shared/font/AdobeClean-LightIt.otf');
+    font-weight: 200;
+    font-style: italic;
 }
 
 @font-face {
-  font-family: 'Adobe Clean';
-  src: url('file://shared/font/AdobeClean-BoldSemiCn.otf');
-  font-weight: 500;
-  font-style: normal;
+    font-family: 'Adobe Clean';
+    src: url('file://shared/font/AdobeClean-BoldSemiCn.otf');
+    font-weight: 500;
+    font-style: normal;
 }
 
 @hairline: 1px;
@@ -99,84 +98,93 @@ input {
 
 // Standard def displays
 @media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 801px) and (max-device-width: 1280px) {
-
-  html { font-size: @base-8; }
-
+    html { font-size: @base-8; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1281px) and (max-device-width: 1440px) {
-
-  html { font-size: @base-8; }
-
+    html { font-size: @base-8; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1441px) and (max-device-width: 1680px) {
-
-  html { font-size: @base-10; }
+    html { font-size: @base-10; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 1681px) {
-
-  html { font-size: @base-10; }
-
+    html { font-size: @base-10; }
 }
 
 // Retina displays
-
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 801px) and (max-device-width: 1280px) {
-
-  html { font-size: @base-8; }
-
+    html { font-size: @base-8; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1281px) and (max-device-width: 1440px) {
-
-  html { font-size: @base-8; }
-
+    html { font-size: @base-8; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1441px) and (max-device-width: 1680px) {
-
-  html { font-size: @base-9; }
+    html { font-size: @base-9; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 1681px) and (max-device-width: 2560px) {
-
-  html { font-size: @base-10; }
-
+    html { font-size: @base-10; }
 }
 
 @media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) {
-
-  html { font-size: @base-11; }
-
+    html { font-size: @base-11; }
 }
 
-/* Setup Color Stops */
-.color-stop__light {
-    @import (multiple) "./shared/colors-light.less";
-    @import (multiple) "./component-styles.less";
+/* -- MASTER CONTAINER -- */
 
-    color: @item-active;
+.fade-in-mixin {
+    &.main__ready .section-container,
+    &.main__ready .section-container__no-collapse {
+        opacity: 1;
+        transition: all 200ms ease;
+    }
 }
 
-.color-stop__dark {
-    @import (multiple) "./shared/colors-dark.less";
-    @import (multiple) "./component-styles.less";
+.main {
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    position: absolute;
+    display: flex;
+    cursor: default;
+    overflow: hidden;
 
-    color: @item-active;
-}
+    /* Setup Color Stops */
+    &.color-stop__light {
+        @import (multiple) "./shared/colors-light.less";
+        @import (multiple) "./component-styles.less";
 
-.color-stop__medium {
-    @import (multiple) "./shared/colors-medium.less";
-    @import (multiple) "./component-styles.less";
+        color: @item-active;
+        .fade-in-mixin();
+    }
 
-    color: @item-active;
-}
+    &.color-stop__dark {
+        @import (multiple) "./shared/colors-dark.less";
+        @import (multiple) "./component-styles.less";
 
-.color-stop__original {
-    @import (multiple) "./shared/colors-original.less";
-    @import (multiple) "./component-styles.less";
+        color: @item-active;
+        .fade-in-mixin();
+    }
 
-    color: @item-active;
+    &.main.color-stop__medium {
+        @import (multiple) "./shared/colors-medium.less";
+        @import (multiple) "./component-styles.less";
+
+        color: @item-active;
+        .fade-in-mixin();
+    }
+
+    &.main.color-stop__original {
+        @import (multiple) "./shared/colors-original.less";
+        @import (multiple) "./component-styles.less";
+
+        color: @item-active;
+
+        .fade-in-mixin();
+    }
 }

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -26,19 +26,6 @@
 @toolbar-width: 3rem;
 @panel-border-width: 0.2rem;
 
-/* -- MASTER CONTAINER -- */
-
-.main {
-    right: 0;
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    position: absolute;
-    display: flex;
-    cursor: default;
-    overflow: hidden;
-}
-
 /* -- PROPERTIES -- */
 .panel-set {
     height: 100%;
@@ -226,12 +213,6 @@
 
 .layer-count {
     opacity: 0;
-}
-
-.main__ready .section-container,
-.main__ready .section-container__no-collapse {
-    opacity: 1;
-    transition: all 200ms ease;
 }
 
 .artboard-presets .section-container,


### PR DESCRIPTION
This PR makes it possible to change the UI color stop (theme) from Design Space via `Window > Color Theme`. Changing the color stop updates the UI theme, the titlebar color and also the artboard backdrop color. Notes:

1. Currently there is a Photoshop bug that prevents the artboard backdrop color from being updated until the canvas is panned or otherwise invalidated, but @jsbache is looking into that.
2. This moves the `color-stop__XYZ` class from `body` to the `Main` React element, which is now in charge of deciding what stop to render.
3. The stop is still fetched at application start time so that the first render has the correct theme, but it's also fetched in `ui.beforeStartup` so that the correct value can make it into the store. This is slightly redundant, but tolerable I think.
4. I made some unrelated whitespace cleanups in main.less since I was in there anyway.