### PR TITLE
Verification post-conditions as actions

### DIFF
--- a/src/js/actions/edit.js
+++ b/src/js/actions/edit.js
@@ -391,7 +391,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
         transfers: [history.decrementHistory],
-        post: [layers._verifyLayerIndex],
+        post: ["verifyLayers.verifyLayerIndex"],
         modal: true,
         hideOverlays: true
     };
@@ -414,7 +414,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
         transfers: [history.incrementHistory],
-        post: [layers._verifyLayerIndex],
+        post: ["verifyLayers.verifyLayerIndex"],
         modal: true,
         hideOverlays: true
     };

--- a/src/js/actions/groups.js
+++ b/src/js/actions/groups.js
@@ -35,7 +35,6 @@ define(function (require, exports) {
 
     var Layer = require("js/models/layer"),
         collection = require("js/util/collection"),
-        layerActions = require("./layers"),
         events = require("../events"),
         locks = require("js/locks"),
         locking = require("js/util/locking"),
@@ -212,7 +211,7 @@ define(function (require, exports) {
     groupSelected.action = {
         reads: [locks.PS_DOC, locks.JS_DOC],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        post: [layerActions._verifyLayerIndex, layerActions._verifyLayerSelection]
+        post: ["verifyLayers.verifyLayerIndex", "verifyLayers.verifyLayerSelection"]
     };
 
     /**
@@ -397,7 +396,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: ["layers.resetSelection", "layers.initializeLayers", "layers.getLayerIDsForDocumentID"],
-        post: [layerActions._verifyLayerIndex, layerActions._verifyLayerSelection]
+        post: ["verifyLayers.verifyLayerIndex", "verifyLayers.verifyLayerSelection"]
     };
 
     /**
@@ -613,8 +612,8 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: ["layers.resetIndex", "export.addDefaultAsset", "layers.unlockBackgroundLayer"],
-        post: [layerActions._verifyLayerIndex, layerActions._verifyLayerSelection,
-            layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifyLayerIndex", "verifyLayers.verifyLayerSelection",
+            "verifyLayers.verifySelectedBounds"]
     };
 
     exports.groupSelected = groupSelected;

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -31,7 +31,6 @@ define(function (require, exports) {
         ps = require("adapter").ps,
         documentLib = require("adapter").lib.document,
         historyLib = require("adapter").lib.history,
-        layerActions = require("./layers"),
         documentActions = require("./documents");
 
     var events = require("js/events"),
@@ -329,7 +328,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.JS_HISTORY, locks.JS_DOC, locks.PS_DOC],
         transfers: ["documents.updateDocument"],
-        post: [layerActions._verifyLayerIndex],
+        post: ["verifyLayers.verifyLayerIndex"],
         modal: true,
         hideOverlays: true
     };

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -66,6 +66,8 @@ define(function (require, exports, module) {
         transform: require("./transform"),
         type: require("./type"),
         typetool: require("./typetool"),
-        ui: require("./ui")
+        ui: require("./ui"),
+        verifyDocuments: require("./verify/documents.js"),
+        verifyLayers: require("./verify/layers.js")
     };
 });

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -221,7 +221,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -352,7 +352,7 @@ define(function (require, exports) {
         reads: [],
         writes: [],
         transfers: [setStrokeColor],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -397,7 +397,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -486,7 +486,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -695,7 +695,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -723,7 +723,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -751,7 +751,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -779,7 +779,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetLayers, layerActions.resetLayersByIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     exports.setStrokeEnabled = setStrokeEnabled;

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -467,7 +467,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -568,7 +568,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetIndex],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -691,7 +691,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [layerActions.resetLayers],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
     
     /**
@@ -758,7 +758,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.JS_DOC, locks.PS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
     
     /**
@@ -776,7 +776,7 @@ define(function (require, exports) {
         reads: [],
         writes: [locks.JS_DOC, locks.JS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
     
     /**
@@ -871,7 +871,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
     
     /**
@@ -1062,7 +1062,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -1084,7 +1084,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP],
         writes: [locks.PS_DOC, locks.JS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -1216,7 +1216,7 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [locks.PS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -1283,7 +1283,7 @@ define(function (require, exports) {
         writes: [],
         transfers: ["history.newHistoryStateRogueSafe", "layers.resetBounds", "layers.resetSelection",
             "layers.resetIndex"],
-        post: [layerActions._verifySelectedBounds],
+        post: ["verifyLayers.verifySelectedBounds"],
         hideOverlays: true
     };
 
@@ -1350,7 +1350,7 @@ define(function (require, exports) {
         transfers: ["layers.addLayers", "ui.updateTransform", "layers.resetLayers", "layers.resetBounds",
             "history.newHistoryStateRogueSafe"],
         modal: true,
-        post: [layerActions._verifySelectedBounds],
+        post: ["verifyLayers.verifySelectedBounds"],
         hideOverlays: true
     };
 

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -176,7 +176,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updatePostScript, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -248,7 +248,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updateFace, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -412,7 +412,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updateSize, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
     
     /**
@@ -481,7 +481,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updateTracking, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -552,7 +552,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updateLeading, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**
@@ -620,7 +620,7 @@ define(function (require, exports) {
         writes: [locks.PS_DOC],
         transfers: [updateAlignment, layerActions.resetBounds, layerActions.resetLayers],
         modal: true,
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     /**

--- a/src/js/actions/typetool.js
+++ b/src/js/actions/typetool.js
@@ -88,7 +88,7 @@ define(function (require, exports) {
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
         transfers: [layerActions.resetLayers],
-        post: [layerActions._verifySelectedBounds]
+        post: ["verifyLayers.verifySelectedBounds"]
     };
 
     exports.handleDeletedLayer = handleDeletedLayer;

--- a/src/js/actions/verify/documents.js
+++ b/src/js/actions/verify/documents.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var Promise = require("bluebird"),
+        _ = require("lodash");
+
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document;
+
+    var locks = require("js/locks"),
+        documentActions = require("../documents");
+
+    /**
+     * Verify the correctness of the list of open document IDs.
+     *
+     * @return {Promise} Rejects if the number or order of open document IDs in
+     *  differs from Photoshop.
+     */
+    var verifyOpenDocuments = function () {
+        var applicationStore = this.flux.store("application"),
+            openDocumentIDs = applicationStore.getOpenDocumentIDs();
+
+        return descriptor.getProperty("application", "numberOfDocuments")
+            .bind(this)
+            .then(function (docCount) {
+                var docPromises = _.range(1, docCount + 1)
+                    .map(function (index) {
+                        var indexRef = documentLib.referenceBy.index(index);
+                        return documentActions._getDocumentByRef(indexRef, ["documentID"], []);
+                    });
+
+                return Promise.all(docPromises);
+            })
+            .then(function (documentIDs) {
+                if (openDocumentIDs.size !== documentIDs.length) {
+                    throw new Error("Incorrect open document count: " + openDocumentIDs.size +
+                        " instead of " + documentIDs.length);
+                } else {
+                    openDocumentIDs.forEach(function (openDocumentID, index) {
+                        var documentID = documentIDs[index].documentID;
+                        if (openDocumentID !== documentID) {
+                            throw new Error("Incorrect document ID at index " + index + ": " + openDocumentID +
+                                " instead of " + documentID);
+                        }
+                    });
+                }
+            });
+    };
+    verifyOpenDocuments.action = {
+        reads: [locks.PS_APP, locks.JS_APP],
+        writes: []
+    };
+
+    /**
+     * Verify the correctness of the currently active document ID.
+     *
+     * @return {Promise} Rejects if active document ID differs from Photoshop.
+     */
+    var verifyActiveDocument = function () {
+        var currentRef = documentLib.referenceBy.current,
+            applicationStore = this.flux.store("application"),
+            currentDocumentID = applicationStore.getCurrentDocumentID();
+
+        return documentActions._getDocumentByRef(currentRef, ["documentID"], [])
+            .bind(this)
+            .get("documentID")
+            .then(function (documentID) {
+                if (currentDocumentID !== documentID) {
+                    throw new Error("Incorrect active document: " + currentDocumentID +
+                        " instead of " + documentID);
+                }
+            }, function () {
+                if (typeof currentDocumentID === "number") {
+                    throw new Error("Spurious active document: " + currentDocumentID);
+                }
+            });
+    };
+    verifyActiveDocument.action = {
+        reads: [locks.PS_APP, locks.JS_APP],
+        writes: []
+    };
+
+    exports.verifyActiveDocument = verifyActiveDocument;
+    exports.verifyOpenDocuments = verifyOpenDocuments;
+});

--- a/src/js/actions/verify/layers.js
+++ b/src/js/actions/verify/layers.js
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var Promise = require("bluebird"),
+        Immutable = require("immutable");
+        
+    var descriptor = require("adapter").ps.descriptor,
+        documentLib = require("adapter").lib.document,
+        layerLib = require("adapter").lib.layer;
+
+    var locks = require("js/locks"),
+        documentActions = require("../documents"),
+        layerActions = require("../layers");
+
+    /**
+     * Verify the correctness of the list of layer IDs.
+     *
+     * @return {Promise} Rejects if the number or order of layer IDs in the
+     *  active document differs from Photoshop.
+     */
+    var verifyLayerIndex = function () {
+        var applicationStore = this.flux.store("application"),
+            currentDocument = applicationStore.getCurrentDocument();
+
+        if (!currentDocument) {
+            return Promise.resolve();
+        }
+
+        return layerActions.getLayerIDsForDocumentID(currentDocument.id)
+            .bind(this)
+            .then(function (payload) {
+                var layerIDs = payload.layerIDs;
+
+                if (currentDocument.layers.all.size !== layerIDs.length) {
+                    throw new Error("Incorrect layer count: " + currentDocument.layers.all.size +
+                        " instead of " + layerIDs.length);
+                } else {
+                    layerIDs.reverse();
+                    currentDocument.layers.index.forEach(function (layerID, index) {
+                        if (layerID !== layerIDs[index]) {
+                            throw new Error("Incorrect layer ID at index " + index + ": " + layerID +
+                                " instead of " + layerIDs[index]);
+                        }
+                    });
+                }
+            });
+    };
+    verifyLayerIndex.action = {
+        reads: [locks.JS_APP, locks.JS_DOC, locks.PS_DOC],
+        writes: []
+    };
+
+    /**
+     * Verify the correctness of the layer selection.
+     *
+     * @return {Promise} Rejects if set of selected layer IDs differs from
+     *  Photoshop.
+     */
+    var verifyLayerSelection = function () {
+        var applicationStore = this.flux.store("application"),
+            currentDocument = applicationStore.getCurrentDocument();
+
+        if (!currentDocument) {
+            return Promise.resolve();
+        }
+        
+        var documentRef = documentLib.referenceBy.current;
+        return documentActions._getDocumentByRef(documentRef, ["targetLayers"], [])
+            .bind(this)
+            .then(function (payload) {
+                var targetLayers = payload.targetLayers.map(function (targetLayer) {
+                    return targetLayer._index;
+                });
+
+                if (currentDocument.layers.selected.size !== targetLayers.length) {
+                    throw new Error("Incorrect selected layer count: " + currentDocument.layers.selected.size +
+                        " instead of " + targetLayers.length);
+                } else {
+                    targetLayers.forEach(function (targetLayerIndex) {
+                        var layer = currentDocument.layers.byIndex(targetLayerIndex + 1);
+                        if (!layer.selected) {
+                            throw new Error("Missing layer selection at index " + targetLayerIndex);
+                        }
+                    });
+                }
+            }, function () {
+                if (currentDocument.layers.selected.size > 0) {
+                    throw new Error("Incorrect selected layer count: " + currentDocument.layers.selected.size +
+                        " instead of " + 0);
+                }
+            });
+    };
+    verifyLayerSelection.action = {
+        reads: [locks.JS_APP, locks.JS_DOC, locks.PS_DOC],
+        writes: []
+    };
+
+    /**
+     * Verify the bounds of the selected layers and their descendants.
+     *
+     * @return {Promise}
+     */
+    var verifySelectedBounds = function () {
+        var applicationStore = this.flux.store("application"),
+            currentDocument = applicationStore.getCurrentDocument();
+
+        if (!currentDocument) {
+            return Promise.resolve();
+        }
+        
+        var docRef = documentLib.referenceBy.current,
+            layers = currentDocument.layers.allSelected.toList(),
+            propertyRefs = layers
+                .map(function (layer) {
+                    var property = layerActions._boundsPropertyForLayer(layer);
+
+                    return [
+                        docRef,
+                        layerLib.referenceBy.id(layer.id),
+                        {
+                            _ref: "property",
+                            _property: property
+                        }
+                    ];
+                })
+                .toArray();
+
+        return descriptor.batchGet(propertyRefs)
+            .bind(this)
+            .then(function (results) {
+                if (results.length !== propertyRefs.length) {
+                    throw new Error("Incorrect bounds count: " + propertyRefs.length + " instead of " + results.length);
+                }
+
+                results = results.map(function (descriptor, index) {
+                    var layer = layers.get(index);
+
+                    return {
+                        layerID: layer.id,
+                        descriptor: descriptor
+                    };
+                });
+
+                var currentDocument = applicationStore.getCurrentDocument(),
+                    currentLayers = currentDocument.layers,
+                    nextLayers = currentLayers.resetBounds(results);
+
+                if (!Immutable.is(currentLayers, nextLayers)) {
+                    throw new Error("Bounds mismatch");
+                }
+            });
+    };
+    verifySelectedBounds.action = {
+        reads: [locks.JS_APP, locks.JS_DOC, locks.PS_DOC],
+        writes: []
+    };
+
+    exports.verifyLayerIndex = verifyLayerIndex;
+    exports.verifyLayerSelection = verifyLayerSelection;
+    exports.verifySelectedBounds = verifySelectedBounds;
+});

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -775,6 +775,10 @@ define(function (require, exports, module) {
                     log.debug("Verifying " + postTitle + " for " + actionTitle);
 
                     var postPromises = post.map(function (conjunct, index) {
+                        if (typeof conjunct === "string") {
+                            conjunct = this._actionsByName.get(conjunct);
+                        }
+
                         return conjunct.apply(this)
                             .catch(function (err) {
                                 var errMessage = err && err.message || "no error message";


### PR DESCRIPTION
This PR converts the verification postconditions to quasi-actions and allows them to be specified symbolically with pathnames instead of just via direct references. This also moves all of the verification actions into new modules underneath `actions/verify` in an attempt to tidy up `actions.documents` and `actions.layers`.

Above I referred to these as quasi-actions because the controller doesn't quite treat them the same way when executing them as action post-conditions. In particular, their locks are ignored and they're always executed in parallel under the reasonable assumption that they are side-effect free. At some point, as @mcilroyc and I have discussed, it would be nice to have both `pre` and `post` action lists which are treated a little more like action transfers, for consistency and uniformity. This is one step in that direction, but more remain.

Addresses #3443.