### PR TITLE
Adding tag/version strings to adapter and generator-connection deps in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "classnames": "^2.2.0",
     "d3": "^3.5.9",
     "fluxxor": "^1.7.3",
-    "generator-connection": "adobe-photoshop/generator-connection",
+    "generator-connection": "adobe-photoshop/generator-connection#v2.4.0",
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
     "loglevel": "^1.4.0",
@@ -82,7 +82,7 @@
     "react-addons-pure-render-mixin": "^0.14.2",
     "react-dom": "^0.14.2",
     "scriptjs": "^2.5.8",
-    "spaces-adapter": "adobe-photoshop/spaces-adapter.git",
+    "spaces-adapter": "adobe-photoshop/spaces-adapter.git#v0.32.0",
     "tinycolor2": "^1.1.2",
     "wolfy87-eventemitter": "^4.3.0"
   }


### PR DESCRIPTION
This isn't as cool as it used to be with `bower`, which allowed semver strings to be supplied, but I think this is better than not supplying a version at all.  @volfied ?  