### PR TITLE
Add 0.33 and 0.67 export scales [master]

### DIFF
--- a/src/js/models/exportasset.js
+++ b/src/js/models/exportasset.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
      *
      * @type {Imutable.List.<number>}
      */
-    var SCALES = Immutable.List([1, 2, 3, 4, 5, 0.5, 0.75, 1.5]);
+    var SCALES = Immutable.List([1, 2, 3, 4, 5, 0.33, 0.5, 0.67, 0.75, 1.5]);
 
     /**
      * @constructor


### PR DESCRIPTION
This is a tiny workaround for #3331. This does not fully address the issue. This pull request is against master; there will be a different PR against the `ps-16.1` branch. 