### PR TITLE
Datalist refactoring

### DIFF
--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -106,6 +106,7 @@ define(function (require, exports, module) {
          * Update this asset's scale
          *
          * @private
+         * @type {Datalist~onChange}
          */
         _handleUpdateScale: function (scale) {
             var scaleNum = mathUtil.parseNumber(scale);
@@ -128,6 +129,7 @@ define(function (require, exports, module) {
          * Update this asset's format and quality
          *
          * @private
+         * @type {Datalist~onChange}
          */
         _handleUpdateFormat: function (id) {
             var formatIndex = mathUtil.parseNumber(id),
@@ -172,10 +174,8 @@ define(function (require, exports, module) {
                             className="dialog-export-scale"
                             options={_scaleOptions.toList()}
                             value={scaleOption.title}
-                            defaultSelected={scaleOption.id}
+                            selected={scaleOption.id}
                             onChange={this._handleUpdateScale}
-                            live={false}
-                            autoSelect={false}
                             changeOnBlur={false}
                             size="column-4" />
                     </div>
@@ -191,10 +191,8 @@ define(function (require, exports, module) {
                             className="dialog-export-format"
                             options={_formatOptions.toList()}
                             value={formatOption.title}
-                            defaultSelected={formatOptionId}
+                            selected={formatOptionId}
                             onChange={this._handleUpdateFormat}
-                            live={false}
-                            autoSelect={false}
                             changeOnBlur={false}
                             size="column-8" />
                     </div>

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -101,8 +101,7 @@ define(function (require, exports, module) {
          * Handles the list item selection. 
          *
          * @private
-         * @param {string} itemID - either libraryID or one of _LIBRARY_COMMANDS.
-         * @return {boolean}
+         * @type {Datalist~onChange}
          */
         _handleSelectListItem: function (itemID) {
             if (_LIBRARY_COMMANDS.indexOf(itemID) === -1) {
@@ -116,9 +115,6 @@ define(function (require, exports, module) {
             if (itemID === _CREATE_LIBRARY && this.props.onCreateLibrary) {
                 this.props.onCreateLibrary(true);
             }
-
-            // Return false to cancel the current selection.
-            return false;
         },
 
         /**
@@ -347,11 +343,9 @@ define(function (require, exports, module) {
                     className="dialog-libraries"
                     options={listOptions}
                     value={selectedLibraryName}
-                    live={false}
-                    autoSelect={false}
                     onChange={this._handleSelectListItem}
                     releaseOnBlur={true}
-                    defaultSelected={selectedLibraryID}
+                    selected={selectedLibraryID}
                     disabled={this.props.disabled} />
                 <SplitButtonList className="libraries__split-button-list">
                     <SplitButtonItem

--- a/src/js/jsx/sections/style/BlendMode.jsx
+++ b/src/js/jsx/sections/style/BlendMode.jsx
@@ -209,9 +209,9 @@ define(function (require, exports, module) {
                     className="dialog-blendmodes"
                     options={modesToShow}
                     value={title}
-                    defaultSelected={mode}
+                    selected={mode}
                     size={this.props.size}
-                    onChange={this.props.handleChange}
+                    onHighlightedChange={this.props.handleChange}
                     onFocus={this.props.onFocus} />
             );
         }

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
          * Set the type face of the selected text layers from a font's ID.
          * 
          * @private
-         * @param {string} typefaceID
+         * @type {Datalist~onHighlightedChange}
          */
         _handleTypefaceChange: function (typefaceID) {
             var typefaceIndex = mathUtil.parseNumber(typefaceID), // typefaceID is equivalent to index in typefaces
@@ -159,12 +159,12 @@ define(function (require, exports, module) {
 
             this._setPostScript(postScriptName);
         },
-        
+
         /**
-         * Handle change of type weight.
+         * Handle change of type weight. 
          *
          * @private
-         * @param {string} postScriptName
+         * @type {Datalist~onHighlightedChange}
          */
         _handleTypeWeightChange: function (postScriptName) {
             this._setPostScript(postScriptName);
@@ -651,11 +651,11 @@ define(function (require, exports, module) {
                             disabled={locked}
                             list={typefaceListID}
                             value={familyName}
-                            defaultSelected={selectedTypefaceID}
+                            selected={selectedTypefaceID}
                             placeholderText={placeholderText}
                             options={this.state.typefaces}
-                            onChange={this._handleTypefaceChange}
-                            size="column-full" />
+                            size="column-full"
+                            onHighlightedChange={this._handleTypefaceChange}/>
                     </div>
                     <div className="formline formline__space-between">
                         <div className={"control-group control-group__vertical column-4"}>
@@ -675,10 +675,10 @@ define(function (require, exports, module) {
                                 list={weightListID}
                                 disabled={locked || !styleTitle}
                                 value={styleTitle}
-                                defaultSelected={postScriptFamilyName}
+                                selected={postScriptFamilyName}
                                 options={familyFontOptions}
-                                onChange={this._handleTypeWeightChange}
-                                size="column-22" />
+                                size="column-22"
+                                onHighlightedChange={this._handleTypeWeightChange}/>
                         </div>
                     </div>
                     <div className="formline formline__space-between">

--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -231,7 +231,8 @@ define(function (require, exports, module) {
          * @param {string} id
          */
         _setSelected: function (id) {
-            if (this.props.onChange(id) !== false) {
+            if (this._lastSelected !== id && this.props.onChange(id) !== false) {
+                this._lastSelected = id;
                 this.setState({
                     selected: id
                 });


### PR DESCRIPTION

This PR made the following improvements:

* added `onHighlightedChange` callback to distinguish with `onChange`. The first one is fired when the current highlighted option is changed (mouse over or using arrow key), and the latter is fired when the user confirm the selection via mouse click / return / enter.
* Removed `live` `autoSelect ` prop, as you can use the `onHighlightedChange` instead. Also clean up some internal state.
* added `onClose` (you can search `Datalist~onClose` for details). With this we should be able to revet to initial selection if user close the list with selecting the highlighted option for Type/Blend mode, but things get more complicated when it comes to MIXED state, so I did not introduce the change in this PR yet.
* Better jsdoc for callbacks.
* Bug fix: disabled Tab key in the search dialog. otherwise the search input will lose focus while the dialog is still open, which does not look right.

@designedbyscience can you please review? Thank you.
