### PR TITLE
Faster document activation

### DIFF
--- a/src/js/jsx/Guard.jsx
+++ b/src/js/jsx/Guard.jsx
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
      * @private
      * @type {function}
      */
-    var _resetCursorDebounced = synchronization.debounce(os.resetCursor, os, 100);
+    var _resetCursorDebounced = synchronization.debounce(os.resetCursor, os, 500);
 
     var Guard = React.createClass({
 


### PR DESCRIPTION
~~This relies on #3457, which should be merged before this.~~

This improves perceived document switching time by exploiting additional concurrency in `documents.selectDocument`. In particular, if the document is already initialized, we dispatch the event which causes the UI to update (which is expensive) in parallel with the Photoshop call to select the document (which is also expensive). The former still explicitly follows the latter in case the document has not yet been initialized.

I've tried to generally follow the sequential constraints strongly implied by the existing mask-cleanup actions, but I'm not completely sure that the ordering (or lackthereof) is entirely correct. In particular, I don't really understand why, on master, the call to `deselectAll` follows the Photoshop selection change. I gather from that the it doesn't really matter whether this is called before or after the select command. @pineapplespatula: let me know if this makes sense.

I don't _think_ it's necessary to call `resetLinkedLayers` the first time a document is initialized; only every other time (ugh). @volfied: let me know if this makes sense.

I've removed the call to `history.queryCurrentHistory` because either a) the document is uninitialized, in which case the current history will be initialized by `updateDocument`, or b) the document is already initialized, in which case we don't need to init its history again. @mcilroyc: let me know if this makes sense.

I still think we can do better than this, especially for big documents. In theory the fast case shouldn't take any longer than it takes to update a few top-level CSS classes. But, for big documents, this seems to take longer, presumably because the application store's change event causes more than just the top-level components to re-render. 

Partially addresses #3458. (Just "partially" because of the aforementioned excessive React rendering.)