### PR TITLE
Print changed files in the watcher

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -166,6 +166,9 @@ module.exports = function (grunt) {
                     spawn: false,
                     interrupt: true
                 }
+            },
+            sources: {
+                files: ["src/**/*"]
             }
         },
         // Build tasks


### PR DESCRIPTION
I was getting tired of trying to guess whether webpack actually rebuilt or if I was staring at the same [emitted] line from last time.

So now we run this empty watcher task in Grunt that prints out when a file in src has changed, and then webpack prints it's emitted, so we get a nice time stamp and changed files log before each incremental rebuild. Devs rejoice!

Btw, Webpack doesn't offer this!!! :-1: