### PR TITLE
Fix setState error thrown by AssetPreviewImage when switching column mode

### DIFF
--- a/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetPreviewImage.jsx
@@ -98,6 +98,13 @@ define(function (require, exports, module) {
             })
             .bind(this)
             .then(function (path) {
+                // component will be unmounted if the column mode is changed (Two-Column/Single-Column Mode) 
+                // before it completes fetching the rendition path. If so, simply ignore the result as the new 
+                // component will fetch the rendition path again.
+                if (!this.isMounted()) {
+                    return;
+                }
+
                 // path will be undefined when the element is a graphic and its representation 
                 // is empty (e.g. an empty artboard).
                 this.setState({


### PR DESCRIPTION
Happens when you siwtch the column mode while `AssetPreviewImage` is fetching the rendition path, because the panels are reconstructed.

@volfied can you review since you are the first witness 