### PR TITLE
Factor panel actions/store/lock out of ui actions/store/lock

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -670,7 +670,7 @@ define(function (require, exports) {
         return this.transfer(ui.setOverlayOffsetsForFirstDocument)
             .bind(this)
             .then(function () {
-                this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
+                this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
 
                 if (!filePath) {
                     // An "open" event will be triggered
@@ -705,7 +705,7 @@ define(function (require, exports) {
     };
     open.action = {
         reads: [],
-        writes: [locks.PS_APP, locks.JS_UI],
+        writes: [locks.PS_APP, locks.JS_PANEL],
         transfers: [initActiveDocument, ui.updateTransform, application.updateRecentFiles,
             ui.setOverlayOffsetsForFirstDocument, menu.native, toolActions.changeVectorMaskMode],
         lockUI: true,
@@ -725,7 +725,7 @@ define(function (require, exports) {
             document = this.flux.store("application").getCurrentDocument();
         }
 
-        this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
+        this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
 
         var closeObj = documentLib.close(document.id),
             playOptions = {
@@ -747,7 +747,7 @@ define(function (require, exports) {
     };
     close.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_UI, locks.PS_APP, locks.PS_DOC],
+        writes: [locks.JS_PANEL, locks.PS_APP, locks.PS_DOC],
         transfers: [ui.cloak, disposeDocument],
         lockUI: true,
         post: [_verifyActiveDocument, _verifyOpenDocuments]
@@ -765,7 +765,7 @@ define(function (require, exports) {
             document = flux.stores.document.getDocument(documentID),
             documentRef = documentLib.referenceBy.id(documentID);
 
-        this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: false });
+        this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
 
         return this.transfer(ui.cloak)
             .bind(this)
@@ -810,7 +810,7 @@ define(function (require, exports) {
     };
     selectDocument.action = {
         reads: [locks.JS_TOOL],
-        writes: [locks.JS_APP],
+        writes: [locks.JS_APP, locks.JS_PANEL],
         transfers: ["layers.resetLinkedLayers", historyActions.queryCurrentHistory,
             ui.updateTransform, toolActions.select, ui.cloak, guideActions.queryCurrentGuides,
             toolActions.changeVectorMaskMode, updateDocument],

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -386,16 +386,16 @@ define(function (require, exports) {
             return Promise.resolve();
         } else {
             return Promise.join(
-                this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false }),
+                this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
                 this.transfer(history.decrementHistory, currentDocument.id),
                 function () {
-                    return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
+                    return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
                 }.bind(this));
         }
     };
     undo.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_UI],
+        writes: [locks.JS_PANEL],
         transfers: [history.decrementHistory],
         post: [layers._verifyLayerIndex],
         modal: true
@@ -413,10 +413,10 @@ define(function (require, exports) {
             return Promise.resolve();
         } else {
             return Promise.join(
-                this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false }),
+                this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
                 this.transfer(history.incrementHistory, currentDocument.id),
                 function () {
-                    return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
+                    return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
                 }.bind(this));
         }
     };

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -103,9 +103,11 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var resetGuidePolicies = function () {
-        var toolStore = this.flux.store("tool"),
-            appStore = this.flux.store("application"),
-            uiStore = this.flux.store("ui"),
+        var flux = this.flux,
+            toolStore = flux.store("tool"),
+            appStore = flux.store("application"),
+            uiStore = flux.store("ui"),
+            panelStore = flux.store("panel"),
             currentDocument = appStore.getCurrentDocument(),
             currentPolicy = _currentGuidePolicyID,
             currentTool = toolStore.getCurrentTool(),
@@ -125,7 +127,7 @@ define(function (require, exports) {
         // How thick the policy line should be while defined as an area around the guide
         var policyThickness = 2,
             guides = currentDocument.guides,
-            canvasBounds = uiStore.getCloakRect(),
+            canvasBounds = panelStore.getCloakRect(),
             topAncestors = currentDocument.layers.selectedTopAncestors,
             topAncestorIDs = collection.pluck(topAncestors, "id"),
             visibleGuides = guides.filter(function (guide) {
@@ -180,7 +182,7 @@ define(function (require, exports) {
             });
     };
     resetGuidePolicies.action = {
-        reads: [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI],
+        reads: [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI, locks.JS_PANEL],
         writes: [],
         transfers: [policy.removePointerPolicies, policy.addPointerPolicies],
         modal: true
@@ -236,8 +238,10 @@ define(function (require, exports) {
      * @return {boolean} True if guide is within the canvas bounds
      */
     var _guideWithinVisibleCanvas = function (orientation, position) {
-        var uiStore = this.flux.store("ui"),
-            cloakRect = uiStore.getCloakRect(),
+        var flux = this.flux,
+            uiStore = flux.store("ui"),
+            panelStore = flux.store("panel"),
+            cloakRect = panelStore.getCloakRect(),
             horizontal = orientation === "horizontal",
             x = horizontal ? 0 : position,
             y = horizontal ? position : 0,
@@ -331,7 +335,7 @@ define(function (require, exports) {
             });
     };
     setGuide.action = {
-        reads: [],
+        reads: [locks.JS_UI, locks.JS_PANEL],
         writes: [locks.JS_DOC],
         transfers: [resetGuidePolicies, deleteGuide]
     };

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -300,7 +300,7 @@ define(function (require, exports) {
     var revertCurrentDocument = function () {
         var historyStore = this.flux.store("history"),
             currentDocumentID = this.flux.store("application").getCurrentDocumentID(),
-            clearOverlaysPromise = this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: false }),
+            clearOverlaysPromise = this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
             nextStateIndex = historyStore.lastSavedStateIndex(currentDocumentID),
             superPromise;
         
@@ -328,12 +328,12 @@ define(function (require, exports) {
         return Promise.join(clearOverlaysPromise, superPromise)
             .bind(this)
             .then(function () {
-                return this.dispatchAsync(events.ui.TOGGLE_OVERLAYS, { enabled: true });
+                return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
             });
     };
     revertCurrentDocument.action = {
         reads: [locks.JS_APP],
-        writes: [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC, locks.JS_UI],
+        writes: [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC, locks.JS_PANEL],
         transfers: ["documents.updateDocument"],
         post: [layerActions._verifyLayerIndex],
         modal: true

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -815,9 +815,10 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var createLayerFromElement = function (element, location) {
-        var appStore = this.flux.store("application"),
-            libState = this.flux.store("library").getState(),
-            uiStore = this.flux.store("ui"),
+        var flux = this.flux,
+            appStore = flux.store("application"),
+            libState = flux.store("library").getState(),
+            uiStore = flux.store("ui"),
             currentDocument = appStore.getCurrentDocument(),
             currentLibrary = libState.currentLibrary,
             pixelRatio = window.devicePixelRatio;

--- a/src/js/actions/sampler.js
+++ b/src/js/actions/sampler.js
@@ -345,8 +345,9 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var click = function (doc, x, y, secondary) {
-        var uiStore = this.flux.store("ui"),
-            docStore = this.flux.store("document"),
+        var flux = this.flux,
+            uiStore = flux.store("ui"),
+            docStore = flux.store("document"),
             coords = uiStore.transformWindowToCanvas(x, y),
             layerTree = doc.layers;
         
@@ -405,8 +406,9 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var showHUD = function (doc, x, y) {
-        var uiStore = this.flux.store("ui"),
-            docStore = this.flux.store("document"),
+        var flux = this.flux,
+            uiStore = flux.store("ui"),
+            docStore = flux.store("document"),
             coords = uiStore.transformWindowToCanvas(x, y),
             layerTree = doc.layers;
 

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -637,7 +637,7 @@ define(function (require, exports) {
         }
         
         if (dontDeselect) {
-            return this.dispatchAsync(events.ui.SUPERSELECT_MARQUEE, { x: x, y: y, enabled: true });
+            return this.dispatchAsync(events.panel.SUPERSELECT_MARQUEE, { x: x, y: y, enabled: true });
         } else {
             var uiStore = this.flux.store("ui"),
                 canvasCoords = uiStore.transformWindowToCanvas(x, y),
@@ -645,7 +645,7 @@ define(function (require, exports) {
 
             if (coveredLayers.isEmpty()) {
                 // This general bounds check on JS prevents a PS call and starts marquee faster
-                return this.dispatchAsync(events.ui.SUPERSELECT_MARQUEE, { x: x, y: y, enabled: true });
+                return this.dispatchAsync(events.panel.SUPERSELECT_MARQUEE, { x: x, y: y, enabled: true });
             } else {
                 // Hide transform controls
                 return descriptor.playObject(toolLib.setToolOptions("moveTool", { "$Abbx": false }))
@@ -675,8 +675,8 @@ define(function (require, exports) {
         }
     };
     drag.action = {
-        reads: [locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_UI],
+        reads: [locks.JS_DOC, locks.JS_UI],
+        writes: [locks.PS_DOC, locks.JS_PANEL],
         transfers: [click]
     };
 
@@ -692,7 +692,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var marqueeSelect = function (doc, runMarquee, ids, add) {
-        this.dispatch(events.ui.SUPERSELECT_MARQUEE, { enabled: false });
+        this.dispatch(events.panel.SUPERSELECT_MARQUEE, { enabled: false });
 
         if (!runMarquee || !ids) {
             return Promise.resolve();
@@ -713,7 +713,7 @@ define(function (require, exports) {
     };
     marqueeSelect.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.JS_UI],
+        writes: [locks.JS_PANEL],
         transfers: [layerActions.deselectAll, layerActions.select]
     };
 

--- a/src/js/actions/tool/sampler.js
+++ b/src/js/actions/tool/sampler.js
@@ -45,7 +45,7 @@ define(function (require, exports) {
      */
     var select = function () {
         _mouseMoveHandler = _.throttle(function (event) {
-            this.dispatch(events.ui.MOUSE_POSITION_CHANGED, {
+            this.dispatch(events.panel.MOUSE_POSITION_CHANGED, {
                 currentMouseX: event.location[0],
                 currentMouseY: event.location[1]
             });
@@ -71,7 +71,7 @@ define(function (require, exports) {
     var deselect = function () {
         OS.removeListener("externalMouseMove", _mouseMoveHandler);
 
-        var mousePositionPromise = this.dispatchAsync(events.ui.MOUSE_POSITION_CHANGED, null),
+        var mousePositionPromise = this.dispatchAsync(events.panel.MOUSE_POSITION_CHANGED, null),
             hideHUDPromise = this.dispatchAsync(events.style.HIDE_HUD)
                 .bind(this)
                 .then(function () {
@@ -83,7 +83,7 @@ define(function (require, exports) {
     };
     deselect.action = {
         reads: [],
-        writes: [locks.JS_UI],
+        writes: [locks.JS_PANEL],
         transfers: ["policy.setMode"],
         modal: true
     };

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1262,7 +1262,7 @@ define(function (require, exports) {
         }, this);
 
         _layerTransformHandler = function (event) {
-            this.dispatch(events.ui.TOGGLE_OVERLAYS, { enabled: true });
+            this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: true });
 
             var appStore = this.flux.store("application"),
                 currentDoc = appStore.getCurrentDocument();

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -114,12 +114,14 @@ define(function (require, exports, module) {
         },
         ui: {
             TRANSFORM_UPDATED: "transformUpdated",
+            DISPLAY_CHANGED: "displayChanged"
+        },
+        panel: {
             PANELS_RESIZED: "panelsResized",
             TOGGLE_OVERLAYS: "toggleOverlays",
             SUPERSELECT_MARQUEE: "superselectMarquee",
             REFERENCE_POINT_CHANGED: "referencePointChanged",
             COLOR_STOP_CHANGED: "colorStopChanged",
-            DISPLAY_CHANGED: "displayChanged",
             MOUSE_POSITION_CHANGED: "mousePositionChanged"
         },
         modifiers: {

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
                 applicationStore = flux.store("application"),
                 applicationState = applicationStore.getState(),
                 preferencesState = flux.store("preferences").getState(),
-                components = flux.store("ui").components,
+                components = flux.store("panel").components,
                 documentIDs = applicationState.documentIDs,
                 document = applicationStore.getCurrentDocument(),
                 count = applicationStore.getDocumentCount(),

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
         PROPERTIES_COL = "propertiesVisible";
 
     var Main = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("preferences", "ui")],
+        mixins: [FluxMixin, StoreWatchMixin("preferences", "panel")],
 
         propTypes: {
             initialColorStop: React.PropTypes.string.isRequired
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
                 propertiesCol = preferences.get(PROPERTIES_COL, true) ? 1 : 0,
                 layersCol = preferences.get(LAYERS_LIBRARY_COL, true) ? 1 : 0,
                 numPanels = propertiesCol + layersCol,
-                colorStop = flux.store("ui").getColorStop() || this.props.initialColorStop;
+                colorStop = flux.store("panel").getColorStop() || this.props.initialColorStop;
 
             return {
                 numberOfPanels: numPanels,

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -82,9 +82,9 @@ define(function (require, exports, module) {
                 preferences = preferencesStore.getState();
                 
             // Grab preferences for each UI panel
-            var uiStore = flux.store("ui");
-            _.forOwn(uiStore.components, function (uiComponent) {
-                fluxState[uiComponent] = preferences.get(uiComponent, true);
+            var panelStore = flux.store("panel");
+            _.forOwn(panelStore.components, function (panelComponent) {
+                fluxState[panelComponent] = preferences.get(panelComponent, true);
             });
       
             return fluxState;
@@ -109,12 +109,12 @@ define(function (require, exports, module) {
             var columnCount = 0;
             if (this.state.activeDocument && this.state.activeDocumentInitialized &&
                 this.state.documentIDs.size > 0 && !this.props.singleColumnModeEnabled) {
-                var uiStore = this.getFlux().store("ui");
-                if (this.state[uiStore.components.LAYERS_LIBRARY_COL]) {
+                var panelStore = this.getFlux().store("panel");
+                if (this.state[panelStore.components.LAYERS_LIBRARY_COL]) {
                     columnCount++;
                 }
 
-                if (this.state[uiStore.components.PROPERTIES_COL]) {
+                if (this.state[panelStore.components.PROPERTIES_COL]) {
                     columnCount++;
                 }
             } else {
@@ -148,8 +148,8 @@ define(function (require, exports, module) {
                 return !!state.activeDocument;
             };
 
-            var uiStore = this.getFlux().store("ui"),
-                components = uiStore.components;
+            var panelStore = this.getFlux().store("panel"),
+                components = panelStore.components;
 
             // NOTE: Special case of going from No Doc state requires update to panel sizes
             if (prevState.activeDocumentInitialized !== this.state.activeDocumentInitialized ||
@@ -180,14 +180,14 @@ define(function (require, exports, module) {
                 return false;
             }
 
-            var uiStore = this.getFlux().store("ui"),
-                uiVisibilityChanged = _.some(uiStore.components, function (uiComponent) {
-                    if (this.state[uiComponent] !== nextState[uiComponent]) {
+            var panelStore = this.getFlux().store("panel"),
+                panelVisibilityChanged = _.some(panelStore.components, function (panelComponent) {
+                    if (this.state[panelComponent] !== nextState[panelComponent]) {
                         return true;
                     }
                 }, this);
 
-            return uiVisibilityChanged ||
+            return panelVisibilityChanged ||
                 this.state.activeDocumentInitialized !== nextState.activeDocumentInitialized ||
                 this.state.recentFilesInitialized !== nextState.recentFilesInitialized ||
                 (nextState.documentIDs.size === 0 && !Immutable.is(this.state.recentFiles, nextState.recentFiles)) ||
@@ -197,9 +197,9 @@ define(function (require, exports, module) {
         /** @ignore */
         _handleColumnVisibilityToggle: function (columnName) {
             var flux = this.getFlux(),
-                uiStore = flux.store("ui"),
+                panelStore = flux.store("panel"),
                 modifierStore = flux.store("modifier"),
-                components = uiStore.components,
+                components = panelStore.components,
                 modifierState = modifierStore.getState(),
                 swapModifier = system.isMac ? modifierState.command : modifierState.control,
                 currentlyVisible,
@@ -261,8 +261,8 @@ define(function (require, exports, module) {
                 activeDocument = this.state.activeDocument;
 
             if (activeDocument && this.state.activeDocumentInitialized && documentIDs.size > 0) {
-                var uiStore = this.getFlux().store("ui"),
-                    components = uiStore.components,
+                var panelStore = this.getFlux().store("panel"),
+                    components = panelStore.components,
                     documentProperties = {
                         transformPanels: [],
                         appearancePanels: [],

--- a/src/js/jsx/Scrim.jsx
+++ b/src/js/jsx/Scrim.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         Droppable = require("js/jsx/shared/Droppable");
     
     var Scrim = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("dialog", "tool", "ui", "application", "preferences")],
+        mixins: [FluxMixin, StoreWatchMixin("dialog", "tool", "ui", "panel", "application", "preferences")],
 
         /**
          * Dispatches (synthetic) click events from the scrim to the currently
@@ -178,6 +178,7 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 toolState = flux.store("tool").getState(),
                 uiState = flux.store("ui").getState(),
+                panelState = flux.store("panel").getState(),
                 preferenceStore = flux.store("preferences"),
                 applicationStore = flux.store("application"),
                 applicationState = applicationStore.getState(),
@@ -188,7 +189,7 @@ define(function (require, exports, module) {
             return {
                 current: toolState.current,
                 transform: uiState.inverseTransformMatrix,
-                overlaysEnabled: uiState.overlaysEnabled,
+                overlaysEnabled: panelState.overlaysEnabled,
                 policyFrames: policyFrames,
                 document: document,
                 activeDocumentInitialized: applicationState.activeDocumentInitialized,

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -254,7 +254,9 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 newWidth = this.getToolbarWidth();
 
-            return flux.actions.ui.updateToolbarWidth(newWidth);
+            return flux.actions.ui.updatePanelSizes({
+                toolbarWidth: newWidth
+            });
         },
 
         /**

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
         _handleWidthChange: function (event, newWidth) {
             var document = this.props.document,
                 flux = this.getFlux(),
-                referencePoint = flux.store("ui").getState().referencePoint;
+                referencePoint = flux.store("panel").getState().referencePoint;
 
             flux.actions.transform
                 .setSizeThrottled(document, document.layers.selected, { w: newWidth }, referencePoint);
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
         _handleHeightChange: function (event, newHeight) {
             var document = this.props.document,
                 flux = this.getFlux(),
-                referencePoint = flux.store("ui").getState().referencePoint;
+                referencePoint = flux.store("panel").getState().referencePoint;
             
             this.getFlux().actions.transform
                 .setSizeThrottled(document, document.layers.selected, { h: newHeight }, referencePoint);

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -39,14 +39,14 @@ define(function (require, exports, module) {
         nls = require("js/util/nls");
 
     var TransformPanel = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("ui")],
+        mixins: [FluxMixin, StoreWatchMixin("panel")],
 
         getStateFromFlux: function () {
-            var uiStore = this.getFlux().store("ui"),
-                uiState = uiStore.getState();
+            var panelStore = this.getFlux().store("panel"),
+                panelState = panelStore.getState();
 
             return {
-                referencePoint: uiState.referencePoint
+                referencePoint: panelState.referencePoint
             };
         },
 

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -248,7 +248,7 @@ define(function (require, exports, module) {
                 dialogBounds = dialogEl.getBoundingClientRect();
 
                 var dialogElLeft = null,
-                    cloakingRect = this.getFlux().store("ui").getCloakRect(),
+                    cloakingRect = this.getFlux().store("panel").getCloakRect(),
                     cloakingRectWidth = cloakingRect.right - cloakingRect.left;
 
                 if (dialogBounds.width < cloakingRectWidth) {

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     var mathUtil = require("js/util/math");
 
     var GuidesOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("dialog", "document", "tool", "application", "ui")],
+        mixins: [FluxMixin, StoreWatchMixin("dialog", "document", "tool", "application", "panel")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -63,9 +63,9 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 applicationStore = flux.store("application"),
                 toolStore = flux.store("tool"),
-                uiStore = flux.store("ui"),
+                panelStore = flux.store("panel"),
                 modalState = toolStore.getModalToolState(),
-                uiState = uiStore.getState(),
+                panelState = panelStore.getState(),
                 currentTool = toolStore.getCurrentTool(),
                 currentDocument = applicationStore.getCurrentDocument(),
                 appIsModal = flux.store("dialog").getState().appIsModal;
@@ -74,12 +74,12 @@ define(function (require, exports, module) {
                 document: currentDocument,
                 tool: currentTool,
                 modalState: modalState || appIsModal,
-                uiState: uiState
+                overlaysEnabled: panelState.overlaysEnabled
             };
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            return !_.isEqual(this.state.uiState, nextState.uiState) ||
+            return !_.isEqual(this.state.overlaysEnabled, nextState.overlaysEnabled) ||
                 !Immutable.is(this.state.document, nextState.document) ||
                 this.state.tool !== nextState.tool ||
                 this.state.modalState !== nextState.modalState;
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
             svg.selectAll(".guide-edges-group").remove();
 
             if (!currentDocument || this.state.modalState ||
-                !this.state.uiState.overlaysEnabled ||
+                !this.state.overlaysEnabled ||
                 !currentDocument.guidesVisible ||
                 !currentTool || currentTool.id !== "newSelect") {
                 return null;
@@ -176,8 +176,8 @@ define(function (require, exports, module) {
          * Draws the guide edge areas
          */
         drawGuideEdges: function () {
-            var uiStore = this.getFlux().store("ui"),
-                canvasBounds = uiStore.getCloakRect();
+            var panelStore = this.getFlux().store("panel"),
+                canvasBounds = panelStore.getCloakRect();
                 
             if (!canvasBounds) {
                 return;

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -35,14 +35,14 @@ define(function (require, exports, module) {
     var UI = require("adapter").ps.ui;
 
     var PolicyOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("policy", "ui")],
+        mixins: [FluxMixin, StoreWatchMixin("policy", "panel")],
 
         getStateFromFlux: function () {
             var flux = this.getFlux(),
                 policyStore = flux.store("policy"),
-                uiStore = flux.store("ui"),
+                panelStore = flux.store("panel"),
                 pointerPolicies = policyStore.getMasterPointerPolicyList(),
-                canvasBounds = uiStore.getCloakRect();
+                canvasBounds = panelStore.getCloakRect();
 
             return {
                 policies: pointerPolicies,

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     var DEBOUNCE_DELAY = 200;
 
     var SuperselectOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("tool", "document", "application", "ui", "modifier")],
+        mixins: [FluxMixin, StoreWatchMixin("tool", "document", "application", "ui", "panel", "modifier")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -107,8 +107,8 @@ define(function (require, exports, module) {
             var flux = this.getFlux(),
                 applicationStore = flux.store("application"),
                 toolStore = flux.store("tool"),
-                uiStore = flux.store("ui"),
-                uiState = uiStore.getState(),
+                panelStore = flux.store("panel"),
+                panelState = panelStore.getState(),
                 modalState = toolStore.getModalToolState(),
                 currentDocument = applicationStore.getCurrentDocument(),
                 modifierStore = flux.store("modifier"),
@@ -117,8 +117,8 @@ define(function (require, exports, module) {
 
             return {
                 document: currentDocument,
-                marqueeEnabled: uiState.marqueeEnabled,
-                marqueeStart: uiState.marqueeStart,
+                marqueeEnabled: panelState.marqueeEnabled,
+                marqueeStart: panelState.marqueeStart,
                 modalState: modalState,
                 leafBounds: leafModifier
             };

--- a/src/js/locks.js
+++ b/src/js/locks.js
@@ -47,6 +47,7 @@ define(function (require, exports, module) {
         JS_POLICY: "jsPolicy",
         JS_SHORTCUT: "jsShortcut",
         JS_UI: "jsUI",
+        JS_PANEL: "jsPanel",
         JS_PREF: "jsPref",
         JS_HISTORY: "jsHistory",
         JS_STYLE: "jsStyle",

--- a/src/js/models/tools/sampler.js
+++ b/src/js/models/tools/sampler.js
@@ -88,8 +88,8 @@ define(function (require, exports, module) {
         }
 
         if (event.detail.keyChar === " ") {
-            var uiStore = flux.store("ui"),
-                position = uiStore.getCurrentMousePosition();
+            var panelStore = flux.store("panel"),
+                position = panelStore.getCurrentMousePosition();
 
             if (!position) {
                 return;

--- a/src/js/stores/index.js
+++ b/src/js/stores/index.js
@@ -39,6 +39,7 @@ define(function (require, exports) {
         "policy": require("./policy"),
         "menu": require("./menu"),
         "modifier": require("./modifier"),
+        "panel": require("./panel"),
         "preferences": require("./preferences"),
         "ui": require("./ui"),
         "shortcut": require("./shortcut"),

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
                 events.tool.VECTOR_MASK_MODE_CHANGE, this._updateMenuItems,
 
                 events.document.GUIDES_VISIBILITY_CHANGED, this._updateViewMenu,
-                events.ui.COLOR_STOP_CHANGED, this._updateColorStop,
+                events.panel.COLOR_STOP_CHANGED, this._updateColorStop,
                 events.preferences.SET_PREFERENCE, this._updatePreferencesBasedMenuItems
             );
 
@@ -279,8 +279,8 @@ define(function (require, exports, module) {
          * @private
          */
         _updateColorStop: function () {
-            this.waitFor(["ui"], function (uiStore) {
-                var colorStop = uiStore.getColorStop(),
+            this.waitFor(["panel"], function (panelStore) {
+                var colorStop = panelStore.getColorStop(),
                     oldMenu = this._applicationMenu;
 
                 this._applicationMenu = this._applicationMenu.updateColorThemeItems(colorStop);

--- a/src/js/stores/panel.js
+++ b/src/js/stores/panel.js
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var Fluxxor = require("fluxxor");
+    
+    var events = require("../events"),
+        log = require("js/util/log");
+
+    /**
+     * Panel/column identifiers.
+     *
+     * @const
+     * @type {object}
+     */
+    var UI_COMPONENTS = Object.freeze({
+        LAYERS_LIBRARY_COL: "layersLibrariesVisible",
+        PROPERTIES_COL: "propertiesVisible",
+        TRANSFORM_PANEL: "transformVisible",
+        STYLES_PANEL: "stylesVisible",
+        APPEARANCE_PANEL: "appearanceVisible",
+        EFFECTS_PANEL: "effectsVisible",
+        EXPORT_PANEL: "exportVisible",
+        LAYERS_PANEL: "layersVisible",
+        LIBRARIES_PANEL: "libraryVisible"
+    });
+
+    var PanelStore = Fluxxor.createStore({
+
+        /**
+         * Flag to tell whether Scrim should draw any of the SVG overlays or not
+         *
+         * @private
+         * @type {boolean}
+         */
+        _overlaysEnabled: null,
+
+        /**
+         * Flag to tell if the scrim should be drawing a marquee
+         *
+         * @private
+         * @type {boolean}
+         */
+        _marqueeEnabled: null,
+
+        /**
+         * Marquee start location
+         *
+         * @private
+         * @type {{x: number, y: number}}
+         */
+        _marqueeStart: null,
+
+        /**
+         * Panel set width
+         *
+         * @private
+         * @type {number}
+         */
+        _panelWidth: null,
+
+        /**
+         * Icon bar width
+         *
+         * @private
+         * @type {number}
+         */
+        _iconBarWidth: null,
+        
+        /**
+         * Document header height
+         *
+         * @private
+         * @type {number}
+         */
+        _headerHeight: null,
+        
+        /**
+         * Toolbar width, 0 if it's not pinned
+         *
+         * @private
+         * @type {number}
+         */
+        _toolbarWidth: null,
+
+        /**
+         * Constants used to refer to different panels/columns.
+         * 
+         * @const
+         * @type {object}
+         */
+        components: UI_COMPONENTS,
+
+        /**
+         * Reference point for a layer when adjusting W and H
+         * Default is "lt" for left, top
+         *
+         * @private
+         * @type {string}
+         */
+        _referencePoint: null,
+
+        /**
+         * UI color stop. Must be one of "ORIGINAL", "LIGHT", "MEDIUM" or "DARK".
+         *
+         * @private
+         * @type {string}
+         */
+        _colorStop: null,
+
+        /**
+         * The coordinates of the current mouse position if it's being tracked; otherwise null.
+         *
+         * @private
+         * @type {?{currentMouseX: number, currentMouseY: number}}
+         */
+        _currentMousePosition: null,
+
+        initialize: function () {
+            this.bindActions(
+                events.RESET, this._handleReset,
+                events.panel.PANELS_RESIZED, this._handlePanelResize,
+                events.panel.SUPERSELECT_MARQUEE, this._handleMarqueeStart,
+                events.panel.TOGGLE_OVERLAYS, this._handleOverlayToggle,
+                events.panel.REFERENCE_POINT_CHANGED, this._handleReferencePointChanged,
+                events.panel.COLOR_STOP_CHANGED, this._handleColorStopChanged,
+                events.panel.MOUSE_POSITION_CHANGED, this._handleMousePositionChanged,
+                events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
+                events.document.history.RESET_LAYERS, this._handleLayersUpdated,
+                events.document.history.RESET_BOUNDS, this._handleLayersUpdated
+            );
+
+            // HACK: Do not reset panel sizes because they should remain constant.
+            this._panelWidth = 0;
+            this._columnCount = 0;
+            this._iconBarWidth = 0;
+            this._headerHeight = 0;
+            this._toolbarWidth = 0;
+
+            this._handleReset();
+        },
+
+        /**
+         * Reset or initialize store state.
+         *
+         * @private
+         */
+        _handleReset: function () {
+            this._overlaysEnabled = true;
+            this._marqueeEnabled = false;
+            this._marqueeStart = null;
+            this._referencePoint = "lt";
+            this._colorStop = null;
+            this._currentMousePosition = null;
+        },
+        
+        /** @ignore */
+        getState: function () {
+            return {
+                centerOffsets: this.getCenterOffsets(),
+                overlaysEnabled: this._overlaysEnabled,
+                marqueeEnabled: this._marqueeEnabled,
+                marqueeStart: this._marqueeStart,
+                referencePoint: this._referencePoint
+            };
+        },
+        
+        /**
+         * Calculate the overlay offsets, optionally taking into account a
+         * (future) number of open columns.
+         *
+         * @return {{top: number, right: number, bottom: number, left: number}}
+         */
+        getCenterOffsets: function (columns) {
+            var preferences = this.flux.store("preferences").getState(),
+                singleColumn = preferences.get("singleColumnModeEnabled", false),
+                right = (columns !== undefined && singleColumn) ? 0 :
+                    this._iconBarWidth;
+
+            if (singleColumn) {
+                right += this._panelWidth;
+            } else if (columns === undefined || columns === this._columnCount) {
+                right += this._panelWidth;
+            } else if (columns > 0) {
+                if (columns === 1 && this._columnCount === 2) {
+                    right += (this._panelWidth / 2);
+                } else if (columns === 2 && this._columnCount === 1) {
+                    right += (this._panelWidth * 2);
+                } else {
+                    log.warn("Unable to infer enter offsets for " + columns +
+                        " columns from " + this._columnCount);
+                }
+            }
+
+            return {
+                top: this._headerHeight,
+                right: right,
+                left: this._toolbarWidth,
+                bottom: 0
+            };
+        },
+
+        /**
+         * Get the current cloaking rectangle, which omits the static UI.
+         *
+         * @return {?{top: number, right: number, left: number, bottom: number}}
+         */
+        getCloakRect: function () {
+            var centerOffsets = this.getCenterOffsets(),
+                windowWidth = window.document.body.clientWidth,
+                windowHeight = window.document.body.clientHeight;
+            
+            return {
+                left: centerOffsets.left,
+                top: centerOffsets.top,
+                bottom: windowHeight - centerOffsets.bottom,
+                right: windowWidth - centerOffsets.right
+            };
+        },
+
+        /**
+         * Updates the center offsets when they change.
+         *
+         * @private
+         * @param {{panelWidth: number=, headerHeight: number=, toolbarWidth: number=}} payload
+         */
+        _handlePanelResize: function (payload) {
+            var changed;
+            if (payload.hasOwnProperty("panelWidth") && payload.panelWidth !== this._panelWidth) {
+                this._panelWidth = payload.panelWidth;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("columnCount") && payload.columnCount !== this._columnCount) {
+                this._columnCount = payload.columnCount;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("iconBarWidth") && payload.iconBarWidth !== this._iconBarWidth) {
+                this._iconBarWidth = payload.iconBarWidth;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("headerHeight") && payload.headerHeight !== this._headerHeight) {
+                this._headerHeight = payload.headerHeight;
+                changed = true;
+            }
+
+            if (payload.hasOwnProperty("toolbarWidth") && payload.toolbarWidth !== this._toolbarWidth) {
+                this._toolbarWidth = payload.toolbarWidth;
+                changed = true;
+            }
+
+            if (changed) {
+                this.emit("change");
+            }
+        },
+
+        /**
+         * Updates the overlays enabled flag
+         *
+         * @private
+         * @param {{enabled: boolean}} payload
+         */
+        _handleOverlayToggle: function (payload) {
+            this._overlaysEnabled = payload.enabled;
+            this.emit("change");
+        },
+
+        /**
+         * Re-enables the overlays once document layers are updated.
+         *
+         * @private
+         */
+        _handleLayersUpdated: function () {
+            this.waitFor(["document"], function () {
+                this._overlaysEnabled = true;
+                this.emit("change");
+            });
+        },
+
+        /**
+         * Updates the marquee start location and flag
+         *
+         * @param {{x: number, y: number, enabled: boolean}} payload
+         */
+        _handleMarqueeStart: function (payload) {
+            this._marqueeEnabled = payload.enabled;
+            this._marqueeStart = payload.enabled ? {
+                x: payload.x,
+                y: payload.y
+            } : null;
+            
+            this.emit("change");
+        },
+
+        /**
+         * Set the size-adjustment reference point.
+         *
+         * @private
+         * @param {{referencePoint: string}} payload
+         */
+        _handleReferencePointChanged: function (payload) {
+            this._referencePoint = payload.referencePoint;
+            this.emit("change");
+        },
+
+        /**
+         * Set the UI color stop.
+         *
+         * @private
+         * @param {{stop: string}} payload
+         */
+        _handleColorStopChanged: function (payload) {
+            this._colorStop = payload.stop;
+            this.emit("change");
+        },
+
+        /**
+         * Update the current mouse position.
+         *
+         * @private
+         * @param {?{currentMouseX: number, currentMouseY: number}} payload
+         */
+        _handleMousePositionChanged: function (payload) {
+            this._currentMousePosition = payload;
+        },
+
+        /**
+         * Get the current mouse position if it's being tracked; otherwise null.
+         * 
+         * @return {?{currentMouseX: number, currentMouseY: number}}
+         */
+        getCurrentMousePosition: function () {
+            return this._currentMousePosition;
+        },
+
+        /**
+         * Get the current UI color stop.
+         *
+         * @return {?string} An element of the enum appLib.colorStops
+         */
+        getColorStop: function () {
+            return this._colorStop;
+        }
+    });
+
+    module.exports = PanelStore;
+});

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -30,24 +30,6 @@ define(function (require, exports, module) {
         log = require("js/util/log"),
         math = require("js/util/math");
 
-    /**
-     * Panel/column identifiers.
-     *
-     * @const
-     * @type {object}
-     */
-    var UI_COMPONENTS = Object.freeze({
-        LAYERS_LIBRARY_COL: "layersLibrariesVisible",
-        PROPERTIES_COL: "propertiesVisible",
-        TRANSFORM_PANEL: "transformVisible",
-        STYLES_PANEL: "stylesVisible",
-        APPEARANCE_PANEL: "appearanceVisible",
-        EFFECTS_PANEL: "effectsVisible",
-        EXPORT_PANEL: "exportVisible",
-        LAYERS_PANEL: "layersVisible",
-        LIBRARIES_PANEL: "libraryVisible"
-    });
-
     var UIStore = Fluxxor.createStore({
 
         /**
@@ -75,14 +57,6 @@ define(function (require, exports, module) {
         _zoom: null,
 
         /**
-         * Flag to tell whether Scrim should draw any of the SVG overlays or not
-         *
-         * @private
-         * @type {boolean}
-         */
-        _overlaysEnabled: null,
-
-        /**
          * Current root font size, which is used to calculated rem units
          *
          * @private
@@ -90,109 +64,12 @@ define(function (require, exports, module) {
          */
         _rootSize: null,
 
-        /**
-         * Flag to tell if the scrim should be drawing a marquee
-         *
-         * @private
-         * @type {boolean}
-         */
-        _marqueeEnabled: null,
-
-        /**
-         * Marquee start location
-         *
-         * @private
-         * @type {{x: number, y: number}}
-         */
-        _marqueeStart: null,
-
-        /**
-         * Panel set width
-         *
-         * @private
-         * @type {number}
-         */
-        _panelWidth: null,
-
-        /**
-         * Icon bar width
-         *
-         * @private
-         * @type {number}
-         */
-        _iconBarWidth: null,
-        
-        /**
-         * Document header height
-         *
-         * @private
-         * @type {number}
-         */
-        _headerHeight: null,
-        
-        /**
-         * Toolbar width, 0 if it's not pinned
-         *
-         * @private
-         * @type {number}
-         */
-        _toolbarWidth: null,
-
-        /**
-         * Constants used to refer to different panels/columns.
-         * 
-         * @const
-         * @type {object}
-         */
-        components: UI_COMPONENTS,
-
-        /**
-         * Reference point for a layer when adjusting W and H
-         * Default is "lt" for left, top
-         *
-         * @private
-         * @type {string}
-         */
-        _referencePoint: null,
-
-        /**
-         * UI color stop. Must be one of "ORIGINAL", "LIGHT", "MEDIUM" or "DARK".
-         *
-         * @private
-         * @type {string}
-         */
-        _colorStop: null,
-
-        /**
-         * The coordinates of the current mouse position if it's being tracked; otherwise null.
-         *
-         * @private
-         * @type {?{currentMouseX: number, currentMouseY: number}}
-         */
-        _currentMousePosition: null,
-
         initialize: function () {
             this.bindActions(
                 events.RESET, this._handleReset,
                 events.ui.TRANSFORM_UPDATED, this._transformUpdated,
-                events.ui.PANELS_RESIZED, this._handlePanelResize,
-                events.ui.SUPERSELECT_MARQUEE, this._handleMarqueeStart,
-                events.ui.TOGGLE_OVERLAYS, this._handleOverlayToggle,
-                events.ui.REFERENCE_POINT_CHANGED, this._handleReferencePointChanged,
-                events.ui.COLOR_STOP_CHANGED, this._handleColorStopChanged,
-                events.ui.DISPLAY_CHANGED, this._handleDisplayChanged,
-                events.ui.MOUSE_POSITION_CHANGED, this._handleMousePositionChanged,
-                events.document.DOCUMENT_UPDATED, this._handleLayersUpdated,
-                events.document.history.RESET_LAYERS, this._handleLayersUpdated,
-                events.document.history.RESET_BOUNDS, this._handleLayersUpdated
+                events.ui.DISPLAY_CHANGED, this._handleDisplayChanged
             );
-
-            // HACK: Do not reset panel sizes because they should remain constant.
-            this._panelWidth = 0;
-            this._columnCount = 0;
-            this._iconBarWidth = 0;
-            this._headerHeight = 0;
-            this._toolbarWidth = 0;
 
             this._handleReset();
         },
@@ -204,15 +81,9 @@ define(function (require, exports, module) {
          */
         _handleReset: function () {
             this._setRootSize();
-            this._overlaysEnabled = true;
-            this._marqueeEnabled = false;
-            this._marqueeStart = null;
             this._zoom = null;
             this._transformMatrix = null;
             this._inverseTransformMatrix = null;
-            this._referencePoint = "lt";
-            this._colorStop = null;
-            this._currentMousePosition = null;
         },
         
         /** @ignore */
@@ -220,12 +91,7 @@ define(function (require, exports, module) {
             return {
                 transformMatrix: this._transformMatrix,
                 inverseTransformMatrix: this._inverseTransformMatrix,
-                zoomFactor: this._zoom,
-                centerOffsets: this.getCenterOffsets(),
-                overlaysEnabled: this._overlaysEnabled,
-                marqueeEnabled: this._marqueeEnabled,
-                marqueeStart: this._marqueeStart,
-                referencePoint: this._referencePoint
+                zoomFactor: this._zoom
             };
         },
         
@@ -302,59 +168,6 @@ define(function (require, exports, module) {
             return {
                 x: xt,
                 y: yt
-            };
-        },
-
-        /**
-         * Calculate the overlay offsets, optionally taking into account a
-         * (future) number of open columns.
-         *
-         * @return {{top: number, right: number, bottom: number, left: number}}
-         */
-        getCenterOffsets: function (columns) {
-            var preferences = this.flux.store("preferences").getState(),
-                singleColumn = preferences.get("singleColumnModeEnabled", false),
-                right = (columns !== undefined && singleColumn) ? 0 :
-                    this._iconBarWidth;
-
-            if (singleColumn) {
-                right += this._panelWidth;
-            } else if (columns === undefined || columns === this._columnCount) {
-                right += this._panelWidth;
-            } else if (columns > 0) {
-                if (columns === 1 && this._columnCount === 2) {
-                    right += (this._panelWidth / 2);
-                } else if (columns === 2 && this._columnCount === 1) {
-                    right += (this._panelWidth * 2);
-                } else {
-                    log.warn("Unable to infer enter offsets for " + columns +
-                        " columns from " + this._columnCount);
-                }
-            }
-
-            return {
-                top: this._headerHeight,
-                right: right,
-                left: this._toolbarWidth,
-                bottom: 0
-            };
-        },
-
-        /**
-         * Get the current cloaking rectangle, which omits the static UI.
-         *
-         * @return {?{top: number, right: number, left: number, bottom: number}}
-         */
-        getCloakRect: function () {
-            var centerOffsets = this.getCenterOffsets(),
-                windowWidth = window.document.body.clientWidth,
-                windowHeight = window.document.body.clientHeight;
-            
-            return {
-                left: centerOffsets.left,
-                top: centerOffsets.top,
-                bottom: windowHeight - centerOffsets.bottom,
-                right: windowWidth - centerOffsets.right
             };
         },
 
@@ -478,104 +291,6 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Updates the center offsets when they change.
-         *
-         * @private
-         * @param {{panelWidth: number=, headerHeight: number=, toolbarWidth: number=}} payload
-         */
-        _handlePanelResize: function (payload) {
-            var changed;
-            if (payload.hasOwnProperty("panelWidth") && payload.panelWidth !== this._panelWidth) {
-                this._panelWidth = payload.panelWidth;
-                changed = true;
-            }
-
-            if (payload.hasOwnProperty("columnCount") && payload.columnCount !== this._columnCount) {
-                this._columnCount = payload.columnCount;
-                changed = true;
-            }
-
-            if (payload.hasOwnProperty("iconBarWidth") && payload.iconBarWidth !== this._iconBarWidth) {
-                this._iconBarWidth = payload.iconBarWidth;
-                changed = true;
-            }
-
-            if (payload.hasOwnProperty("headerHeight") && payload.headerHeight !== this._headerHeight) {
-                this._headerHeight = payload.headerHeight;
-                changed = true;
-            }
-
-            if (payload.hasOwnProperty("toolbarWidth") && payload.toolbarWidth !== this._toolbarWidth) {
-                this._toolbarWidth = payload.toolbarWidth;
-                changed = true;
-            }
-
-            if (changed) {
-                this.emit("change");
-            }
-        },
-
-        /**
-         * Updates the overlays enabled flag
-         *
-         * @private
-         * @param {{enabled: boolean}} payload
-         */
-        _handleOverlayToggle: function (payload) {
-            this._overlaysEnabled = payload.enabled;
-            this.emit("change");
-        },
-
-        /**
-         * Re-enables the overlays once document layers are updated.
-         *
-         * @private
-         */
-        _handleLayersUpdated: function () {
-            this.waitFor(["document"], function () {
-                this._overlaysEnabled = true;
-                this.emit("change");
-            });
-        },
-
-        /**
-         * Updates the marquee start location and flag
-         *
-         * @param {{x: number, y: number, enabled: boolean}} payload
-         */
-        _handleMarqueeStart: function (payload) {
-            this._marqueeEnabled = payload.enabled;
-            this._marqueeStart = payload.enabled ? {
-                x: payload.x,
-                y: payload.y
-            } : null;
-            
-            this.emit("change");
-        },
-
-        /**
-         * Set the size-adjustment reference point.
-         *
-         * @private
-         * @param {{referencePoint: string}} payload
-         */
-        _handleReferencePointChanged: function (payload) {
-            this._referencePoint = payload.referencePoint;
-            this.emit("change");
-        },
-
-        /**
-         * Set the UI color stop.
-         *
-         * @private
-         * @param {{stop: string}} payload
-         */
-        _handleColorStopChanged: function (payload) {
-            this._colorStop = payload.stop;
-            this.emit("change");
-        },
-
-        /**
          * Re-set the root font size when the display changes.
          *
          * @private
@@ -586,40 +301,12 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Update the current mouse position.
-         *
-         * @private
-         * @param {?{currentMouseX: number, currentMouseY: number}} payload
-         */
-        _handleMousePositionChanged: function (payload) {
-            this._currentMousePosition = payload;
-        },
-
-        /**
-         * Get the current mouse position if it's being tracked; otherwise null.
-         * 
-         * @return {?{currentMouseX: number, currentMouseY: number}}
-         */
-        getCurrentMousePosition: function () {
-            return this._currentMousePosition;
-        },
-
-        /**
          * Get the current transform matrix if it's being tracked; otherwise null.
          * 
          * @return {?Array.<number>}
          */
         getCurrentTransformMatrix: function () {
             return this._transformMatrix;
-        },
-
-        /**
-         * Get the current UI color stop.
-         *
-         * @return {?string} An element of the enum appLib.colorStops
-         */
-        getColorStop: function () {
-            return this._colorStop;
         }
     });
 


### PR DESCRIPTION
This PR factors a panel action module, store and lock out from the existing UI action module, store and lock. This reduces contention for the UI lock somewhat at startup time, and also arguably also makes this  code a little easier to understand. In some cases it wasn't clear what state/action should go where, but the rule of thumb I tried to use was: if it has to do with the _window_ put it in the UI store, and if it has to do with a _panel_ put it in the panel store. (We should probably rename the UI store to something more appropriate, but I don't currently have a suggestion, so I left it alone.) This seems to shave ~100ms off startup time on my MBP due to reduced lock contention.