### PR TITLE
Add Menu command to create a vector mask from a shape layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-addons-pure-render-mixin": "^0.14.2",
     "react-dom": "^0.14.2",
     "scriptjs": "^2.5.8",
-    "spaces-adapter": "adobe-photoshop/spaces-adapter.git#v0.32.0",
+    "spaces-adapter": "adobe-photoshop/spaces-adapter.git#v1.0.0",
     "tinycolor2": "^1.1.2",
     "wolfy87-eventemitter": "^4.3.0"
   }

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1004,6 +1004,19 @@ define(function (require, exports, module) {
     }));
 
     /**
+     * Given a layers, return if that layer can support a vector mask
+     *
+     * @param {Layer} layer
+     * @return {boolean}
+     */
+    Object.defineProperty(LayerStructure.prototype, "canSupportVectorMask", objUtil.cachedLookupSpec(function (layer) {
+        return !layer.isGroupEnd &&
+            !layer.isVector &&
+            !layer.isBackground &&
+            !layer.locked;
+    }));
+
+    /**
      * Create a new non-group layer model from a Photoshop layer descriptor and
      * add it to the structure.
      *

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -268,7 +268,20 @@ define(function (require, exports, module) {
                 (document !== null) && hasPreviousHistoryState,
             "later-history":
                 (document !== null) && hasNextHistoryState,
-            "not-vector-mask-mode": !vectorMaskMode
+            "not-vector-mask-mode":
+                !vectorMaskMode,
+            "vector-mask-from-shape":
+                (document !== null) &&
+                !document.unsupported &&
+                (document.layers !== null) &&
+                (document.layers.selectedNormalized.size === 2) &&
+                (document.layers.selected.some(function (layer) {
+                    return layer.isVector;
+                })) &&
+                (document.layers.selected.some(function (layer) {
+                    return document.layers.canSupportVectorMask(layer) &&
+                        !layer.vectorMaskEnabled;
+                }))
         };
     };
 

--- a/src/nls/en/menu.json
+++ b/src/nls/en/menu.json
@@ -108,7 +108,8 @@
             "APPLE_WATCH_42MM": "Apple Watch 42mm",
             "WEB_1440_900": "Web (1440 x 900)",
             "WEB_1920_1080": "Web (1920 x 1080)"
-        }
+        },
+        "NEW_VECTOR_MASK_FROM_SHAPE" : "Create Vector Mask from Layer"
     },
     "TYPE": {
         "$MENU": "Type",

--- a/src/nls/en/shortcuts-mac.json
+++ b/src/nls/en/shortcuts-mac.json
@@ -32,7 +32,8 @@
         },
         "LAYER": {
             "CREATE_ARTBOARD": "b",
-            "DUPLICATE": "j"
+            "DUPLICATE": "j",
+            "NEW_VECTOR_MASK_FROM_SHAPE": "m"
         },
         "ARRANGE": {
             "FLIP_HORIZONTAL": "/",

--- a/src/nls/en/shortcuts-win.json
+++ b/src/nls/en/shortcuts-win.json
@@ -28,7 +28,8 @@
         },
         "LAYER": {
             "CREATE_ARTBOARD": "b",
-            "DUPLICATE": "j"
+            "DUPLICATE": "j",
+            "NEW_VECTOR_MASK_FROM_SHAPE": "m"
         },
         "ARRANGE": {
             "FLIP_HORIZONTAL": "/",

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -48,7 +48,8 @@
         "MODIFY_EXPORT_ASSETS": "Updated Export Asset Configurations",
         "APPLY_TEXT_STYLE": "Apply Text Style",
         "APPLY_LAYER_STYLE": "Apply Layer Style",
-        "CREATE_LAYER_FROM_ELEMENT": "Create Layer From Graphic Asset"
+        "CREATE_LAYER_FROM_ELEMENT": "Create Layer From Graphic Asset",
+        "NEW_VECTOR_MASK_FROM_SHAPE": "Create Vector Mask From Shape Layer"
     },
     "APP_NAME": "Photoshop",
     "FIRST_LAUNCH": {

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -239,7 +239,12 @@
         },
         "NEW_ARTBOARD_FROM_TEMPLATE": {
             "$enable-rule": "supported-document,not-vector-mask-mode"
+        },
+        "NEW_VECTOR_MASK_FROM_SHAPE": {
+            "$action": "mask.createVectorMaskFromShape",
+            "$enable-rule": "vector-mask-from-shape"
         }
+
     },
     "ARRANGE": {
         "$enable-rule": "always",

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -356,6 +356,18 @@
                 {
                     "id": "NEW_ARTBOARD_FROM_TEMPLATE",
                     "submenu": []
+                },
+                {
+                    "separator": true
+                },
+                {
+                    "id": "NEW_VECTOR_MASK_FROM_SHAPE",
+                    "shortcut": {
+                        "keyChar": true,
+                        "modifiers": {
+                            "command": true
+                        }
+                    }
                 }
             ]
         },

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -320,6 +320,18 @@
                 {
                     "id": "NEW_ARTBOARD_FROM_TEMPLATE",
                     "submenu": []
+                },
+                {
+                    "separator": true
+                },
+                {
+                    "id":"NEW_VECTOR_MASK_FROM_SHAPE",
+                    "shortcut": {
+                        "keyChar": true,
+                        "modifiers": {
+                            "control": true
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
requires https://github.com/adobe-photoshop/spaces-adapter/pull/175 
added new menu item
<img width="371" alt="screen shot 2015-12-09 at 3 19 49 pm" src="https://cloud.githubusercontent.com/assets/1008531/11702058/60f1257a-9e88-11e5-8306-0f69146d2db7.png">

which is only enabled if you select two layers, one which is a vector shape and the other is a layer that allows for vector masks to be applied 

<img width="366" alt="screen shot 2015-12-09 at 3 21 38 pm" src="https://cloud.githubusercontent.com/assets/1008531/11702086/95a8d3d0-9e88-11e5-8ab6-f4121b0a216f.png">
<img width="311" alt="screen shot 2015-12-09 at 3 22 03 pm" src="https://cloud.githubusercontent.com/assets/1008531/11702092/9fc28834-9e88-11e5-955a-f7d5c99f18cf.png">



