### PR TITLE
Declarative overlay management

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -385,7 +385,8 @@ define(function (require, exports) {
     initActiveDocument.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC, locks.JS_APP],
-        transfers: [historyActions.queryCurrentHistory, "layers.deselectAll", "application.updateRecentFiles"]
+        transfers: [historyActions.queryCurrentHistory, "layers.deselectAll", "application.updateRecentFiles"],
+        hideOverlays: true
     };
 
     /**
@@ -439,7 +440,8 @@ define(function (require, exports) {
         reads: [locks.PS_DOC, locks.PS_APP],
         writes: [locks.JS_DOC],
         transfers: [historyActions.queryCurrentHistory],
-        lockUI: true
+        lockUI: true,
+        hideOverlays: true
     };
 
     /**
@@ -530,7 +532,8 @@ define(function (require, exports) {
         writes: [locks.JS_DOC, locks.JS_APP],
         transfers: [updateDocument, "layers.resetLinkedLayers", "history.queryCurrentHistory",
             "ui.updateTransform", "application.updateRecentFiles", "libraries.deleteGraphicTempFiles"],
-        lockUI: true
+        lockUI: true,
+        hideOverlays: true
     };
 
     /**
@@ -569,7 +572,8 @@ define(function (require, exports) {
         reads: [locks.PS_APP],
         writes: [locks.JS_APP],
         transfers: [updateDocument, historyActions.queryCurrentHistory, ui.updateTransform],
-        lockUI: true
+        lockUI: true,
+        hideOverlays: true
     };
 
     /**
@@ -591,7 +595,8 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.PS_APP],
         transfers: [menu.native, "panel.setOverlayOffsetsForFirstDocument"],
-        lockUI: true
+        lockUI: true,
+        hideOverlays: true
     };
 
     /**
@@ -652,7 +657,8 @@ define(function (require, exports) {
         transfers: [preferencesActions.setPreference, allocateDocument,
             "panel.setOverlayOffsetsForFirstDocument", exportActions.addDefaultAsset, toolActions.changeVectorMaskMode],
         post: [_verifyActiveDocument, _verifyOpenDocuments],
-        locksUI: true
+        locksUI: true,
+        hideOverlays: true
     };
 
     /**
@@ -669,8 +675,6 @@ define(function (require, exports) {
         return this.transfer("panel.setOverlayOffsetsForFirstDocument")
             .bind(this)
             .then(function () {
-                this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
-
                 if (!filePath) {
                     // An "open" event will be triggered
                     return this.transfer(menu.native, { commandID: _OPEN_DOCUMENT, waitForCompletion: true })
@@ -704,11 +708,12 @@ define(function (require, exports) {
     };
     open.action = {
         reads: [],
-        writes: [locks.PS_APP, locks.JS_PANEL],
+        writes: [locks.PS_APP],
         transfers: [initActiveDocument, ui.updateTransform, application.updateRecentFiles,
             "panel.setOverlayOffsetsForFirstDocument", menu.native, toolActions.changeVectorMaskMode],
         lockUI: true,
-        post: [_verifyActiveDocument, _verifyOpenDocuments]
+        post: [_verifyActiveDocument, _verifyOpenDocuments],
+        hideOverlays: true
     };
 
     /**
@@ -723,8 +728,6 @@ define(function (require, exports) {
         if (document === undefined) {
             document = this.flux.store("application").getCurrentDocument();
         }
-
-        this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
 
         var closeObj = documentLib.close(document.id),
             playOptions = {
@@ -746,10 +749,11 @@ define(function (require, exports) {
     };
     close.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_PANEL, locks.PS_APP, locks.PS_DOC],
+        writes: [locks.PS_APP, locks.PS_DOC],
         transfers: ["panel.cloak", disposeDocument],
         lockUI: true,
-        post: [_verifyActiveDocument, _verifyOpenDocuments]
+        post: [_verifyActiveDocument, _verifyOpenDocuments],
+        hideOverlays: true
     };
 
     /**
@@ -763,8 +767,6 @@ define(function (require, exports) {
             documentID = typeof documentSpec === "number" ? documentSpec : documentSpec.id,
             document = flux.stores.document.getDocument(documentID),
             documentRef = documentLib.referenceBy.id(documentID);
-
-        this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: false });
 
         return this.transfer("panel.cloak")
             .bind(this)
@@ -809,12 +811,13 @@ define(function (require, exports) {
     };
     selectDocument.action = {
         reads: [locks.JS_TOOL],
-        writes: [locks.JS_APP, locks.JS_PANEL],
+        writes: [locks.JS_APP],
         transfers: ["layers.resetLinkedLayers", historyActions.queryCurrentHistory,
             ui.updateTransform, toolActions.select, "panel.cloak", guideActions.queryCurrentGuides,
             toolActions.changeVectorMaskMode, updateDocument],
         lockUI: true,
-        post: [_verifyActiveDocument]
+        post: [_verifyActiveDocument],
+        hideOverlays: true
     };
 
     /**
@@ -1004,7 +1007,8 @@ define(function (require, exports) {
         writes: [],
         transfers: [updateDocument, "layers.addLayers", "layers.resetLayers", "layers.resetIndex",
         "history.newHistoryStateRogueSafe"],
-        modal: true
+        modal: true,
+        hideOverlays: true
     };
 
     /**

--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -29,8 +29,7 @@ define(function (require, exports) {
 
     var os = require("adapter").os;
 
-    var events = require("../events"),
-        locks = require("../locks"),
+    var locks = require("../locks"),
         layers = require("js/actions/layers"),
         menu = require("./menu"),
         collection = require("js/util/collection"),
@@ -384,21 +383,17 @@ define(function (require, exports) {
         var currentDocument = this.flux.store("application").getCurrentDocument();
         if (!currentDocument) {
             return Promise.resolve();
-        } else {
-            return Promise.join(
-                this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
-                this.transfer(history.decrementHistory, currentDocument.id),
-                function () {
-                    return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
-                }.bind(this));
         }
+
+        return this.transfer(history.decrementHistory, currentDocument.id);
     };
     undo.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_PANEL],
+        writes: [],
         transfers: [history.decrementHistory],
         post: [layers._verifyLayerIndex],
-        modal: true
+        modal: true,
+        hideOverlays: true
     };
 
     /**
@@ -411,21 +406,17 @@ define(function (require, exports) {
         var currentDocument = this.flux.store("application").getCurrentDocument();
         if (!currentDocument) {
             return Promise.resolve();
-        } else {
-            return Promise.join(
-                this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
-                this.transfer(history.incrementHistory, currentDocument.id),
-                function () {
-                    return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
-                }.bind(this));
         }
+
+        return this.transfer(history.incrementHistory, currentDocument.id);
     };
     redo.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_PANEL],
+        writes: [],
         transfers: [history.incrementHistory],
         post: [layers._verifyLayerIndex],
-        modal: true
+        modal: true,
+        hideOverlays: true
     };
 
     exports.nativeCut = nativeCut;

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -300,7 +300,6 @@ define(function (require, exports) {
     var revertCurrentDocument = function () {
         var historyStore = this.flux.store("history"),
             currentDocumentID = this.flux.store("application").getCurrentDocumentID(),
-            clearOverlaysPromise = this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: false }),
             nextStateIndex = historyStore.lastSavedStateIndex(currentDocumentID),
             superPromise;
         
@@ -324,19 +323,15 @@ define(function (require, exports) {
                 });
         }
 
-        // Clear the overlays in parallel with the revert, and then re-enabled them when both complete
-        return Promise.join(clearOverlaysPromise, superPromise)
-            .bind(this)
-            .then(function () {
-                return this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: true });
-            });
+        return superPromise;
     };
     revertCurrentDocument.action = {
         reads: [locks.JS_APP],
-        writes: [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC, locks.JS_PANEL],
+        writes: [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC],
         transfers: ["documents.updateDocument"],
         post: [layerActions._verifyLayerIndex],
-        modal: true
+        modal: true,
+        hideOverlays: true
     };
 
     /**

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1929,7 +1929,8 @@ define(function (require, exports) {
         writes: [],
         transfers: [resetBounds],
         modal: true,
-        post: [_verifySelectedBounds]
+        post: [_verifySelectedBounds],
+        hideOverlays: true
     };
 
     /**

--- a/src/js/actions/panel.js
+++ b/src/js/actions/panel.js
@@ -183,7 +183,8 @@ define(function (require, exports) {
     };
     cloak.action = {
         reads: [locks.JS_PANEL],
-        writes: [locks.PS_APP]
+        writes: [locks.PS_APP],
+        hideOverlays: true
     };
 
     /**
@@ -247,9 +248,10 @@ define(function (require, exports) {
         return adapterUI.setOverlayOffsets(centerOffsets);
     };
     setOverlayOffsetsForFirstDocument.action = {
-        reads: [locks.JS_PREF, locks.JS_APP],
+        reads: [locks.JS_PREF, locks.JS_APP, locks.JS_PANEL],
         writes: [locks.PS_APP],
-        transfers: []
+        transfers: [],
+        hideOverlays: true
     };
 
     /**
@@ -317,7 +319,11 @@ define(function (require, exports) {
 
         // Handles Photoshop focus change events
         _activationChangeHandler = function (event) {
-            this.dispatchAsync(events.panel.TOGGLE_OVERLAYS, { enabled: event.becameActive });
+            if (event.becameActive) {
+                this.dispatch(events.panel.END_CANVAS_UPDATE);
+            } else {
+                this.dispatch(events.panel.START_CANVAS_UPDATE);
+            }
         }.bind(this);
         adapterOS.addListener("activationChanged", _activationChangeHandler);
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1283,7 +1283,8 @@ define(function (require, exports) {
         writes: [],
         transfers: ["history.newHistoryStateRogueSafe", "layers.resetBounds", "layers.resetSelection",
             "layers.resetIndex"],
-        post: [layerActions._verifySelectedBounds]
+        post: [layerActions._verifySelectedBounds],
+        hideOverlays: true
     };
 
     /**
@@ -1293,8 +1294,6 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var handleTransformLayer = function (event) {
-        this.dispatch(events.panel.TOGGLE_OVERLAYS, { enabled: true });
-
         var appStore = this.flux.store("application"),
             currentDoc = appStore.getCurrentDocument();
 
@@ -1347,11 +1346,12 @@ define(function (require, exports) {
     };
     handleTransformLayer.action = {
         read: [locks.JS_APP, locks.JS_DOC],
-        writes: [locks.JS_PANEL],
+        writes: [],
         transfers: ["layers.addLayers", "ui.updateTransform", "layers.resetLayers", "layers.resetBounds",
             "history.newHistoryStateRogueSafe"],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: [layerActions._verifySelectedBounds],
+        hideOverlays: true
     };
 
     /**

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -118,7 +118,8 @@ define(function (require, exports, module) {
         },
         panel: {
             PANELS_RESIZED: "panelsResized",
-            TOGGLE_OVERLAYS: "toggleOverlays",
+            START_CANVAS_UPDATE: "startCanvasUpdate",
+            END_CANVAS_UPDATE: "endCanvasUpdate",
             SUPERSELECT_MARQUEE: "superselectMarquee",
             REFERENCE_POINT_CHANGED: "referencePointChanged",
             COLOR_STOP_CHANGED: "colorStopChanged",

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -715,6 +715,7 @@ define(function (require, exports, module) {
         }
 
         var lockUI = actionObject.lockUI,
+            hideOverlays = actionObject.hideOverlays,
             post = actionObject.post,
             modal = actionObject.modal || false,
             actionTitle;
@@ -723,6 +724,10 @@ define(function (require, exports, module) {
             actionTitle = "sub-action " + actionName + " of action " + parentActionName;
         } else {
             actionTitle = "action " + actionName;
+        }
+
+        if (hideOverlays) {
+            actionReceiver.dispatch(events.panel.START_CANVAS_UPDATE);
         }
 
         var uiWasLocked = this._uiLocked;
@@ -755,6 +760,14 @@ define(function (require, exports, module) {
                 return actionPromise;
             })
             .tap(function () {
+                if (hideOverlays) {
+                    actionReceiver.dispatch(events.panel.END_CANVAS_UPDATE);
+                }
+
+                if (lockUI && !uiWasLocked) {
+                    this._unlockUI();
+                }
+
                 if (global.debug && post && post.length > 0 &&
                     flux.store("preferences").get("postConditionsEnabled")) {
                     var postStart = Date.now(),
@@ -778,11 +791,6 @@ define(function (require, exports, module) {
                             log.debug("Verified " + postTitle + " for " + actionTitle +
                                 " in " + postElapsed + "ms");
                         });
-                }
-            })
-            .tap(function () {
-                if (lockUI && !uiWasLocked) {
-                    this._unlockUI();
                 }
             });
     };

--- a/src/js/stores/ui.js
+++ b/src/js/stores/ui.js
@@ -285,8 +285,6 @@ define(function (require, exports, module) {
             }
 
             this._zoom = payload.zoom;
-            this._overlaysEnabled = true;
-
             this.emit("change");
         },
 


### PR DESCRIPTION
This PR adds declarative management of overlay enablement by way of a new `hideOverlays` boolean action property. When actions like this are executing the overlays are disabled, and then they're re-enabled when all the `hideOverlay` actions are complete. This generally simplifies things (fewer explicit event dispatches) and allows for local reasoning ([as they say!](https://en.wikipedia.org/wiki/Separation_logic)) about the state of the overlays.

One exception to this simple handling is the "scroll" event handler. We use a debounced handler there, but we also want to hide the overlays immediately and not reveal them until after the debounced handler has run. I could imagine handling this case declaratively as well, but since it's currently a one-off I didn't bother.

Addresses #3450 and #2714.