### PR TITLE
Better way to handle empty value in TextInput

### DIFF
--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -155,13 +155,7 @@ define(function (require, exports, module) {
          * @param {string} newName 
          */
         _handleLayerNameChange: function (event, newName) {
-            if (newName.length !== 0) {
-                if (newName !== this.props.layer.name) {
-                    this.getFlux().actions.layers.rename(this.props.document, this.props.layer, newName);
-                }
-            } else {
-                this.refs.layerName.setValue(this.props.layer.name);
-            }
+            this.getFlux().actions.layers.rename(this.props.document, this.props.layer, newName);
         },
 
         /**
@@ -664,7 +658,8 @@ define(function (require, exports, module) {
                                         value={layer.name}
                                         disabled={this.props.disabled || !nameEditable}
                                         onKeyDown={this._skipToNextLayerName}
-                                        onChange={this._handleLayerNameChange}>
+                                        onChange={this._handleLayerNameChange}
+                                        allowEmpty={false}>
                                     </TextInput>
                                     {showHideButton}
                                 </span>

--- a/src/js/jsx/sections/libraries/assets/AssetSection.jsx
+++ b/src/js/jsx/sections/libraries/assets/AssetSection.jsx
@@ -91,13 +91,7 @@ define(function (require, exports, module) {
          * @param {string} newName
          */
         _handleRename: function (event, newName) {
-            if (newName.length !== 0) {
-                if (this.props.displayName !== newName) {
-                    this.getFlux().actions.libraries.renameAsset(this.props.element, newName);
-                }
-            } else {
-                this.refs.input.setValue(this.props.displayName);
-            }
+            this.getFlux().actions.libraries.renameAsset(this.props.element, newName);
         },
 
         /**
@@ -205,7 +199,8 @@ define(function (require, exports, module) {
                                 onClick={this._handleTitleClicked}
                                 onDoubleClick={this._handleStartEditingTitle}
                                 onChange={this._handleRename}
-                                onBlur={this._handleEndEditingTitle}/>
+                                onBlur={this._handleEndEditingTitle}
+                                allowEmpty={false}/>
                             {subTitle}
                         </div>
                         <SplitButtonItem
@@ -233,7 +228,8 @@ define(function (require, exports, module) {
                             onClick={this._handleTitleClicked}
                             onDoubleClick={this._handleStartEditingTitle}
                             onChange={this._handleRename}
-                            onBlur={this._handleEndEditingTitle}/>
+                            onBlur={this._handleEndEditingTitle}
+                            allowEmpty={false}/>
                         {subTitle}
                     </div>
                 );

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -655,7 +655,8 @@ define(function (require, exports, module) {
                         onKeyDown={this._handleKeyDown}
                         onChange={this._handleInputChanged}
                         onFocus={this._handleFocus}
-                        onClick={this._handleInputClicked} />
+                        onClick={this._handleInputClicked}
+                        allowEmpty={false} />
                   </div>
             );
         }

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -749,14 +749,13 @@ define(function (require, exports, module) {
                         ref="textInput"
                         disabled={this.props.disabled}
                         size={size}
-                        continuous={true}
                         value={title}
                         placeholder={this.props.placeholderText}
                         neverSelectAll={this.props.neverSelectAllInput}
                         onFocus={this._handleInputFocus}
                         onBlur={this._handleInputBlur}
                         onKeyDown={this._handleInputKeyDown}
-                        onChange={this._handleInputChange}
+                        onInputChange={this._handleInputChange}
                         onDOMChange={this._handleInputDOMChange}
                         onClick={this._handleInputClick} />
                     {autocomplete}


### PR DESCRIPTION
* Instead of handling empty value in the handler, I added new option `allowEmpty` which will ignore empty value and skip the `onChange` handler.
* `onChange` was not clear before: it could be onChange handler or onCommit handler (when `continuous` prop is true). I reduce its scope by adding a new handle `onInputChange`, which also helps remove the `continuous` prop. Please see doc for difference of two handlers.
* bug fix: disallow empty value in ColorPicker. Otherwise inputting empty value will set color to black.

@volfied @mcilroyc can you review since you both reviewed #3410 ?