### PR TITLE
Verify selected layer bounds

### DIFF
--- a/src/js/actions/groups.js
+++ b/src/js/actions/groups.js
@@ -613,7 +613,8 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: ["layers.resetIndex", "export.addDefaultAsset", "layers.unlockBackgroundLayer"],
-        post: [layerActions._verifyLayerIndex, layerActions._verifyLayerSelection]
+        post: [layerActions._verifyLayerIndex, layerActions._verifyLayerSelection,
+            layerActions._verifySelectedBounds]
     };
 
     exports.groupSelected = groupSelected;

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -220,7 +220,8 @@ define(function (require, exports) {
     setStroke.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetBounds]
+        transfers: [layerActions.resetBounds],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -350,7 +351,8 @@ define(function (require, exports) {
     setStrokeEnabled.action = {
         reads: [],
         writes: [],
-        transfers: [setStrokeColor]
+        transfers: [setStrokeColor],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -394,7 +396,8 @@ define(function (require, exports) {
     setStrokeAlignment.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetBounds]
+        transfers: [layerActions.resetBounds],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -482,7 +485,8 @@ define(function (require, exports) {
     setStrokeWidth.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetBounds]
+        transfers: [layerActions.resetBounds],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -690,7 +694,8 @@ define(function (require, exports) {
     combineUnion.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex]
+        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -717,7 +722,8 @@ define(function (require, exports) {
     combineSubtract.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex]
+        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -744,7 +750,8 @@ define(function (require, exports) {
     combineIntersect.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex]
+        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -771,7 +778,8 @@ define(function (require, exports) {
     combineDifference.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex]
+        transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
+        post: [layerActions._verifySelectedBounds]
     };
 
     exports.setStrokeEnabled = setStrokeEnabled;

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -175,7 +175,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updatePostScript, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -246,7 +247,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updateFace, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -409,7 +411,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updateSize, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
     
     /**
@@ -477,7 +480,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updateTracking, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -547,7 +551,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updateLeading, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**
@@ -614,7 +619,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [updateAlignment, layerActions.resetBounds, layerActions.resetLayers],
-        modal: true
+        modal: true,
+        post: [layerActions._verifySelectedBounds]
     };
 
     /**

--- a/src/js/actions/typetool.js
+++ b/src/js/actions/typetool.js
@@ -87,7 +87,8 @@ define(function (require, exports) {
         modal: true,
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
-        transfers: [layerActions.resetLayers]
+        transfers: [layerActions.resetLayers],
+        post: [layerActions._verifySelectedBounds]
     };
 
     exports.handleDeletedLayer = handleDeletedLayer;

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -464,7 +464,7 @@ define(function (require, exports, module) {
         /**
          * The subset of Layer models that are all selected or are descendants of selected
          *
-         * @return {Immutable.List.<Layer>}
+         * @return {Immutable.OrderedSet.<Layer>}
          */
         "allSelected": function () {
             return this.selected.flatMap(this.descendants, this).toOrderedSet();


### PR DESCRIPTION
This PR adds a post-verification step for selected layer bounds to actions that modify the bounds. It also "cleans up" (and hopefully doesn't break?) the layer transform event handler.

With this on, I immediately notice a few warnings. Some of them are "false" in that there are actions racing to update the bounds, and the post-verification step sometimes runs before a later action fixes things up. I also see a number of what appear to be true (if perhaps not severe?) warnings when transforming layers via the transform panel due to rounding issues. In any case, I think we should add these warnings first and triage them later.