### PR TITLE
Keep webpack watcher alive on compilation errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -188,7 +188,8 @@ module.exports = function (grunt) {
             },
             watch: {
                 watch: true,
-                keepalive: true
+                keepalive: true,
+                failOnError: false
             }
         },
         uglify: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ var buildConfigs = languages.map(function (lang) {
             path: "./build/",
             filename: "spaces-design-" + lang + ".js"
         },
-        bail: true, // Abort after first error
         module: {
             loaders: [
                 // Transpiling React code to js


### PR DESCRIPTION
Simple fix for #3366, should make developing a bit faster.