### PR TITLE
Add a timeout warning to cc-lib-api load promise

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -1267,6 +1267,7 @@ define(function (require, exports) {
         descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);
 
         return apiLoadPromise
+            .timeout(3000, "CC Libraries API load timeout, please don't restart and notify the chatroom!")
             .bind(this)
             .then(function () {
                 /* global ccLibraries */


### PR DESCRIPTION
Hopefully we'll figure out the root of this issue and remove this timeout check, but for now, adding this to get some repro cases from everyone.