### PR TITLE
Use cancellation and local flag to remove isMounted calls

### DIFF
--- a/src/js/jsx/shared/Select.jsx
+++ b/src/js/jsx/shared/Select.jsx
@@ -143,6 +143,14 @@ define(function (require, exports, module) {
      */
     var Select = React.createClass({
 
+        /**
+         * ID of timeout handler used to delay rendering the component
+         * Stored for canceling if component gets unmounted before timeout
+         *
+         * @type {number}
+         */
+        _mountTimeoutID: null,
+
         propTypes: {
             options: React.PropTypes.instanceOf(Immutable.Iterable).isRequired,
             defaultSelected: React.PropTypes.string,
@@ -198,6 +206,13 @@ define(function (require, exports, module) {
             }
 
             return -1;
+        },
+
+        componentWillUnmount: function () {
+            if (this._mountTimeoutID) {
+                window.clearTimeout(this._mountTimeoutID);
+                this._mountTimeoutID = null;
+            }
         },
 
         componentWillReceiveProps: function (nextProps) {
@@ -608,14 +623,14 @@ define(function (require, exports, module) {
             // Re-render a few milliseconds after mounting with the full set of
             // options. This is hack to eliminate a noticeable pause at mount
             // time with many options.
-            window.setTimeout(function () {
+            this._mountTimeoutID = window.setTimeout(function () {
+                this._mountTimeoutID = null;
+
                 // If we're tabbing between, component will
                 // unmount before this timeout occurs
-                if (this.isMounted()) {
-                    this.setState({
-                        mounted: true
-                    });
-                }
+                this.setState({
+                    mounted: true
+                });
             }.bind(this), 100);
 
             this._scrollTo(this.state.selected);

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -118,12 +118,10 @@ define(function (require, exports, module) {
          * @param {CustomEvent} event EXTERNAL_MOUSE_MOVE event coming from _spaces.OS
          */
         mouseMoveHandler: function (event) {
-            if (this.isMounted()) {
-                this._currentMouseX = event.location[0];
-                this._currentMouseY = event.location[1];
-                
-                this.updateMouseOverHighlights();
-            }
+            this._currentMouseX = event.location[0];
+            this._currentMouseY = event.location[1];
+            
+            this.updateMouseOverHighlights();
         },
 
         /**
@@ -135,12 +133,10 @@ define(function (require, exports, module) {
          * @param {MouseEvent} event
          */
         windowMouseMoveHandler: function (event) {
-            if (this.isMounted()) {
-                this._currentMouseX = event.x;
-                this._currentMouseY = event.y;
+            this._currentMouseX = event.x;
+            this._currentMouseY = event.y;
 
-                this.updateMouseOverHighlights();
-            }
+            this.updateMouseOverHighlights();
         },
 
         /**
@@ -149,10 +145,6 @@ define(function (require, exports, module) {
          * @private
          */
         drawOverlay: function () {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var currentDocument = this.state.document,
                 currentTool = this.state.tool,
                 svg = d3.select(ReactDOM.findDOMNode(this));

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
 
         componentWillUnmount: function () {
             window.removeEventListener("resize", this._drawDebounced);
+            this._drawDebounced.cancel();
         },
 
         componentDidUpdate: function () {
@@ -85,10 +86,6 @@ define(function (require, exports, module) {
          * Draws the policy overlay showing where the pointer policies are
          */
         drawOverlay: function () {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var svg = d3.select(ReactDOM.findDOMNode(this));
 
             svg.selectAll(".policy-overlays").remove();

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -110,6 +110,7 @@ define(function (require, exports, module) {
         },
 
         componentWillUnmount: function () {
+            this._drawDebounced.cancel();
             OS.removeListener("externalMouseMove", this.mouseMoveHandler);
         },
 
@@ -142,12 +143,10 @@ define(function (require, exports, module) {
          * @param {CustomEvent} event EXTERNAL_MOUSE_MOVE event coming from _spaces.OS
          */
         mouseMoveHandler: function (event) {
-            if (this.isMounted()) {
-                this._currentMouseX = event.location[0];
-                this._currentMouseY = event.location[1];
-                
-                this.updateMouseOverHighlights();
-            }
+            this._currentMouseX = event.location[0];
+            this._currentMouseY = event.location[1];
+            
+            this.updateMouseOverHighlights();
         },
 
         /**
@@ -156,10 +155,6 @@ define(function (require, exports, module) {
          * @private
          */
         drawOverlay: function () {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var currentDocument = this.state.document,
                 svg = d3.select(ReactDOM.findDOMNode(this));
 

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -131,9 +131,12 @@ define(function (require, exports, module) {
         },
 
         componentWillUnmount: function () {
+            this._drawDebounced.cancel();
+
             window.removeEventListener("mousemove", this.marqueeUpdater);
             window.removeEventListener("mouseup", this.mouseUpHandler);
             window.removeEventListener("mousedown", this.mouseDownHandler);
+            
             OS.removeListener("externalMouseMove", this.mouseMoveHandler);
         },
 
@@ -171,14 +174,12 @@ define(function (require, exports, module) {
          * @param {CustomEvent} event EXTERNAL_MOUSE_MOVE event coming from _spaces.OS
          */
         mouseMoveHandler: function (event) {
-            if (this.isMounted()) {
-                this._currentMouseX = event.location[0];
-                this._currentMouseY = event.location[1];
-                if (this.state.marqueeEnabled) {
-                    this.updateMarqueeRect();
-                } else {
-                    this.updateMouseOverHighlights();
-                }
+            this._currentMouseX = event.location[0];
+            this._currentMouseY = event.location[1];
+            if (this.state.marqueeEnabled) {
+                this.updateMarqueeRect();
+            } else {
+                this.updateMouseOverHighlights();
             }
         },
 
@@ -189,12 +190,10 @@ define(function (require, exports, module) {
          * @param {MouseEvent} event
          */
         marqueeUpdater: function (event) {
-            if (this.isMounted()) {
-                this._currentMouseX = event.x;
-                this._currentMouseY = event.y;
-                if (this.state.marqueeEnabled) {
-                    this.updateMarqueeRect();
-                }
+            this._currentMouseX = event.x;
+            this._currentMouseY = event.y;
+            if (this.state.marqueeEnabled) {
+                this.updateMarqueeRect();
             }
         },
 
@@ -203,10 +202,6 @@ define(function (require, exports, module) {
          * Cleans it first
          */
         drawOverlay: function () {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var currentDocument = this.state.document,
                 svg = d3.select(ReactDOM.findDOMNode(this));
 
@@ -386,10 +381,6 @@ define(function (require, exports, module) {
          * @param {MouseEvent} event
          */
         mouseUpHandler: function (event) {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var runMarquee = !!this._marqueeRect;
             
             this.getFlux().actions.superselect.marqueeSelect(

--- a/src/js/jsx/tools/SuperselectVectorMaskOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectVectorMaskOverlay.jsx
@@ -68,10 +68,6 @@ define(function (require, exports, module) {
          * Cleans it first
          */
         drawOverlay: function () {
-            if (!this.isMounted()) {
-                return;
-            }
-
             var currentDocument = this.state.document,
                 svg = d3.select(ReactDOM.findDOMNode(this));
             svg.selectAll(".superselect-vector-mask-bounds").remove();
@@ -203,7 +199,7 @@ define(function (require, exports, module) {
                     d3.event.stopPropagation();
                 });
  
-            // ellipse
+            // ellipsec
             // 
             this._vectorMaskHudGroup
                 .append("use")


### PR DESCRIPTION
Addresses #3438, by removing isMounted calls across the board.

For D3 overlays, we rely on a flag, which is simple/stupid way.

For Select, we cancel the timeout callback using `window.clearTimeout`

For AssetPreviewImage, we cancel the promise, which is a no-op if it's already resolved.