### PR TITLE
Make source map works for both internal and external dev tools.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ var buildConfigs = languages.map(function (lang) {
     };
 
     if (devMode) {
-        options.devtool = "source-map";
+        options.devtool = "inline-source-map";
         options.debug = "true";
         // These lines break the build into two chunks, one for our code, and one for all our dependencies
         // This allows for a faster rebuild time


### PR DESCRIPTION
By using the `inline-source-map` option https://webpack.github.io/docs/configuration.html#devtool
Tested on dev 926.