### PR TITLE
No nesting except ABs rule, used for align commands

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -520,6 +520,26 @@ define(function (require, exports, module) {
             }, this);
         },
 
+        "selectedHasNesting": function () {
+            var selectedSet = this.selected.toSet();
+
+            return this.selected.some(function (layer) {
+                return this.strictAncestors(layer).some(function (ancestor) {
+                    return selectedSet.contains(ancestor);
+                });
+            }, this);
+        },
+
+        "selectedHasNestingExceptArtboards": function () {
+            var selectedSet = this.selected.toSet();
+
+            return this.selected.some(function (layer) {
+                return this.strictAncestors(layer).some(function (ancestor) {
+                    return !ancestor.isArtboard && selectedSet.contains(ancestor);
+                });
+            }, this);
+        },
+
         /**
          * Determine if selected layers are "locked"
          * Currently true for any of the following:

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -213,13 +213,18 @@ define(function (require, exports, module) {
                 (document !== null) &&
                 !document.unsupported &&
                 (document.layers !== null) &&
-                (document.layers.selectedNormalized.size === 2),
+                (document.layers.selected.size === 2),
             "layers-selected-2+":
                 (document !== null) &&
                 !document.unsupported &&
                 (document.layers !== null) &&
+                (document.layers.selected.size > 1),
+            "layers-selected-normalized-2+":
+                (document !== null) &&
+                !document.unsupported &&
+                (document.layers !== null) &&
                 (document.layers.selectedNormalized.size > 1),
-            "layers-selected-3+":
+            "layers-selected-normalized-3+":
                 (document !== null) &&
                 !document.unsupported &&
                 (document.layers !== null) &&
@@ -247,11 +252,12 @@ define(function (require, exports, module) {
                 (document !== null) &&
                 !document.unsupported &&
                 (document.layers !== null) &&
-                !(document.layers.selected.some(function (layer) {
-                    return document.layers.ancestors(layer).some(function (ancestor) {
-                        return layer !== ancestor && document.layers.selected.contains(ancestor);
-                    });
-                })),
+                !document.layers.selectedHasNesting,
+            "no-nesting-except-artboards":
+                (document !== null) &&
+                !document.unsupported &&
+                (document.layers !== null) &&
+                !document.layers.selectedHasNestingExceptArtboards,
             "have-linked":
                 (document !== null) &&
                 !document.unsupported &&

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -282,41 +282,41 @@
             "$enable-rule": "layer-selected"
         },
         "DISTRIBUTE": {
-            "$enable-rule": "layers-selected-3+,no-background,no-nesting",
+            "$enable-rule": "layers-selected-normalized-3+,no-background,no-nesting",
             "DISTRIBUTE_HORIZONTAL": {
                 "$action": "transform.distributeX",
-                "$enable-rule": "layers-selected-3+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-normalized-3+,no-background,no-nesting"
             },
             "DISTRIBUTE_VERTICAL": {
                 "$action": "transform.distributeY",
-                "$enable-rule": "layers-selected-3+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-normalized-3+,no-background,no-nesting"
             }
         },
         "ALIGN": {
-            "$enable-rule": "layers-selected-2+,no-background,no-nesting",
+            "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards",
             "ALIGN_LEFT": {
                 "$action": "transform.alignLeft",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             },
             "ALIGN_CENTER": {
                 "$action": "transform.alignHCenter",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             },
             "ALIGN_RIGHT": {
                 "$action": "transform.alignRight",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             },
             "ALIGN_TOP": {
                 "$action": "transform.alignTop",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             },
             "ALIGN_MIDDLE": {
                 "$action": "transform.alignVCenter",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             },
             "ALIGN_BOTTOM": {
                 "$action": "transform.alignBottom",
-                "$enable-rule": "layers-selected-2+,no-background,no-nesting"
+                "$enable-rule": "layers-selected-2+,no-background,no-nesting-except-artboards"
             }
         },
         "BRING_TO_FRONT": {


### PR DESCRIPTION
This PR enables Align operations for artboards, given all other rules still apply.

We were using `hasStrictSelectedAncestors` for both Align and Distribute buttons. However, artboards are alignable ancestors as far as Photoshop is concerned, so I've broken the disabled checks for the UI buttons into two separate functions, and use a custom checker for Align, while still using the available functions for Distribute.

Also introduced a new menu rule: `no-nesting-except-artboards`, where nesting is allowed in selected layers as long as it's the artboard in the selection.

This addresses #3197.