### PR TITLE
Clean up ui locks

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -835,7 +835,7 @@ define(function (require, exports) {
     };
     selectNextDocument.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_UI],
+        writes: [],
         transfers: [selectDocument],
         lockUI: true
     };
@@ -857,7 +857,7 @@ define(function (require, exports) {
     };
     selectPreviousDocument.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_UI],
+        writes: [],
         transfers: [selectDocument],
         lockUI: true
     };

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -422,7 +422,7 @@ define(function (require, exports) {
     };
     redo.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_UI],
+        writes: [locks.JS_PANEL],
         transfers: [history.incrementHistory],
         post: [layers._verifyLayerIndex],
         modal: true

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -173,7 +173,7 @@ define(function (require, exports) {
     };
     setPostScript.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_UI],
+        writes: [locks.PS_DOC],
         transfers: [updatePostScript, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };
@@ -244,7 +244,7 @@ define(function (require, exports) {
     };
     setFace.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.JS_UI, locks.PS_DOC],
+        writes: [locks.PS_DOC],
         transfers: [updateFace, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };
@@ -407,7 +407,7 @@ define(function (require, exports) {
     };
     setSize.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.JS_UI, locks.PS_DOC],
+        writes: [locks.PS_DOC],
         transfers: [updateSize, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };
@@ -475,7 +475,7 @@ define(function (require, exports) {
     };
     setTracking.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_UI],
+        writes: [locks.PS_DOC],
         transfers: [updateTracking, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };
@@ -545,7 +545,7 @@ define(function (require, exports) {
     };
     setLeading.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_UI],
+        writes: [locks.PS_DOC],
         transfers: [updateLeading, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };
@@ -612,7 +612,7 @@ define(function (require, exports) {
     };
     setAlignment.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_UI],
+        writes: [locks.PS_DOC],
         transfers: [updateAlignment, layerActions.resetBounds, layerActions.resetLayers],
         modal: true
     };


### PR DESCRIPTION
We had some JS_UI locks that were no longer valid, those are removed. In most cases, these locks are essentially redundant with the transfers, so it helps keep things cleaner.

Almost all type actions seemed unnecessary, but @pineapplespatula, am I missing something?

Also in edit.js, since we dispatch `panel.TOGGLE_OVERLAYS` now, changed the lock there, this was a dormant bug.