### PR TITLE
Notify webpack build status via system notifications.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "uglifyjs": "^2.4.10",
     "url-loader": "^0.5.6",
     "webpack": "^1.12.3",
-    "webpack-dev-server": "^1.12.1"
+    "webpack-dev-server": "^1.12.1",
+    "webpack-notifier": "^1.2.1"
   },
   "dependencies": {
     "bluebird": "^3.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,8 @@
 "use strict";
 
 var path = require("path"),
-    webpack = require("webpack");
+    webpack = require("webpack"),
+    WebpackNotifierPlugin = require("webpack-notifier");
 
 require("es6-promise").polyfill(); // Required for css loading
 
@@ -105,7 +106,8 @@ var buildConfigs = languages.map(function (lang) {
             // This passes __PG_DEBUG__ variable to the bundle
             new webpack.DefinePlugin({
                 __PG_DEBUG__: devMode
-            })
+            }),
+            new WebpackNotifierPlugin({ alwaysNotify: true })
         ]
     };
 


### PR DESCRIPTION
* You will receive a system notification everytime when webpack rebuilds. This might have better experience than reloading Design Space without knowing whether your change is integrated. 
* Syntax error will not abort `grunt debug`. It will send system notification instead.

<img width="865" alt="screen shot 2015-12-07 at 11 06 31 am" src="https://cloud.githubusercontent.com/assets/118264/11636842/07b4ce28-9cd3-11e5-941e-de50e63deab3.png">
