### PR TITLE
Replace SVG animated loader with a CSS animated one

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-addons-perf": "^0.14.2",
     "react-tools": "^0.13.1",
     "uglifyjs": "^2.4.10",
-    "url-loader": "^0.5.6",
     "webpack": "^1.12.3",
     "webpack-dev-server": "^1.12.1",
     "webpack-notifier": "^1.2.1"

--- a/src/img/ico-loader.svg
+++ b/src/img/ico-loader.svg
@@ -1,65 +1,11 @@
 <svg version="1.1" id="loader" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="100%" height="100%" viewBox="0 0 16 16" xml:space="preserve">
-    <g transform="scale(.5625)">
-        <circle cx="9" cy="7" r="3" opacity="1">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = "0"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-        <circle opacity=".16666" cx="17" cy="7" r="3">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = ".16666s"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-        <circle opacity=".33333" cx="21" cy="13.5" r="3">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = ".3333s"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-        <circle opacity=".4999" cx="17" cy="20" r="3">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = ".499999999333332s"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-        <circle opacity=".6667" cx="9" cy="20" r="3">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = ".666666665999998s"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-        <circle opacity=".83333" cx="5" cy="13.5" r="3">
-          <animate attributeType="XML"
-              attributeName="opacity"
-              from="1" 
-              to="0"
-              begin = ".833333332666664s"
-              repeatCount ="indefinite"
-              fill = "freeze"
-              dur="1s"/>
-        </circle>
-    </g>
+    <g> 
+        <circle opacity="1" cx="5"  cy="2" r="2"/>
+        <circle opacity=".1667" cx="11"  cy="2" r="2"/>
+        <circle opacity=".3333" cx="14"  cy="7.196" r="2"/>
+        <circle opacity=".4999" cx="11" cy="12.392" r="2"/>
+        <circle opacity=".6667" cx="5"  cy="12.392" r="2"/>
+        <circle opacity=".8333" cx="2"  cy="7.196" r="2"/>
+     </g>
 </svg>

--- a/src/js/jsx/Main.jsx
+++ b/src/js/jsx/Main.jsx
@@ -39,15 +39,6 @@ define(function (require, exports, module) {
         ExportModal = require("js/jsx/sections/export/ExportModal"),
         Guard = require("js/jsx/Guard"),
         system = require("js/util/system");
-        
-    /**
-     * Chrome does not play animated svg loaded from external file via svg:use. 
-     * We need to embed these icons and refer to them using their id (instead of path).
-     * Demo of the problem is at http://bl.ocks.org/bertspaan/6182774.
-     * 
-     * @private
-     */
-    var _ICO_LOADER = require("img/ico-loader.svg");
 
     var LAYERS_LIBRARY_COL = "layersLibrariesVisible",
         PROPERTIES_COL = "propertiesVisible";
@@ -190,10 +181,6 @@ define(function (require, exports, module) {
                     <Help />
                     <Search />
                     <ExportModal />
-
-                    <svg style={{ display: "none" }}>
-                        <defs dangerouslySetInnerHTML={{ __html: _ICO_LOADER }}/>
-                    </svg>
                 </div>
             );
         }

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
             var panelClassnames = classnames("exports-panel__container");
 
             var exportButton = serviceBusy ?
-                (<SVGIcon CSSID="loader" viewbox="0 0 16 16" iconPath="" />)
+                (<SVGIcon CSSID="loader" viewbox="0 0 16 16" />)
                 : nls.localize("strings.EXPORT.BUTTON_EXPORT");
 
             return (
@@ -312,6 +312,7 @@ define(function (require, exports, module) {
                     <div className="exports-panel__two-column">
                         <div className="exports-panel__button-group">
                             <Button
+                                className="loader-animation"
                                 disabled={this.state.exportDisabled || serviceBusy}
                                 onClick={this._exportAllAssets.bind(this, prefixMap)}>
                                 {exportButton}

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -241,9 +241,9 @@ define(function (require, exports, module) {
                             iconId="libraries-stock"
                             onClick={this._handleStockButtonClicked}/>
                         <SplitButtonItem
+                            className={this.props.isSyncing ? "loader-animation" : null}
                             title={nls.localize("strings.TOOLTIPS.SYNC_LIBRARIES")}
                             iconId={this.props.isSyncing ? "loader" : "libraries-cc"}
-                            iconPath={this.props.isSyncing ? "" : null}
                             onClick={this._handleSyncLibraries}
                             disabled={this.props.disabled}/>
                     </ul>

--- a/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
@@ -114,8 +114,8 @@ define(function (require, exports, module) {
         render: function () {
             if (this.state.loading) {
                 return (<div className="libraries__asset__preview-image
-                    libraries__asset__preview-image-loading">
-                    <SVGIcon viewBox="0 0 16 16" CSSID="loader" iconPath=""/>
+                    libraries__asset__preview-image-loading loader-animation">
+                    <SVGIcon viewBox="0 0 16 16" CSSID="loader" />
                 </div>);
             }
             

--- a/src/style/component-styles.less
+++ b/src/style/component-styles.less
@@ -7,6 +7,7 @@
 @import (multiple) "./shared/animation.less";
 @import (multiple) "./shared/label.less";
 
+@import (multiple) "./shared/loader.less";
 @import (multiple) "./shared/compact-stats.less";
 @import (multiple) "./shared/drop-down.less";
 @import (multiple) "./shared/icons.less";

--- a/src/style/shared/loader.less
+++ b/src/style/shared/loader.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -21,45 +21,10 @@
  *
  */
 
-@-webkit-keyframes bounceIn {
-  0% {
-    transform: scale(0.1);
-    opacity: 0;
-  }
-  60% {
-    transform: scale(1.2);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@-webkit-keyframes revealFromCenter {
-  0% {
-    width: 0%;
-    opacity: 0;
-  }
-  100% {
-    width: 80%;
-    opacity: 1;
-  }
-}
-
-@-webkit-keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes loader-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+.loader-animation svg use{    
+    animation: loader-spin;
+    animation-duration: 0.66s; 
+    animation-timing-function: steps(6,end);     
+    animation-iteration-count: infinite;
+    transform-origin: center center;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,18 +70,6 @@ var buildConfigs = languages.map(function (lang) {
                     test: /\.json$/,
                     exclude: /(node_modules)/,
                     loader: "json"
-                },
-                // SVG files get loaded to memory if they are smaller than 100 KB
-                // TODO: We have a lot of svg files that are external
-                // and read at run time, see if bundling them along is any better
-                // using require.context
-                {
-                    test: /\.svg$/,
-                    exclude: /(node_modules)/,
-                    loader: "url",
-                    query: {
-                        name: "[name].[ext]" // This keeps the file name intact
-                    }
                 }
             ]
         },


### PR DESCRIPTION
SMIL SVG animations are being deprecated in Chrome in favor of CSS animations. Due to how we include SVGs (using the `<use>` tag), we cannot simply add CSS animations to the individual SVGs. I added some CSS in order to target the proper tag with the spinning loaded animation.

Since we are no longer pulling in the SVG in Main.jsx, I was able to remove that code as well as the url-loader, which @volfied says was only used for that.

Addresses #3384 and #3217