### PR TITLE
Short circuit resetLayers if passed in doc no longer exists

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -481,6 +481,13 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
+        var storedDocument = this.flux.store("document").getDocument(document.id);
+
+        if (!storedDocument) {
+            log.debug("Ignoring this resetLayers call, the document does not exist");
+            return Promise.resolve();
+        }
+
         var docRef = documentLib.referenceBy.id(document.id),
             layersPromise;
 
@@ -542,7 +549,7 @@ define(function (require, exports) {
             .then(function (descriptors) {
                 var index = 0, // annoyingly, Immutable.Set.prototype.forEach does not provide an index
                     payload = {
-                        documentID: document.id,
+                        documentID: storedDocument.id,
                         suppressDirty: suppressDirty,
                         lazy: lazy
                     };


### PR DESCRIPTION
Addresses #3258, PS would diligently send us the `make` event for the text layer under edit as we're closing the document, and we would enqueue the `resetLayers` action. And since the document was gone, things would go on the fritz. Now we check to see if the document model still exists, similar to what handleHistoryState does.