### PR TITLE
Revert input to original value if the new layer/asset name is empty.

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -155,7 +155,13 @@ define(function (require, exports, module) {
          * @param {string} newName 
          */
         _handleLayerNameChange: function (event, newName) {
-            this.getFlux().actions.layers.rename(this.props.document, this.props.layer, newName);
+            if (newName.length !== 0) {
+                if (newName !== this.props.layer.name) {
+                    this.getFlux().actions.layers.rename(this.props.document, this.props.layer, newName);
+                }
+            } else {
+                this.refs.layerName.setValue(this.props.layer.name);
+            }
         },
 
         /**

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -91,8 +91,12 @@ define(function (require, exports, module) {
          * @param {string} newName
          */
         _handleRename: function (event, newName) {
-            if (this.props.displayName !== newName) {
-                this.getFlux().actions.libraries.renameAsset(this.props.element, newName);
+            if (newName.length !== 0) {
+                if (this.props.displayName !== newName) {
+                    this.getFlux().actions.libraries.renameAsset(this.props.element, newName);
+                }
+            } else {
+                this.refs.input.setValue(this.props.displayName);
             }
         },
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -146,6 +146,15 @@ define(function (require, exports, module) {
         getValue: function () {
             return this.state.value;
         },
+        
+        /**
+         * Update the text input's current value
+         */
+        setValue: function (value) {
+            this.setState({
+                value: value
+            });
+        },
 
         /**
          * Update the value of the text input.


### PR DESCRIPTION
This PR fixes issue that user can input empty layer name (issue #3265). 
I also found the same issue on libraries asset name, and it is fixed too.