### PR TITLE
Library description pushes buttons off screen Fix for #3404

### DIFF
--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -262,9 +262,13 @@
             background-color: @list-select-color;
             padding-right: 0;
             .libraries__asset__title {
+                max-width: 13.8rem;
                 input[type="text"], input[type="text"]:disabled, input[type="text"]:hover, input[type="text"]:hover:disabled{
                     color: @item-hover;
                 }
+            }
+            .split-button__item {
+                max-width: 1.6rem;
             }
         }
 


### PR DESCRIPTION
Limit width of title area DIV to a max-width so the subtitle span won't push the button off screen