### PR TITLE
Statically eliminate debug code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,6 +204,9 @@ module.exports = function (grunt) {
                 options: {
                     compress: {
                         unused: false // This saves us about half an hour, losing 200 KB
+                    },
+                    define: {
+                        __PG_DEBUG__: false
                     }
                 },
                 files: ALL_LOCALES.reduce(function (map, locale) {

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -36,7 +36,6 @@ define(function (require, exports) {
         locks = require("js/locks"),
         system = require("js/util/system"),
         log = require("js/util/log"),
-        global = require("js/util/global"),
         headlights = require("js/util/headlights"),
         policyActions = require("./policy"),
         preferencesActions = require("./preferences");
@@ -99,7 +98,7 @@ define(function (require, exports) {
                 return ps.performMenuCommand(payload);
             })
             .then(function (success) {
-                if (global.debug && !success) {
+                if (__PG_DEBUG__ && !success) {
                     log.error("Menu command not available: " + payload.commandID);
                 }
                 
@@ -166,7 +165,7 @@ define(function (require, exports) {
      * window.
      */
     var runTests = function () {
-        if (global.debug) {
+        if (__PG_DEBUG__) {
             var href = window.location.href,
                 baseHref = href.substring(0, href.lastIndexOf("src/index.html")),
                 testHref = baseHref + "test/index.html";
@@ -339,7 +338,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var togglePolicyFrames = function () {
-        if (!global.debug) {
+        if (!__PG_DEBUG__) {
             return Promise.resolve();
         }
 
@@ -361,7 +360,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var togglePostconditions = function () {
-        if (!global.debug) {
+        if (!__PG_DEBUG__) {
             return Promise.resolve();
         }
 
@@ -404,7 +403,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var toggleActionTransferLogging = function () {
-        if (!global.debug) {
+        if (!__PG_DEBUG__) {
             return Promise.resolve();
         }
 

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -39,8 +39,7 @@ define(function (require, exports, module) {
         AsyncDependencyQueue = require("./util/async-dependency-queue"),
         synchronization = require("./util/synchronization"),
         performance = require("./util/performance"),
-        log = require("./util/log"),
-        global = require("./util/global");
+        log = require("./util/log");
 
     /**
      * The number of logical CPU cores, used to determine the maximum number of
@@ -469,7 +468,7 @@ define(function (require, exports, module) {
                         nextReceiver = self._actionReceivers.get(nextAction),
                         reads = self._transitiveReads.get(nextAction),
                         writes = self._transitiveWrites.get(nextAction),
-                        logTransfers = global.debug &&
+                        logTransfers = __PG_DEBUG__ &&
                             this.flux.store("preferences").getState().get("logActionTransfers"),
                         enqueued;
 
@@ -768,7 +767,7 @@ define(function (require, exports, module) {
                     this._unlockUI();
                 }
 
-                if (global.debug && post && post.length > 0 &&
+                if (__PG_DEBUG__ && post && post.length > 0 &&
                     flux.store("preferences").get("postConditionsEnabled")) {
                     var postStart = Date.now(),
                         postTitle = post.length + " postcondition" + (post.length > 1 ? "s" : "");
@@ -840,7 +839,7 @@ define(function (require, exports, module) {
                         log.debug("Finished action %s in %dms with RTT %dms; %d/%d",
                             actionName, elapsed, total, actionQueue.active(), actionQueue.pending());
 
-                        if (global.debug) {
+                        if (__PG_DEBUG__) {
                             performance.recordAction(namespace, name, enqueued, start, finished);
                         }
                     })

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -34,8 +34,7 @@ define(function (require, exports) {
         FluxController = require("./fluxcontroller"),
         log = require("js/util/log"),
         performanceUtil = require("js/util/performance"),
-        nls = require("js/util/nls"),
-        global = require("js/util/global");
+        nls = require("js/util/nls");
 
     /**
      * The application controller. Holds the internal Fluxxor.Flux instance.
@@ -58,7 +57,7 @@ define(function (require, exports) {
 
         log.error("Unrecoverable error:", message);
 
-        if (global.debug) {
+        if (__PG_DEBUG__) {
             shutdown();
         } else {
             var dialogMessage = nls.localize("strings.ERR.UNRECOVERABLE");
@@ -99,7 +98,7 @@ define(function (require, exports) {
                 " is incompatible with the required version, " +
                  _formatVersion(adapter.compatiblePluginVersion);
 
-            if (global.debug) {
+            if (__PG_DEBUG__) {
                 log.error(message);
             } else {
                 throw new Error(message);
@@ -167,7 +166,7 @@ define(function (require, exports) {
         cancellation: true
     });
 
-    if (global.debug) {
+    if (__PG_DEBUG__) {
         Promise.longStackTraces();
         Promise.onPossiblyUnhandledRejection(function (err) {
             throw err;

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -30,7 +30,6 @@ define(function (require, exports, module) {
     var MenuItem = require("./menuitem"),
         MenuShortcut = require("./menushortcut"),
         keyutil = require("js/util/key"),
-        global = require("js/util/global"),
         pathUtil = require("js/util/path"),
         system = require("js/util/system"),
         object = require("js/util/object");
@@ -504,7 +503,7 @@ define(function (require, exports, module) {
             "TOGGLE_SINGLE_COLUMN_MODE": { "checked": preferences.get("singleColumnModeEnabled", false) }
         });
 
-        if (global.debug) {
+        if (__PG_DEBUG__) {
             return updatedMenu.updateSubmenuItems("HELP", {
                 "TOGGLE_POLICY_FRAMES": { "checked": preferences.get("policyFramesEnabled", false) },
                 "TOGGLE_POSTCONDITIONS": { "checked": preferences.get("postConditionsEnabled", false) },

--- a/src/js/models/menuitem.js
+++ b/src/js/models/menuitem.js
@@ -33,8 +33,7 @@ define(function (require, exports, module) {
     var MenuShortcut = require("./menushortcut"),
         object = require("js/util/object"),
         nls = require("js/util/nls"),
-        keyutil = require("js/util/key"),
-        global = require("js/util/global");
+        keyutil = require("js/util/key");
 
     /**
      * A model of a menu item
@@ -210,7 +209,7 @@ define(function (require, exports, module) {
             var rawSubMenu = rawMenu.submenu;
 
             // Filter out debug-only menu entries in non-debug mode
-            if (!global.debug) {
+            if (!__PG_DEBUG__) {
                 rawSubMenu = rawSubMenu.filter(function (subMenu) {
                     return !subMenu.debug;
                 });

--- a/src/js/util/global.js
+++ b/src/js/util/global.js
@@ -25,15 +25,6 @@ define(function (require, exports) {
     "use strict";
 
     /**
-     * Indicates whether the application is running in debug mode.
-     * __PG_DEBUG__ is defined through webpack
-     * 
-     * @const
-     * @type {boolean} 
-     */
-    var DEBUG = !!__PG_DEBUG__;
-
-    /**
      * Namespace used for photoshop extension data
      * 
      * @const
@@ -41,6 +32,5 @@ define(function (require, exports) {
      */
     var EXTENSION_DATA_NAMESPACE = "designSpace";
 
-    exports.debug = DEBUG;
     exports.EXTENSION_DATA_NAMESPACE = EXTENSION_DATA_NAMESPACE;
 });

--- a/src/js/util/headlights.js
+++ b/src/js/util/headlights.js
@@ -24,9 +24,9 @@
 define(function (require, exports) {
     "use strict";
 
-    var Promise = require("bluebird"),
-        adapterPS = require("adapter").ps,
-        global = require("./global");
+    var Promise = require("bluebird");
+
+    var adapterPS = require("adapter").ps;
 
     /**
      * Logs an event entry in Headlights for Photoshop
@@ -43,7 +43,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var logEvent = function (category, subcategory, event) {
-        if (global.debug) {
+        if (__PG_DEBUG__) {
             return Promise.resolve();
         } else {
             return adapterPS.logHeadlightsEvent(category, subcategory, String(event));

--- a/src/js/util/log.js
+++ b/src/js/util/log.js
@@ -27,9 +27,7 @@ define(function (require, exports, module) {
 
     var loglevel = require("loglevel");
 
-    var global = require("./global");
-
-    if (global.debug) {
+    if (__PG_DEBUG__) {
         // If the debug global is set, log messages at and below debug level
         loglevel.enableAll();
     } else {


### PR DESCRIPTION
This PR replaces `global.debug` and its references with the `__PG_DEBUG__` global variable, and instructs uglify to define it as `false`. This makes it easier (read: possible) for uglify to statically elide dead debugging code blocks. This eliminates redundant runtime checks and, for fun, also reduces the size of the compiled bundles by ~2k. This only affects the non-debug compiled builds.