### PR TITLE
Fix for expand/collapse all groups

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -817,11 +817,11 @@ define(function (require, exports) {
      *
      * @param {Document} document
      * @param {Layer|Immutable.Iterable.<Layer>} layers
-     * @param {boolean} expand If true, expand the groups. Otherwise, collapse them.
-     * @param {boolean=} descendants Whether to expand all descendants of the given layers.
+     * @param {boolean} expand - If true, expand the groups. Otherwise, collapse them.
+     * @param {boolean=} recursive - Whether to expand/collapse all descendants groups of the given layers.
      * @return {Promise}
      */
-    var setGroupExpansion = function (document, layers, expand, descendants) {
+    var setGroupExpansion = function (document, layers, expand, recursive) {
         if (layers instanceof Layer) {
             layers = Immutable.List.of(layers);
         }
@@ -835,7 +835,9 @@ define(function (require, exports) {
             return Promise.resolve();
         }
 
-        if (descendants) {
+        var targetLayers = layers;
+
+        if (recursive) {
             layers = layers.flatMap(document.layers.descendants, document.layers);
         }
 
@@ -888,14 +890,14 @@ define(function (require, exports) {
         }
 
         var documentRef = documentLib.referenceBy.id(document.id),
-            layerRefs = layers
+            layerRefs = targetLayers
                 .map(function (layer) {
                     return layerLib.referenceBy.id(layer.id);
                 })
                 .unshift(documentRef)
                 .toArray();
 
-        var expandPlayObject = layerLib.setGroupExpansion(layerRefs, !!expand);
+        var expandPlayObject = layerLib.setGroupExpansion(layerRefs, !!expand, recursive);
 
         playObjects.push(expandPlayObject);
 


### PR DESCRIPTION
**This PR requires dev >= 932 and Adapter PR https://github.com/adobe-photoshop/spaces-adapter/pull/174**

Fix issue #3271 that not all descendant groups are expanded when option-click a group.