### PR TITLE
Experiment: direct radius updates

### DIFF
--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -148,9 +148,10 @@ define(function (require, exports, module) {
          *
          * @param {Document} nextDocument
          * @param {boolean=} dirty Whether to set the dirty bit, assuming the model has changed
-         * @param {boolean=} suppressChange
+         * @param {boolean=} suppressChange Whether or not to suppress the change event
+         * @param {string=} changeEventName The event to emit. Default: "change".
          */
-        setDocument: function (nextDocument, dirty, suppressChange) {
+        setDocument: function (nextDocument, dirty, suppressChange, changeEventName) {
             var oldDocument = this._openDocuments[nextDocument.id];
             if (Immutable.is(oldDocument, nextDocument)) {
                 return;
@@ -174,7 +175,8 @@ define(function (require, exports, module) {
                 });
 
             if (initialized) {
-                this.emit("change");
+                // Include the document in the event payload
+                this.emit(changeEventName || "change", nextDocument);
             }
         },
 
@@ -705,7 +707,9 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Set the radii for the given layers in the given document.
+         * Set the radii for the given layers in the given document. NOTE: This
+         * only emits a "radiiChange" event instead of a general-purpose "change"
+         * event.
          *
          * @private
          * @param {{documentID: number, layerIDs: Array.<number>, radii: object}} payload
@@ -718,7 +722,7 @@ define(function (require, exports, module) {
                 nextLayers = document.layers.setBorderRadii(layerIDs, radii),
                 nextDocument = document.set("layers", nextLayers);
 
-            this.setDocument(nextDocument, true);
+            this.setDocument(nextDocument, true, false, "radiiChange");
         },
 
         /**


### PR DESCRIPTION
This is an experimental change with the goal of speeding up the `Radius` component. With this change, the `DocumentStore` will no longer emit "change" events that result from `RADII_CHANGED` dispatches. Instead, a new, single-purpose "radiusChanged" event is emitted, and only the `Radius` component listens for these events. Consequently, `RADII_CHANGED` dispatches can be handled in ~5ms instead of ~40ms on master. The savings comes from not having to virtually re-render much higher level components without any effect on the DOM. This only works because no other components care about the details of border radii; future React components that care about radii changes would have to listen to this event in addition to "change" events. So, the cost is some extra complexity. Is this additional complexity worthwhile? I don't know; that's why I called this an experiment!

Also note that, incidentally, this _particular_ changes doesn't result in a radius slider that is significantly more responsive despite looking significantly better in the Chromium timeline. I believe this is because we're hitting the same Photoshop/Spaces architectural limitation as in the color picker: mouse events are not delivered while Photoshop is busy playing commands. In particular, commands that set change border radii.

Here's a rough idea of how the timeline changes.
Before:
![image](https://cloud.githubusercontent.com/assets/1075154/11968445/31ccf704-a8c1-11e5-8db4-6e63a1817a7a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1075154/11968446/368d67e2-a8c1-11e5-8a47-60e37677a348.png)

The profiles above are at roughly the same zoom level. Each of the two big spikes in the "before" run is from a document "change" handler, and the smaller, secondary spikes are from the menu and overlays. In the "after" run, the two "radiiChange" handlers are of the same magnitude as the secondary spikes and so they're hard to distinguish at a glance. You can also see roughly from the summaries in each run that there isn't too much practical difference in terms of redraw frequency: ~4fps :person_frowning: 

I'm hopeful that we can use a trick like this to reduce the time to redraw the layers panel on `SELECT_LAYERS_BY_ID` dispatches. That should not be similarly plagued with event routing issues. @shaoshing is working on this now.

Partially addresses #3451, but not completely due at least to the aforementioned well known Photoshop architectural issues.