### PR TITLE
fix Vector Mask HUD to use Panel Store instead of UI store for the cloak rect

### DIFF
--- a/src/js/jsx/tools/SuperselectVectorMaskOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectVectorMaskOverlay.jsx
@@ -163,8 +163,8 @@ define(function (require, exports, module) {
          */
         _drawVectorMaskHUDObjects: function () {
             var flux = this.getFlux(),
-                uiStore = flux.store("ui"),
-                cloakRect = uiStore.getCloakRect();
+                panelStore = flux.store("panel"),
+                cloakRect = panelStore.getCloakRect();
             
             var layerTree = this.state.document.layers;
     


### PR DESCRIPTION
fix for issue #3394 