### PR TITLE
Scrubbiness for more

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -98,19 +98,24 @@ define(function (require, exports) {
      *                                     parent artboard of the layer
      * @param {string} refPoint Two character string denoting corner/edge of the layer to set the position into
      * @param {Array.<{layer: Layer, x: number, y: number}>} moveResults payload for updating each layer's bounds
+     * @param {boolean=} translate Whether to use translate or set absolute position by given coordinates
+     *                             absolute position is default
      *
      * @return {Immutable.List<{layer: Layer, playObject: PlayObject}>}
      */
-    var _getMoveLayerActions = function (document, targetLayer, position, refPoint, moveResults) {
+    var _getMoveLayerActions = function (document, targetLayer, position, refPoint, moveResults, translate) {
         var overallBounds = position.relative ?
                 document.layers.relativeChildBounds(targetLayer) :
                 document.layers.childBounds(targetLayer),
             positionKeys = uiUtil.getPositionKeysByRefPoint(refPoint),
             deltaX = position.hasOwnProperty("x") ? position.x - overallBounds[positionKeys.x] : 0,
             deltaY = position.hasOwnProperty("y") ? position.y - overallBounds[positionKeys.y] : 0,
+            newX = translate ? deltaX : (overallBounds.left + deltaX),
+            newY = translate ? deltaY : (overallBounds.top + deltaY),
             documentRef = documentLib.referenceBy.id(document.id),
             movingLayers = document.layers.descendants(targetLayer),
-            layerRef = [documentRef, layerLib.referenceBy.id(targetLayer.id)];
+            layerRef = [documentRef, layerLib.referenceBy.id(targetLayer.id)],
+            descriptorFn = translate ? layerLib.translate : layerLib.setPosition;
 
         moveResults = moveResults || [];
 
@@ -130,7 +135,7 @@ define(function (require, exports) {
 
         return Immutable.List.of({
             layer: targetLayer,
-            playObject: layerLib.translate(layerRef, deltaX, deltaY)
+            playObject: descriptorFn(layerRef, newX, newY)
         });
     };
          
@@ -404,44 +409,59 @@ define(function (require, exports) {
      * @param {boolean} position.relative If true, x and y will be relative to the owner artboard of layer
      * @param {string} refPoint Two character string denoting the active reference point so we know 
      *                 which corner of the layer to move
-     *
+     * @param {object} options Batch play options
+     * 
      * @return {Promise}
      */
-    var setPosition = function (document, layerSpec, position, refPoint) {
+    var setPosition = function (document, layerSpec, position, refPoint, options) {
+        options = _.merge({}, options);
         layerSpec = layerSpec.filterNot(function (layer) {
             return layer.isGroupEnd;
         });
 
         var payload = {
-                documentID: document.id,
-                positions: [],
-                history: {
-                    newState: true,
-                    name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION")
-                }
-            },
-            options = {
-                paintOptions: _paintOptions,
-                historyStateInfo: {
-                    name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION"),
-                    target: documentLib.referenceBy.id(document.id)
-                }
-            };
+            documentID: document.id,
+            positions: [],
+            coalesce: !!options.coalesce,
+            history: {
+                newState: true,
+                name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION")
+            }
+        };
 
+        options = _.merge(options, {
+            paintOptions: _paintOptions,
+            historyStateInfo: {
+                name: nls.localize("strings.ACTIONS.SET_LAYER_POSITION"),
+                target: documentLib.referenceBy.id(document.id),
+                coalesce: !!options.coalesce,
+                suppressHistoryStateNotification: !!options.coalesce
+            }
+        });
+
+        // If coalescing, we use absolute setPosition function to avoid model mismatch
         var dispatchPromise = this.dispatchAsync(events.document.history.REPOSITION_LAYERS, payload),
             translateLayerActions = layerSpec.reduce(function (actions, layer) {
                 var layerActions = _getMoveLayerActions.call(this,
-                        document, layer, position, refPoint, payload.positions);
+                        document, layer, position, refPoint, payload.positions, !options.coalesce);
                 return actions.concat(layerActions);
             }, Immutable.List(), this);
 
-        var positionPromise = layerActionsUtil.playLayerActions(document, translateLayerActions, true, options)
+        var transaction = descriptor.beginTransaction(options),
+            actionOpts = _.merge(options, {
+                transaction: transaction
+            });
+
+        var positionPromise = layerActionsUtil.playLayerActions(document, translateLayerActions, true, actionOpts)
+            .then(function () {
+                return descriptor.endTransaction(transaction);
+            });
+
+        return Promise.join(dispatchPromise, positionPromise)
             .bind(this)
             .then(function () {
                 return this.transfer(layerActions.resetIndex, undefined);
             });
-
-        return Promise.join(dispatchPromise, positionPromise);
     };
     setPosition.action = {
         reads: [],
@@ -556,10 +576,12 @@ define(function (require, exports) {
      * @param {Layer|Immutable.Iterable.<Layer>} layerSpec Either a Layer reference or array of Layers
      * @param {{w: number=, h: number=}} size
      * @param {string} refPoint reference point, vertical position first then horizontal
+     * @param {object} options Batch play options
      *
      * @returns {Promise}
      */
-    var setSize = function (document, layerSpec, size, refPoint) {
+    var setSize = function (document, layerSpec, size, refPoint, options) {
+        options = _.merge({}, options);
         layerSpec = layerSpec.filterNot(function (layer) {
             return layer.isGroupEnd ||
                 document.layers.strictAncestors(layer)
@@ -569,20 +591,24 @@ define(function (require, exports) {
         }, this);
 
         var payload = {
-                documentID: document.id,
-                sizes: [],
-                history: {
-                    newState: true,
-                    name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE")
-                }
-            },
-            options = {
-                paintOptions: _paintOptions,
-                historyStateInfo: {
-                    name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE"),
-                    target: documentLib.referenceBy.id(document.id)
-                }
-            };
+            documentID: document.id,
+            sizes: [],
+            coalesce: !!options.coalesce,
+            history: {
+                newState: true,
+                name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE")
+            }
+        };
+        
+        options = _.merge(options, {
+            paintOptions: _paintOptions,
+            historyStateInfo: {
+                name: nls.localize("strings.ACTIONS.SET_LAYER_SIZE"),
+                target: documentLib.referenceBy.id(document.id),
+                coalesce: !!options.coalesce,
+                suppressHistoryStateNotification: !!options.coalesce
+            }
+        });
 
         // Document
         var dispatchPromise,
@@ -610,11 +636,11 @@ define(function (require, exports) {
             dispatchPromise = this.dispatchAsync(events.document.history.RESIZE_LAYERS, payload);
 
             var transaction = descriptor.beginTransaction(options),
-                actionOpts = {
+                actionOpts = _.merge(options, {
                     transaction: transaction
-                };
+                });
 
-            sizePromise = descriptor.getProperty(documentRef, "artboards")
+            sizePromise = descriptor.getProperty(documentRef, "artboards", actionOpts)
                 .bind(this)
                 .then(function (artboardInfo) {
                     autoExpandEnabled = artboardInfo.autoExpandEnabled;
@@ -626,7 +652,7 @@ define(function (require, exports) {
                             autoExpandEnabled: false
                         });
 
-                        return descriptor.playObject(setObj);
+                        return descriptor.playObject(setObj, actionOpts);
                     }
                 })
                 .then(function () {
@@ -638,7 +664,7 @@ define(function (require, exports) {
                             autoExpandEnabled: true
                         });
 
-                        return descriptor.playObject(setObj);
+                        return descriptor.playObject(setObj, actionOpts);
                     }
                 })
                 .then(function () {
@@ -1141,12 +1167,24 @@ define(function (require, exports) {
      * @param {number} angle Angle in degrees
      * @return {Promise}
      */
-    var rotate = function (document, angle) {
+    var rotate = function (document, angle, options) {
+        options = _.merge({}, options);
         var layers = _filterTransform(document, document.layers.selected);
         if (layers.isEmpty()) {
             return Promise.resolve();
         }
 
+        var coalesce = !!options.coalesce;
+
+        options = _.merge(options, {
+            historyStateInfo: {
+                name: nls.localize("strings.ACTIONS.ROTATE_LAYERS"),
+                target: documentLib.referenceBy.id(document.id),
+                coalesce: coalesce,
+                suppressHistoryStateNotification: coalesce
+            }
+        });
+        
         var documentRef = documentLib.referenceBy.id(document.id),
             layerRef = layers.map(function (layer) {
                     return layerLib.referenceBy.id(layer.id);
@@ -1154,13 +1192,7 @@ define(function (require, exports) {
                 .unshift(documentRef)
                 .toArray(),
             rotateObj = layerLib.rotate(layerRef, angle),
-            options = {
-                historyStateInfo: {
-                    name: nls.localize("strings.ACTIONS.ROTATE_LAYERS"),
-                    target: documentLib.referenceBy.id(document.id)
-                }
-            },
-            historyPromise = this.transfer(historyActions.newHistoryState, document.id,
+            historyPromise = coalesce ? Promise.resolve() : this.transfer(historyActions.newHistoryState, document.id,
                 nls.localize("strings.ACTIONS.ROTATE_LAYERS")),
             playPromise = locking.playWithLockOverride(document, layers, rotateObj, options);
 

--- a/src/js/jsx/mixin/Scrubby.js
+++ b/src/js/jsx/mixin/Scrubby.js
@@ -30,33 +30,57 @@ define(function (require, exports, module) {
         log = require("js/util/log");
 
     /**
-     * Mixin for drag-and-drop functionality. Clients should call _startUpdates
-     * on mousedown/touchstart and implement the abstract method _updatePosition.
-     * CLinets can optinally implement _updatePositionBegin and _updatePositionEnd
+     * This mixin provides the component with scrubby functionality, where the user can
+     * start dragging on the component in either direction, and continuous updates
+     * about the relative position of the drag is passed to the component
+     *
+     * For minimal use, clients need to provide the `onScrub` function which
+     * is passed the distance mouse traveled since last onScrub call
+     *
+     * Optionally, clients can also provide onScrubStart and onScrubEnd for initialize/cleanup
+     * onScrubStart is passed the initial mouse coordinates (x,y)
+     * onScrubEnd is passed the distance of the scrub from when onScrubStart is called (dx, dy)
      */
     module.exports = {
+        /**
+         * X position of mouse/touch event when scrubbing starts
+         *
+         * @type {number}
+         */
+        _initialScrubX: null,
+
+        /**
+         * Y position of mouse/touch event when scrubbing starts
+         *
+         * @type {number}
+         */
+        _initialScrubY: null,
 
         propTypes: {
             onChange: React.PropTypes.func,
-            max: React.PropTypes.number
+            onScrub: React.PropTypes.func,
+            onScrubStart: React.PropTypes.func,
+            onScrubEnd: React.PropTypes.func
         },
 
         getDefaultProps: function () {
             return {
                 onChange: _.identity,
-                max: 1
+                onScrub: _.identity,
+                onScrubStart: _.identity,
+                onScrubEnd: _.identity
             };
         },
 
         getInitialState: function () {
             return {
-                active: false
+                scrubbing: false
             };
         },
 
         componentDidMount: function () {
-            if (!this._updatePosition) {
-                log.debug("update Position was not declared in a class that uses the Scrubby Mixin");
+            if (!this.props.onScrub && !this.props.onScrubEnd) {
+                log.debug("Scrubby Mixin is being used without onScrub or onScrubEnd defined");
             }
             ReactDOM.findDOMNode(this).addEventListener("mousedown", this._installListeners);
         },
@@ -67,26 +91,28 @@ define(function (require, exports, module) {
         },
 
         /**
-         * On mouse down, all these window listeners will be added to handle Scrubby behavior
+         * On mouse down, starts listening for related mouse/touch events, and starts scrubbing
+         * @param {SyntheticEvent} event
          * @private
          */
-        _installListeners: function () {
-            window.document.addEventListener("mousemove", this._handleUpdate);
-            window.document.addEventListener("touchmove", this._handleUpdate);
-            window.document.addEventListener("mouseup", this._stopUpdates);
-            window.document.addEventListener("touchend", this._stopUpdates);
+        _installListeners: function (event) {
+            this._startScrubUpdates(event);
+            window.document.addEventListener("mousemove", this._handleScrubMove);
+            window.document.addEventListener("touchmove", this._handleScrubMove);
+            window.document.addEventListener("mouseup", this._stopScrubUpdates);
+            window.document.addEventListener("touchend", this._stopScrubUpdates);
         },
 
         /**
-         * On mouse up, _stopUpdates gets called, which calls this to uninstall listeners
+         * On mouse up, _stopScrubUpdates gets called, which calls this to uninstall listeners
          * It's also called on component unmount to not leave zombie listeners behind
          * @private
          */
         _uninstallListeners: function () {
-            window.document.removeEventListener("mousemove", this._handleUpdate);
-            window.document.removeEventListener("touchmove", this._handleUpdate);
-            window.document.removeEventListener("mouseup", this._stopUpdates);
-            window.document.removeEventListener("touchend", this._stopUpdates);
+            window.document.removeEventListener("mousemove", this._handleScrubMove);
+            window.document.removeEventListener("touchmove", this._handleScrubMove);
+            window.document.removeEventListener("mouseup", this._stopScrubUpdates);
+            window.document.removeEventListener("touchend", this._stopScrubUpdates);
         },
 
         /**
@@ -103,59 +129,85 @@ define(function (require, exports, module) {
          * @private
          * @param {MouseEvent} event
          */
-        _suppressClick: function (event) {
+        _suppressScrubbyClick: function (event) {
             event.stopPropagation();
 
-            window.removeEventListener("click", this._suppressClick, true);
+            window.removeEventListener("click", this._suppressScrubbyClick, true);
         },
 
         /**
-         * Handler for the start-drag operation.
+         * Handler for the start of scrubby behavior, logs the start location,
+         * calls the start handler, if provided, and handles the inevitable click event
+         * we'll receive on window
          * 
          * @private
          * @param {SyntheticEvent} e
          */
-        _startUpdates: function (e) {
+        _startScrubUpdates: function (e) {
             e.stopPropagation();
-            var coords = this._getPosition(e);
-            this.setState({ active: true });
-            if (this._updatePositionBegin) {
-                this._updatePositionBegin();
+            
+            var coords = this._getScrubPosition(e);
+            
+            this.setState({
+                scrubbing: true
+            });
+            
+            if (this.props.onScrubStart) {
+                this.props.onScrubStart(coords.x, coords.y);
             }
-            if (this._updatePosition) {
-                this._updatePosition(coords.x, coords.y);
-            }
-            window.addEventListener("click", this._suppressClick, true);
+
+            this._initialScrubX = coords.x;
+            this._initialScrubY = coords.y;
+            
+            // @see _suppressScrubbyClick
+            window.addEventListener("click", this._suppressScrubbyClick, true);
         },
 
         /**
-         * Handler for the update-drag operation.
+         * Handler for the input move during scrubby behavior, 
+         * calls the provided onScrub handler with the delta from the last call
          * 
          * @private
          * @param {SyntheticEvent} e
          */
-        _handleUpdate: function (e) {
-            if (this.state.active) {
+        _handleScrubMove: function (e) {
+            if (this.state.scrubbing) {
                 e.stopPropagation();
-                var coords = this._getPosition(e);
-                if (this._updatePosition) {
-                    this._updatePosition(coords.x, coords.y);
+
+                var coords = this._getScrubPosition(e),
+                    deltaX = coords.x - this._initialScrubX,
+                    deltaY = coords.y - this._initialScrubY;
+
+                if (this.props.onScrub) {
+                    this.props.onScrub(deltaX, deltaY);
                 }
             }
         },
 
         /**
-         * Handler for the stop-drag operation.
+         * Handler for when scrubby behavior is finished by user letting go of the mouse
+         * or the touch event. If provided, calls the onScrubEnd handler with the total mouse delta
+         * between scrub finish and start position, allowing non-live scrubby clients a chance
          * 
          * @private
+         * @param {SyntheticEvent} e
          */
-        _stopUpdates: function () {
+        _stopScrubUpdates: function (e) {
             this._uninstallListeners();
-            if (this._updatePositionEnd) {
-                this._updatePositionEnd();
-            }
-            if (this.state.active) {
-                this.setState({ active: false });
+
+            this.setState({
+                scrubbing: false
+            });
+
+            var coords = this._getScrubPosition(e),
+                deltaX = coords.x - this._initialScrubX,
+                deltaY = coords.y - this._initialScrubY;
+
+            this._initialScrubX = null;
+            this._initialScrubY = null;
+            
+            if (this.props.onScrubEnd) {
+                this.props.onScrubEnd(deltaX, deltaY);
             }
         },
 
@@ -163,9 +215,9 @@ define(function (require, exports, module) {
          * Helper function to extract the position a move or touch event.
          * 
          * @param {SyntheticEvent} e
-         * @return {{x: number, y: num}}
+         * @return {{x: number, y: number}}
          */
-        _getPosition: function (e) {
+        _getScrubPosition: function (e) {
             if (e.touches) {
                 e = e.touches[0];
             }

--- a/src/js/jsx/mixin/Scrubby.js
+++ b/src/js/jsx/mixin/Scrubby.js
@@ -26,8 +26,7 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         ReactDOM = require("react-dom"),
-        _ = require("lodash"),
-        log = require("js/util/log");
+        _ = require("lodash");
 
     /**
      * This mixin provides the component with scrubby functionality, where the user can
@@ -35,7 +34,7 @@ define(function (require, exports, module) {
      * about the relative position of the drag is passed to the component
      *
      * For minimal use, clients need to provide the `onScrub` function which
-     * is passed the distance mouse traveled since last onScrub call
+     * is passed the distance mouse traveled since scrub started
      *
      * Optionally, clients can also provide onScrubStart and onScrubEnd for initialize/cleanup
      * onScrubStart is passed the initial mouse coordinates (x,y)
@@ -57,7 +56,6 @@ define(function (require, exports, module) {
         _initialScrubY: null,
 
         propTypes: {
-            onChange: React.PropTypes.func,
             onScrub: React.PropTypes.func,
             onScrubStart: React.PropTypes.func,
             onScrubEnd: React.PropTypes.func
@@ -65,7 +63,6 @@ define(function (require, exports, module) {
 
         getDefaultProps: function () {
             return {
-                onChange: _.identity,
                 onScrub: _.identity,
                 onScrubStart: _.identity,
                 onScrubEnd: _.identity
@@ -79,9 +76,6 @@ define(function (require, exports, module) {
         },
 
         componentDidMount: function () {
-            if (!this.props.onScrub && !this.props.onScrubEnd) {
-                log.debug("Scrubby Mixin is being used without onScrub or onScrubEnd defined");
-            }
             ReactDOM.findDOMNode(this).addEventListener("mousedown", this._installListeners);
         },
 

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -51,14 +51,14 @@ define(function (require, exports, module) {
          * @private 
          * @type {number}
          */
-        _xScrubbyValue: null,
+        _initialScrubX: null,
         
         /**
          * Variables for storing inital scrub value to determine correct offset.
          * @private 
          * @type {number}
          */
-        _yScrubbyValue: null,
+        _initialScrubY: null,
 
         getDefaultProps: function () {
             return {
@@ -112,22 +112,22 @@ define(function (require, exports, module) {
                 xValues = collection.pluck(bounds, positionKeys.x),
                 value = collection.uniformValue(xValues);
 
-            this._xScrubbyValue = value;
+            this._initialScrubX = value;
         },
 
         /**
-         * Update the current X position of the selected layers.
+         * Update the current X position of the selected layers based on change from initial scrub position
          *
          * @private
-         * @param {number} newX
+         * @param {number} deltaX
          */
-        _handleXScrub: function (newX) {
-            if (_.isNumber(this._xScrubbyValue)) {
+        _handleXScrub: function (deltaX) {
+            if (_.isNumber(this._initialScrubX)) {
                 var document = this.props.document,
                     uiStore = this.getFlux().store("ui"),
                     resolution = document.resolution,
                     positionObj = {
-                        x: (uiStore.zoomCanvasToWindow(newX * resolution) / resolution) + this._xScrubbyValue,
+                        x: (uiStore.zoomCanvasToWindow(deltaX * resolution) / resolution) + this._initialScrubX,
                         relative: true
                     };
                     
@@ -148,22 +148,22 @@ define(function (require, exports, module) {
                 yValues = collection.pluck(bounds, positionKeys.y),
                 value = collection.uniformValue(yValues);
 
-            this._yScrubbyValue = value;
+            this._initialScrubY = value;
         },
         
         /**
          * Update the current X position of the selected layers.
          *
          * @private
-         * @param {number} newY
+         * @param {number} deltaX
          */
-        _handleYScrub: function (newY) {
-            if (_.isNumber(this._yScrubbyValue)) {
+        _handleYScrub: function (deltaX) {
+            if (_.isNumber(this._initialScrubY)) {
                 var document = this.props.document,
                     uiStore = this.getFlux().store("ui"),
                     resolution = document.resolution,
                     positionObj = {
-                        y: (uiStore.zoomCanvasToWindow(newY * resolution) / resolution) + this._yScrubbyValue,
+                        y: (uiStore.zoomCanvasToWindow(deltaX * resolution) / resolution) + this._initialScrubY,
                         relative: true
                     };
 
@@ -238,8 +238,8 @@ define(function (require, exports, module) {
                         title={nls.localize("strings.TOOLTIPS.SET_X_POSITION")}
                         className="label__medium__left-aligned"
                         size="column-1"
-                        onScrub={this._handleXScrub}
-                        onScrubStart={this._handleXScrubBegin}>
+                        onScrub={!disabled && this._handleXScrub}
+                        onScrubStart={!disabled && this._handleXScrubBegin}>
                         {nls.localize("strings.TRANSFORM.X")}
                     </Label>
                     <NumberInput
@@ -256,8 +256,8 @@ define(function (require, exports, module) {
                         title={nls.localize("strings.TOOLTIPS.SET_Y_POSITION")}
                         className="label__medium__left-aligned"
                         size="column-1"
-                        onScrub={this._handleYScrub}
-                        onScrubStart={this._handleYScrubBegin}>
+                        onScrub={!disabled && this._handleYScrub}
+                        onScrubStart={!disabled && this._handleYScrubBegin}>
                         {nls.localize("strings.TRANSFORM.Y")}
                     </Label>
                     <NumberInput

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -98,7 +98,8 @@ define(function (require, exports, module) {
                     <div className="section-container__no-collapse transform__body">
                         <div className="formline formline__padded-first-child formline__space-between">
                             <div className="control-group">
-                                <Size document={this.props.document} />
+                                <Size document={this.props.document}
+                                    referencePoint={this.state.referencePoint}/>
                             </div>
                             <div className="control-group reference-mark" title={referencePointTooltip}>
                                 <svg className="reference-none" preserveAspectRatio="xMidYMid" width="100%"

--- a/src/js/jsx/shared/Label.jsx
+++ b/src/js/jsx/shared/Label.jsx
@@ -25,7 +25,6 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        ReactDOM = require("react-dom"),
         classnames = require("classnames"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
@@ -35,52 +34,7 @@ define(function (require, exports, module) {
         mixins: [FluxMixin, ScrubbyMixin],
         
         propTypes: {
-            size: React.PropTypes.string,
-            onScrub: React.PropTypes.func,
-            onScrubStart: React.PropTypes.func,
-            onScrubEnd: React.PropTypes.func
-        },
-
-        /**
-         * inform the parent that scrubbing has started
-         *
-         * @private
-         */
-        _updatePositionBegin: function () {
-            if (this.props.onScrubStart) {
-                this.props.onScrubStart();
-            }
-        },
-        
-        /**
-         * inform the parent that scrubbing has ended
-         *
-         * @private
-         */
-        _updatePositionEnd: function () {
-            if (this.props.onScrubEnd) {
-                this.props.onScrubEnd();
-            }
-        },
-
-        /**
-         * Update the parents scrubby information
-         *
-         * @private
-         */
-        _updatePosition: function (clientX, clientY) {
-            if (this.props.onScrub) {
-                var rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-
-                var value;
-                if (this.props.vertical) {
-                    value = (rect.bottom - clientY);
-                } else {
-                    value = (clientX - rect.left);
-                }
-
-                this.props.onScrub(value);
-            }
+            size: React.PropTypes.string
         },
 
         render: function () {
@@ -94,8 +48,6 @@ define(function (require, exports, module) {
                 <label
                     {...this.props}
                     ref="label"
-                    onMouseDown={!this.props.disabled && this.props.onScrub && this._startUpdates}
-                    onTouchStart={!this.props.disabled && this.props.onScrub && this._startUpdates}
                     className={className}>
                     {this.props.children}
                 </label>


### PR DESCRIPTION
 - Refactored Scrubby sliders, addressing #3286 and cleaning the code a bit
 - Added scrubbiness to Width and Height labels, also coalescing the scrubs
 - `_getMoveLayerActions` now uses absolute positioning if coalescing is true, but translate otherwise. This change was done in order to not change existing behavior, but have scrub behavior be correct.

This is still a WIP, while I hook up other controls, so I will be updating the PR with more files as I go along, but the core functionality, and example Scrub behavior should be reviewed in case I made some error that'll carry on to other scrub implementations.