### PR TITLE
Fix search bar colors in all color stops

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
     var collection = require("js/util/collection"),
         nls = require("js/util/nls"),
         Datalist = require("js/jsx/shared/Datalist"),
+        SVGIcon = require("js/jsx/shared/SVGIcon"),
         headlights = require("js/util/headlights"),
         Button = require("js/jsx/shared/Button");
 
@@ -537,6 +538,8 @@ define(function (require, exports, module) {
             return (
                 <div
                     onClick={this._handleDialogClick}>
+                   <SVGIcon
+                        CSSID="layer-search-app" />
                    <Datalist
                         ref="datalist"
                         disabled={!this.state.ready}

--- a/src/style/search/search-bar.less
+++ b/src/style/search/search-bar.less
@@ -26,7 +26,7 @@
 @dialog-radius: .6rem;
 
 .search-bar__dialog {
-    background: url("img/ico-layer-search.svg") no-repeat left @bg-panel;
+    background: no-repeat left @bg-panel;
     background-size: @text-xxlarge;
     background-position: 1.7rem 1.5rem;
     top: 25%;
@@ -46,11 +46,27 @@
 
 .search-bar__dialog .drop-down {
     margin-top: 1rem;
-    margin-left: 3.3rem;
-
     border: none;
+    float: right;
     width: @drop-down-width;
     background: @bg-panel;
+}
+
+.search-bar__dialog svg {
+    margin-left: 1.1rem;
+    margin-top: 1.5rem;
+    width: 1.8rem;
+    height: 1.8rem;
+    fill: @icon-active;
+}
+
+.search-bar__dialog .drop-down svg {
+    width: 1.8rem;
+    height: 1.8rem;
+    margin-left: 0rem;
+    margin-top: 0rem;
+    margin-right: 1rem;
+    fill: @icon-active;
 }
 
 .search-bar__dialog .drop-down:hover {
@@ -105,11 +121,9 @@
     background-color: rgba(0,0,0,0.01);
 }
 
-.search-bar__dialog svg {
-    width: 1.8rem;
-    height: 1.8rem;
-    fill: @icon-active;
-    margin-right: 1rem;
+.search-bar__dialog .dialog__target.dialog-search-bar {
+    margin-left: -1.75rem;
+    width: 47.5rem;
 }
 
 .search-bar__dialog .select__option {
@@ -139,7 +153,7 @@
 
 .search-bar__dialog .select__option__selected {
     color: @text-highlight;
-    border-left: .2rem solid @focus-highlight;
+    border-left: .3rem solid @focus-highlight;
     background-color: @bg-app;
     
     svg {
@@ -151,7 +165,7 @@
 }
 
 .search-bar__dialog .select__header {
-    color: @item-inactive;
+    color: @item-disabled;
     border-top: @hairline solid @underlines;
     margin-top: 1rem;
     margin-bottom: .25rem;

--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -98,7 +98,7 @@ dialog::backdrop {
     border-radius: @dialog-radius;
     box-shadow: none;
     border: @hairline solid @underlines;
-    margin-left: -1.8rem;
+    margin-left: -1.6rem;
     margin-top: -2.8rem;
     margin-bottom: 5.3rem;
     -webkit-animation: fadeIn 400ms;


### PR DESCRIPTION
References #3364 (@placegraphichere @iwehrman this might be of most interest to you guys) 

The most important parts of the PR I need approval on are: 

a.) The spacing and layout of the search bar now -- the positions of the search icon, the list icons, the category headers, and the search inquiry as the user is typing. 

For each color stop, check the colors of these with respect to the entire UI in that color stop: 
b.) The search icon
c.) The category headers
d.) The list icons
e.) The text after the list icons
f.) The ancestry text after each option 

As is, we are able to use the same less variable names for each of the items above, no matter the color stop. If changes are to be made to specific color stops, we will just need to add specific selectors targeting that color stop. Note -- Rest assured the blurriness is not actually how the searchbar is rendered, the images are weird for some reason. 

![](https://www.dropbox.com/s/31t7gs6qw1exqr9/Screenshot%202015-12-10%2012.40.04.png?raw=1)
![](https://www.dropbox.com/s/hc4s53t7c48wwfm/Screenshot%202015-12-10%2012.39.55.png?raw=1)
![](https://www.dropbox.com/s/ib7rbyuqts7iy73/Screenshot%202015-12-10%2012.39.42.png?raw=1)
![](https://www.dropbox.com/s/tay02ktmmmtk7a1/Screenshot%202015-12-10%2012.39.28.png?raw=1)