### PR TITLE
Handle locked layers when using the sampler tool

### DIFF
--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
             
             this.drawBoundRectangles(layerTree);
             this.drawSelectionBounds(layerTree);
-            this.drawSamplerHUD();
+            this.drawSamplerHUD(layerTree);
         },
 
         /**
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
          */
         drawSelectionBounds: function (layerTree) {
             var scale = this._scale,
-                bounds = layerTree.selectedAreaBounds;
+                bounds = layerTree.selectedUnlockedAreaBounds;
 
             // Skip empty bounds
             if (!bounds || bounds.empty) {
@@ -263,8 +263,10 @@ define(function (require, exports, module) {
         /**
          * Draws sampler HUD if there is one available from the store
          */
-        drawSamplerHUD: function () {
-            if (!this.state.sampleTypes || !this.state.samplePoint) {
+        drawSamplerHUD: function (layerTree) {
+            var selectedLayers = layerTree.selected.filter(function (l) { return !l.locked });
+            
+            if (selectedLayers.isEmpty() || !this.state.sampleTypes || !this.state.samplePoint) {
                 return;
             }
 

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -348,6 +348,25 @@ define(function (require, exports, module) {
         "selectedAreaBounds": function () {
             return Bounds.union(this.selectedChildBounds);
         },
+        
+        /**
+         * Overall bounds of selection of unlocked layers.
+         * @type {Bounds}
+         */
+        "selectedUnlockedAreaBounds": function () {
+            var unlockedLayers = this.selected.filter(function (l) { return !l.locked; }),
+                bounds = unlockedLayers
+                    .toSeq()
+                    .map(function (layer) {
+                        return this.childBounds(layer);
+                    }, this)
+                    .filter(function (bounds) {
+                        return bounds && bounds.area > 0;
+                    })
+                    .toList();
+
+            return Bounds.union(bounds);
+        },
 
         /**
          * Bounds of all the top layers

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -350,7 +350,7 @@ define(function (require, exports, module) {
         },
         
         /**
-         * Overall bounds of selection of unlocked layers.
+         * Overall bounds of selection, but exclude locked layers.
          * @type {Bounds}
          */
         "selectedUnlockedAreaBounds": function () {


### PR DESCRIPTION
This PR handles locked layers in different sampler scenarios:

1. select a locked layer: sampler is disabled (no HUD and mouse click), no sampler overlay
2. select multiple locked layers: the same as 1
3. selections of locked and unlocked layers: sampler is enabled, but only applies to unlocked layers. locked layers are excluded from the sampler overlay.

Fixes issue #3238 