### PR TITLE
Small NumberInput cleanup, consistent property naming

### DIFF
--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
                     ref="libraryNameInput"
                     className="libraries__bar__input"
                     value={inputDefaultValue}
-                    placeholderText={nls.localize("strings.LIBRARIES.LIBRARY_NAME")}
+                    placeholder={nls.localize("strings.LIBRARIES.LIBRARY_NAME")}
                     onKeyDown={this._handleLibraryNameInputKeydown}/>
                 <div className="libraries__bar__btn-cancel"
                      onClick={this._handleCancelCommand}>

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -727,8 +727,7 @@ define(function (require, exports, module) {
                                 min={MIN_TRACKING}
                                 max={MAX_TRACKING}
                                 size="column-5"
-                                onChange={this._handleTrackingChange}
-                                valueType="size" />
+                                onChange={this._handleTrackingChange} />
                         </div>
                         <div className=" control-group control-group__vertical">
                             <Label
@@ -745,8 +744,7 @@ define(function (require, exports, module) {
                                 max={toPixels(MAX_LEADING_PTS)}
                                 disabled={locked}
                                 special={nls.localize("strings.STYLE.TYPE.AUTO_LEADING")}
-                                onChange={this._handleLeadingChange}
-                                valueType="size" />
+                                onChange={this._handleLeadingChange} />
                         </div>
                     </div>
                 </div>

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -728,7 +728,7 @@ define(function (require, exports, module) {
                         size={size}
                         continuous={true}
                         value={title}
-                        placeholderText={this.props.placeholderText}
+                        placeholder={this.props.placeholderText}
                         neverSelectAll={this.props.neverSelectAllInput}
                         onFocus={this._handleInputFocus}
                         onBlur={this._handleInputBlur}

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -56,14 +56,26 @@ define(function (require, exports, module) {
                 React.PropTypes.string,
                 React.PropTypes.instanceOf(Immutable.Iterable)
             ]),
+            // special string value which, if matched, will be passed directly 
+            // into the DOM element (rather than formatted)
             special: React.PropTypes.string,
+            // Function to call when value is committed 
             onChange: React.PropTypes.func.isRequired,
+            // Amount to change per arrow key increment
             step: React.PropTypes.number,
+            // Amount to change per arrow key + modifier increment
             bigstep: React.PropTypes.number,
+            // Minimum value for input
             min: React.PropTypes.number,
+            // Maximum value for input
             max: React.PropTypes.number,
+            // Precision for rounding number for display
             precision: React.PropTypes.number,
+            // Placeholder text for the input
+            placeholder: React.PropTypes.string,
+            // Disable input
             disabled: React.PropTypes.bool,
+            // (Unit) suffix to add to display of number
             suffix: React.PropTypes.string
         },
 
@@ -415,10 +427,10 @@ define(function (require, exports, module) {
 
             return (
                 <input
-                    {...this.props}
                     type="text"
                     ref="input"
                     spellCheck="false"
+                    placeholder={this.props.placeholder}
                     className={className}
                     disabled={this.props.disabled}
                     value={this.state.rawValue}

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
             // Disable editing and selection of the input
             disabled: React.PropTypes.bool,
             // Placeholder text for the input
-            placeholderText: React.PropTypes.string,
+            placeholder: React.PropTypes.string,
             // Disallow the element from being immediately (single click) focusable 
             doubleClickToEdit: React.PropTypes.bool,
             // On every DOM change event, fire the TextInput onChange handler
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
                 disabled: false,
                 doubleClickToEdit: false,
                 continuous: false,
-                placeholderText: "",
+                placeholder: "",
                 neverSelectAll: false,
                 preventHorizontalScrolling: true
             };
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
         shouldComponentUpdate: function (nextProps, nextState) {
             return !Immutable.is(this.props.value, nextProps.value) ||
                 !Immutable.is(this.state.value, nextState.value) ||
-                !Immutable.is(this.props.placeholderText, nextProps.placeholderText) ||
+                !Immutable.is(this.props.placeholder, nextProps.placeholder) ||
                 this.props.title !== nextProps.title ||
                 this.state.editing !== nextState.editing;
         },
@@ -424,7 +424,7 @@ define(function (require, exports, module) {
                         title={this.props.title}
                         className={className}
                         disabled={this.props.disabled}
-                        placeholder={this.props.placeholderText}
+                        placeholder={this.props.placeholder}
                         onClick={this.props.onClick}
                         onChange={this._handleChange}
                         onKeyDown={this._handleKeyDown}


### PR DESCRIPTION
NumberInput usage was already pretty clean across Design Space. Similar to TextInput, I cleaned up some old properties, removed the property expansion that had existed, added a few notes for the different properties.

Additionally, moved everything to use `placeholder` as the property name for placeholder text. This is the HTML property name, NumberInput and TextInput had slightly varying names.