### PR TITLE
Update transform after a duplicate drag

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1302,7 +1302,11 @@ define(function (require, exports) {
                 // a somewhat more optimistic copy routine, instead of addLayers
                 // which doesn't know that the layers being added are copies of
                 // existing layers.
-                return this.flux.actions.layers.addLayers(currentDoc, toIDs, true, false);
+                return this.flux.actions.layers.addLayers(currentDoc, toIDs, true, false)
+                    .bind(this)
+                    .then(function () {
+                        return this.flux.actions.ui.updateTransform();
+                    });
             } else {
                 return debouncedMoveHandler();
             }


### PR DESCRIPTION
Not entirely sure on the root cause of bug #3149, but from running my snippets I could see that it wasn't the bounds that were the culprit, but the transformation. We get `move` and `moveToArtboard` notifications, and we must be updating our transform before Photoshop finished settling the transform matrix.

I know this is vague, but updating the transform after the duplicate solves the problem.

Addresses #3149

