### PR TITLE
LayersPanel: hierarchical structure (part 1)

### DIFF
--- a/src/js/jsx/sections/layers/DummyLayerFace.jsx
+++ b/src/js/jsx/sections/layers/DummyLayerFace.jsx
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
                     onDrop={this._handleDropLayers}
                     onDragTargetEnter={this._handleDragTargetEnter}
                     onDragTargetLeave={this._handleDragTargetLeave}>
-                    <li className={dummyClassNames}/>
+                    <div className={dummyClassNames}/>
                 </Droppable>
             );
         }

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -57,6 +57,15 @@ define(function (require, exports, module) {
          */
         _isDragEventTarget: false,
 
+        /**
+         * Used to suppress scrolling into view when the selection is changed
+         * by clicking directly on a layer face.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _suppressNextScrollTo: false,
+
         getInitialState: function () {
             return {
                 isDropTarget: false,
@@ -65,7 +74,7 @@ define(function (require, exports, module) {
                 dragStyle: null
             };
         },
-        
+
         shouldComponentUpdate: function (nextProps, nextState) {
             // Drag states
             if (this.state.isDragging !== nextState.isDragging ||
@@ -84,35 +93,33 @@ define(function (require, exports, module) {
                 return true;
             }
 
-            var document = this.props.document,
-                nextDocument = nextProps.document;
-
-            // Depth changes
-            var currentDepth = document.layers.depth(this.props.layer),
-                nextDepth = nextDocument.layers.depth(nextProps.layer);
-
-            if (currentDepth !== nextDepth) {
-                return true;
+            return false;
+        },
+        
+        componentDidMount: function () {
+            // Scroll into view if the current layer is the first selected layers.
+            if (this.props.document.layers.selected.last() === this.props.layer) {
+                this._scrollIntoView(false);
+            }
+        },
+        
+        componentDidUpdate: function (prevProps) {
+            if (this._suppressNextScrollTo) {
+                this._suppressNextScrollTo = false;
+                return;
             }
 
-            // Deeper selection changes
-            var childOfSelection = document.layers.hasSelectedAncestor(this.props.layer);
-            if (childOfSelection || nextDocument.layers.hasSelectedAncestor(nextProps.layer)) {
-                if (!Immutable.is(document.layers.allSelected, nextDocument.layers.allSelected)) {
-                    return true;
+            this._scrollIntoView(prevProps.layer.selected);
+        },
+        
+        _scrollIntoView: function (prevSelected) {
+            if (this.props.layer.selected && !prevSelected) {
+                var node = ReactDOM.findDOMNode(this);
+
+                if (node) {
+                    node.scrollIntoViewIfNeeded();
                 }
             }
-
-            // Given that the face hasn't changed and no selected ancestor has changed, this
-            // component only needs to re-render when going from having a collapsed ancestor
-            // (i.e., being hidden) to not having one (i.e., becoming newly visible).
-            var hadCollapsedAncestor = document.layers.hasCollapsedAncestor(this.props.layer),
-                willHaveCollapsedAncestor = nextDocument.layers.hasCollapsedAncestor(nextProps.layer),
-                hadInvisibleAncestor = document.layers.hasInvisibleAncestor(this.props.layer),
-                willHaveInvisibleAncestor = nextDocument.layers.hasInvisibleAncestor(nextProps.layer);
-
-            return hadCollapsedAncestor !== willHaveCollapsedAncestor ||
-                   hadInvisibleAncestor !== willHaveInvisibleAncestor;
         },
 
         /**
@@ -179,6 +186,7 @@ define(function (require, exports, module) {
          */
         _handleLayerClick: function (event) {
             event.stopPropagation();
+            this._suppressNextScrollTo = true;
 
             var modifier = "select";
             if (event.shiftKey) {
@@ -229,13 +237,14 @@ define(function (require, exports, module) {
          * @param {SyntheticEvent} event
          */
         _handleLayerEdit: function (event) {
+            event.stopPropagation();
+
             var layer = this.props.layer;
             if (layer.locked || !layer.visible) {
                 return;
             }
 
             this.getFlux().actions.superselect.editLayer(this.props.document, this.props.layer);
-            event.stopPropagation();
         },
 
         /**
@@ -246,9 +255,10 @@ define(function (require, exports, module) {
          * @param {boolean} toggled Flag for the ToggleButton, true means locked
          */
         _handleLockToggle: function (event, toggled) {
+            event.stopPropagation();
+
             // Locked if toggled, visible if not
             this.getFlux().actions.layers.setLocking(this.props.document, this.props.layer, toggled);
-            event.stopPropagation();
         },
         
         /**
@@ -278,7 +288,7 @@ define(function (require, exports, module) {
 
             // Do not allow reordering to exceed the nesting limit.
             var doc = this.props.document,
-                targetDepth = doc.layers.depth(target);
+                targetDepth = this.props.depth;
 
             // Target depth is incremented if we're dropping INTO a group
             switch (dropPosition) {
@@ -293,7 +303,7 @@ define(function (require, exports, module) {
             default:
                 break;
             }
-
+            
             // When dragging artboards, the nesting limit is 0 because artboard
             // nesting is forbidden.
             var draggingArtboard = draggedLayers.some(function (layer) {
@@ -348,7 +358,7 @@ define(function (require, exports, module) {
          */
         _getDropPosition: function (dragPosition) {
             var layer = this.props.layer,
-                bounds = ReactDOM.findDOMNode(this).getBoundingClientRect(),
+                bounds = ReactDOM.findDOMNode(this.refs.face).getBoundingClientRect(),
                 dropPosition;
 
             if (layer.isGroup) {
@@ -411,10 +421,12 @@ define(function (require, exports, module) {
                 this._isDragEventTarget = false;
             }
             
-            this.setState({
-                isDragging: false,
-                dragStyle: null
-            });
+            if (this.isMounted()) {
+                this.setState({
+                    isDragging: false,
+                    dragStyle: null
+                });
+            }
         },
         
         /**
@@ -490,7 +502,7 @@ define(function (require, exports, module) {
                 dropPosition = isDropTarget ? this._getDropPosition(dragPosition) : null,
                 canDropLayer = isDropTarget && this._validCompatibleDropTarget(
                     this.props.layer, draggedLayers, dropPosition);
-            
+
             this.setState({
                 isDropTarget: canDropLayer,
                 dropPosition: dropPosition
@@ -513,74 +525,36 @@ define(function (require, exports, module) {
         render: function () {
             var doc = this.props.document,
                 layer = this.props.layer,
-                layerStructure = doc.layers,
                 layerIndex = doc.layers.indexOf(layer),
                 nameEditable = !layer.isBackground,
-                isSelected = layer.selected,
-                isChildOfSelected = !layer.selected &&
-                    layerStructure.parent(layer) &&
-                    layerStructure.parent(layer).selected,
-                isStrictDescendantOfSelected = !isChildOfSelected && layerStructure.hasStrictSelectedAncestor(layer),
                 isDragging = this.state.isDragging,
                 isDropTarget = this.state.isDropTarget,
                 dropPosition = this.state.dropPosition,
-                isGroupStart = layer.isGroup || layer.isArtboard;
-
-            var depth = layerStructure.depth(layer),
-                endOfGroupStructure = false,
-                isLastInGroup = false,
-                dragStyle;
-
-            if (isDragging && this.state.dragStyle) {
-                dragStyle = this.state.dragStyle;
-            } else {
-                // We can skip some rendering calculations if dragging
-                isLastInGroup = layerIndex > 0 &&
-                    isChildOfSelected &&
-                    layerStructure.byIndex(layerIndex - 1).isGroupEnd;
-                
-                // Check to see if this layer is the last in a bunch of nested groups
-                if (isStrictDescendantOfSelected &&
-                    layerStructure.byIndex(layerIndex - 1).isGroupEnd) {
-                    var nextVisibleLayer = doc.layers.allVisibleReversed.get(this.props.visibleLayerIndex + 1);
-                    if (nextVisibleLayer && !doc.layers.hasStrictSelectedAncestor(nextVisibleLayer)) {
-                        endOfGroupStructure = true;
-                    }
-                }
-
-                dragStyle = {};
-            }
+                hasChildren = this.props.childNodes,
+                selected = layer.selected,
+                visible = layer.visible;
             
-            var layerClasses = {
+            var layerClasses = classnames({
                 "layer": true,
-                "layer__group_start": isGroupStart,
-                "layer__select": isSelected,
-                "layer__select_child": isChildOfSelected,
-                "layer__select_descendant": isStrictDescendantOfSelected,
-                "layer__group_end": isLastInGroup,
-                "layer__nested_group_end": endOfGroupStructure,
-                "layer__group_collapsed": layer.isGroup && !layer.expanded,
-                "layer__ancestor_collapsed": doc.layers.hasCollapsedAncestor(layer)
-            };
+                "layer__selected": selected,
+                "layer-group": hasChildren,
+                "layer-group__selected": hasChildren && selected,
+                "layer-group__collapsed": hasChildren && !layer.expanded,
+                "layer-group__not-visible": hasChildren && !visible,
+                "layer-group__drag-target": hasChildren && isDragging
+            });
 
             // Set all the classes need to style this LayerFace
-            var faceClasses = {
+            var faceClasses = classnames({
                 "face": true,
-                "face__select_immediate": isSelected,
-                "face__select_child": isChildOfSelected,
-                "face__select_descendant": isStrictDescendantOfSelected,
-                "face__drag_target": isDragging && this.state.dragStyle,
+                "face__selected": selected,
+                "face__not-visible": !visible,
+                "face__drag-target": isDragging,
                 "face__drop_target": isDropTarget,
                 "face__drop_target_above": isDropTarget && dropPosition === "above",
                 "face__drop_target_below": isDropTarget && dropPosition === "below",
-                "face__drop_target_on": isDropTarget && dropPosition === "on",
-                "face__group_start": isGroupStart,
-                "face__group_lastchild": isLastInGroup,
-                "face__group_lastchildgroup": endOfGroupStructure,
-                "face__not-visible": !layer.visible || layerStructure.hasInvisibleAncestor(layer)
-            };
-
-            faceClasses["face__depth-" + depth] = true;
+                "face__drop_target_on": isDropTarget && dropPosition === "on"
+            }, "face__depth-" + this.props.depth);
 
             // Super Hack: If two tooltip regions are flush and have the same title,
             // the plugin does not invalidate the tooltip when moving the mouse from
@@ -597,8 +571,8 @@ define(function (require, exports, module) {
                         title={nls.localize("strings.TOOLTIPS.SET_LAYER_VISIBILITY") + tooltipPadding}
                         className="face__button_visibility"
                         size="column-2"
-                        buttonType={ layer.visible ? "layer-visible" : "layer-not-visible" }
-                        selected={!layer.visible}
+                        buttonType={ visible ? "layer-visible" : "layer-not-visible" }
+                        selected={!visible}
                         onClick={this._handleVisibilityToggle}>
                     </ToggleButton>
                 ),
@@ -634,10 +608,11 @@ define(function (require, exports, module) {
                         onDrop={this._handleDrop}
                         onDragTargetMove={this._handleDragTargetMove}
                         onDragTargetLeave={this._handleDragTargetLeave}>
-                        <li className={classnames(layerClasses)}>
+                        <div className={layerClasses}>
                             <div
-                                style={dragStyle}
-                                className={classnames(faceClasses)}
+                                ref="face"
+                                style={this.state.dragStyle}
+                                className={faceClasses}
                                 data-layer-id={layer.id}
                                 data-kind={layer.kind.toLowerCase()}
                                 onClick={!this.props.disabled && this._handleLayerClick}>
@@ -676,7 +651,7 @@ define(function (require, exports, module) {
                                     onClick={this._handleLockToggle}>
                                 </ToggleButton>
                             </div>
-                        </li>
+                        </div>
                     </Droppable>
                 </Draggable>
             );

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -530,18 +530,12 @@ define(function (require, exports, module) {
                 isDragging = this.state.isDragging,
                 isDropTarget = this.state.isDropTarget,
                 dropPosition = this.state.dropPosition,
-                hasChildren = this.props.childNodes,
                 selected = layer.selected,
                 visible = layer.visible;
             
             var layerClasses = classnames({
                 "layer": true,
-                "layer__selected": selected,
-                "layer-group": hasChildren,
-                "layer-group__selected": hasChildren && selected,
-                "layer-group__collapsed": hasChildren && !layer.expanded,
-                "layer-group__not-visible": hasChildren && !visible,
-                "layer-group__drag-target": hasChildren && isDragging
+                "layer__drag-target": isDragging
             });
 
             // Set all the classes need to style this LayerFace

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -288,7 +288,7 @@ define(function (require, exports, module) {
 
             // Do not allow reordering to exceed the nesting limit.
             var doc = this.props.document,
-                targetDepth = this.props.depth;
+                targetDepth = doc.layers.depth(this.props.layer);
 
             // Target depth is incremented if we're dropping INTO a group
             switch (dropPosition) {
@@ -420,13 +420,11 @@ define(function (require, exports, module) {
                 this.getFlux().actions.panel.enableTooltips();
                 this._isDragEventTarget = false;
             }
-            
-            if (this.isMounted()) {
-                this.setState({
-                    isDragging: false,
-                    dragStyle: null
-                });
-            }
+
+            this.setState({
+                isDragging: false,
+                dragStyle: null
+            });
         },
         
         /**
@@ -526,6 +524,7 @@ define(function (require, exports, module) {
             var doc = this.props.document,
                 layer = this.props.layer,
                 layerIndex = doc.layers.indexOf(layer),
+                layerDepth = doc.layers.depth(layer),
                 nameEditable = !layer.isBackground,
                 isDragging = this.state.isDragging,
                 isDropTarget = this.state.isDropTarget,
@@ -548,7 +547,7 @@ define(function (require, exports, module) {
                 "face__drop_target_above": isDropTarget && dropPosition === "above",
                 "face__drop_target_below": isDropTarget && dropPosition === "below",
                 "face__drop_target_on": isDropTarget && dropPosition === "on"
-            }, "face__depth-" + this.props.depth);
+            }, "face__depth-" + layerDepth);
 
             // Super Hack: If two tooltip regions are flush and have the same title,
             // the plugin does not invalidate the tooltip when moving the mouse from

--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -27,14 +27,18 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        Immutable = require("immutable");
+
+    var Layer = require("js/models/layer"),
+        Document = require("js/models/document");
 
     var DummyLayerFace = require("./DummyLayerFace"),
         LayerFace = require("./LayerFace");
 
     var LayerGroup = React.createClass({
         mixins: [FluxMixin],
-        
+
         /**
          * True if the LayerGroup's components are rendered. Used to avoid
          * rendering layer group until it is first visible.
@@ -42,32 +46,32 @@ define(function (require, exports, module) {
          * @type {Boolean}
          */
         isRendered: false,
-        
+
         propTypes: {
             /**
              * List of Layer nodes in the same layer group.
-             * @type {Immutable.List.<LayerNode>}
+             * @type {Immutable.Iterable.<LayerNode>}
              */
-            layerNodes: React.PropTypes.object.isRequired,
+            layerNodes: React.PropTypes.instanceOf(Immutable.Iterable).isRequired,
 
             /**
              * The parent layer of the layer nodes.
              * @type {Layer}
              */
-            parentLayer: React.PropTypes.object,
-            
+            parentLayer: React.PropTypes.instanceOf(Layer),
+
             /**
              * @type {Document}
              */
-            document: React.PropTypes.object.isRequired,
-            
+            document: React.PropTypes.instanceOf(Document).isRequired,
+
             /**
              * @type {Boolean}
              */
             disabled: React.PropTypes.bool
         },
         
-        shouldComponentUpdate: function() {
+        shouldComponentUpdate: function () {
             // TODO Currently we always render the entire LayerGroup tree and let the LayerFace components
             // to run their own shouldComponentUpdate validation. In the future, we may consider 
             // consolidating the validations in one place (e.g. in the LayerPanel or the root LayerGroup),
@@ -119,7 +123,7 @@ define(function (require, exports, module) {
                 }
                 
                 return results;
-            }.bind(this), []);
+            }, [], this);
 
             if (isRoot) {
                 var bottomLayer = this.props.document.layers.byIndex(1);

--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -32,12 +32,19 @@ define(function (require, exports, module) {
     var DummyLayerFace = require("./DummyLayerFace"),
         LayerFace = require("./LayerFace");
 
-    var LayersGroup = React.createClass({
+    var LayerGroup = React.createClass({
         mixins: [FluxMixin],
+        
+        propTypes: {
+            /**
+             * True if the layer group is the root.
+             * @type {Boolean}
+             */
+            isRoot: React.PropTypes.bool
+        },
 
         getDefaultProps: function () {
             return {
-                depth: 0,
                 isRoot: false
             };
         },
@@ -47,19 +54,18 @@ define(function (require, exports, module) {
                 var layer = this.props.document.layers.byID(layerNode.id);
                 
                 if (!layer.isGroupEnd) {
-                    var layersGroup = layerNode.children && (
-                        <LayersGroup
+                    var layerGroup = layerNode.children && (
+                        <LayerGroup
                             disabled={this.props.disabled}
                             document={this.props.document}
-                            layerNodes={layerNode.children}
-                            depth={this.props.depth + 1}/>
+                            layerNodes={layerNode.children}/>
                     );
 
                     var className = classnames({
-                        "layer-group": layersGroup,
-                        "layer-group__selected": layersGroup && layer.selected,
-                        "layer-group__collapsed": layersGroup && !layer.expanded,
-                        "layer-group__not-visible": layersGroup && !layer.visible
+                        "layer-group": layerGroup,
+                        "layer-group__selected": layerGroup && layer.selected,
+                        "layer-group__collapsed": layerGroup && !layer.expanded,
+                        "layer-group__not-visible": layerGroup && !layer.visible
                     });
 
                     results.push(
@@ -68,10 +74,9 @@ define(function (require, exports, module) {
                                 key={layer.key}
                                 disabled={this.props.disabled}
                                 document={this.props.document}
-                                depth={this.props.depth}
                                 layer={layer}
                                 childNodes={layerNode.children}/>
-                            {layersGroup}
+                            {layerGroup}
                         </li>
                     );
                 }
@@ -99,5 +104,5 @@ define(function (require, exports, module) {
         }
     });
 
-    module.exports = LayersGroup;
+    module.exports = LayerGroup;
 });

--- a/src/js/jsx/sections/layers/LayersGroup.jsx
+++ b/src/js/jsx/sections/layers/LayersGroup.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -26,7 +26,8 @@ define(function (require, exports, module) {
 
     var React = require("react"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React);
+        FluxMixin = Fluxxor.FluxMixin(React),
+        classnames = require("classnames");
 
     var DummyLayerFace = require("./DummyLayerFace"),
         LayerFace = require("./LayerFace");
@@ -53,9 +54,16 @@ define(function (require, exports, module) {
                             layerNodes={layerNode.children}
                             depth={this.props.depth + 1}/>
                     );
-                    
+
+                    var className = classnames({
+                        "layer-group": layersGroup,
+                        "layer-group__selected": layersGroup && layer.selected,
+                        "layer-group__collapsed": layersGroup && !layer.expanded,
+                        "layer-group__not-visible": layersGroup && !layer.visible
+                    });
+
                     results.push(
-                        <li key={layer.key}>
+                        <li key={layer.key} className={className}>
                             <LayerFace
                                 key={layer.key}
                                 disabled={this.props.disabled}

--- a/src/js/jsx/sections/layers/LayersGroup.jsx
+++ b/src/js/jsx/sections/layers/LayersGroup.jsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var React = require("react"),
+        Fluxxor = require("fluxxor"),
+        FluxMixin = Fluxxor.FluxMixin(React);
+
+    var DummyLayerFace = require("./DummyLayerFace"),
+        LayerFace = require("./LayerFace");
+
+    var LayersGroup = React.createClass({
+        mixins: [FluxMixin],
+
+        getDefaultProps: function () {
+            return {
+                depth: 0,
+                isRoot: false
+            };
+        },
+
+        render: function () {
+            var layerFaces = this.props.layerNodes.reduce(function (results, layerNode) {
+                var layer = this.props.document.layers.byID(layerNode.id);
+                
+                if (!layer.isGroupEnd) {
+                    var layersGroup = layerNode.children && (
+                        <LayersGroup
+                            disabled={this.props.disabled}
+                            document={this.props.document}
+                            layerNodes={layerNode.children}
+                            depth={this.props.depth + 1}/>
+                    );
+                    
+                    results.push(
+                        <li key={layer.key}>
+                            <LayerFace
+                                key={layer.key}
+                                disabled={this.props.disabled}
+                                document={this.props.document}
+                                depth={this.props.depth}
+                                layer={layer}
+                                childNodes={layerNode.children}/>
+                            {layersGroup}
+                        </li>
+                    );
+                }
+                
+                return results;
+            }.bind(this), []);
+
+            if (this.props.isRoot) {
+                var bottomLayer = this.props.document.layers.byIndex(1);
+                
+                if (bottomLayer.isGroupEnd) {
+                    layerFaces.push(
+                        <li key="dummy">
+                            <DummyLayerFace key="dummy" document={this.props.document}/>
+                        </li>
+                    );
+                }
+            }
+            
+            return (
+                <ul className="layers-group">
+                    {layerFaces}
+                </ul>
+            );
+        }
+    });
+
+    module.exports = LayersGroup;
+});

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
     var os = require("adapter").os;
 
     var TitleHeader = require("js/jsx/shared/TitleHeader"),
-        LayersGroup = require("./LayersGroup"),
+        LayerGroup = require("./LayerGroup"),
         nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         synchronization = require("js/util/synchronization");
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
                         ref="container"
                         className={containerClasses}
                         onClick={this._handleContainerClick}>
-                        <LayersGroup
+                        <LayerGroup
                             isRoot={true}
                             disabled={this.props.disabled}
                             document={doc}

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -25,7 +25,6 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        ReactDOM = require("react-dom"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable"),
@@ -34,8 +33,7 @@ define(function (require, exports, module) {
     var os = require("adapter").os;
 
     var TitleHeader = require("js/jsx/shared/TitleHeader"),
-        LayerFace = require("./LayerFace"),
-        DummyLayerFace = require("./DummyLayerFace"),
+        LayersGroup = require("./LayersGroup"),
         nls = require("js/util/nls"),
         collection = require("js/util/collection"),
         synchronization = require("js/util/synchronization");
@@ -87,59 +85,8 @@ define(function (require, exports, module) {
          */
         _setTooltipThrottled: null,
 
-        /**
-         * Set of layer IDs with faces that have been mounted. Used to avoid
-         * rendering faces until they are first visible. Initialized when the
-         * panel is mounted.
-         *
-         * @private
-         * @type {Set.<number>}
-         */
-        _mountedLayerIDs: null,
-
-        /**
-         * The list of layers last scrolled to. Used by _scrollToSelection
-         * when determining whether to scroll.
-         *
-         * @private
-         * @type {Immutable.List.<Layer>}
-         */
-        _lastScrolledTo: Immutable.List(),
-
-        /**
-         * Used to suppress scrolling into view when the selection is changed
-         * by clicking directly on a layer face.
-         *
-         * @private
-         * @type {boolean}
-         */
-        _suppressNextScrollTo: false,
-
         componentWillMount: function () {
             this._setTooltipThrottled = synchronization.throttle(os.setTooltip, os, 500);
-            this._mountedLayerIDs = new Set();
-        },
-
-        /**
-         * A capture-phase click handler for the container. Used to suppress
-         * scrolling into view when clicking on the layers panel directly.
-         *
-         * @private
-         * @param {SyntheticEvent} event
-         */
-        _handleContainerClickCapture: function (event) {
-            var containerNode = ReactDOM.findDOMNode(this.refs.container);
-            if (event.target !== containerNode) {
-                this._suppressNextScrollTo = true;
-            }
-        },
-
-        componentDidMount: function () {
-            this._scrollToSelection(this.props.document.layers);
-        },
-
-        componentDidUpdate: function () {
-            this._scrollToSelection(this.props.document.layers);
         },
 
         shouldComponentUpdate: function (nextProps) {
@@ -155,44 +102,6 @@ define(function (require, exports, module) {
             return this.props.active !== nextProps.active ||
                 !Immutable.is(_getFaces(this.props), _getFaces(nextProps)) ||
                 !Immutable.is(_getDepths(this.props), _getDepths(nextProps));
-        },
-
-        /**
-         * Scrolls the layers panel to make (newly) selected layers visible.
-         *
-         * @param {LayerStructure} layerStructure
-         */
-        _scrollToSelection: function (layerStructure) {
-            // This is set when a face is clicked on initially. Suppressing the call
-            // to scrollIntoViewIfNeeded below prevents a forced synchronous layout.
-            if (this._suppressNextScrollTo) {
-                this._suppressNextScrollTo = false;
-                this._lastScrolledTo = Immutable.List();
-                return;
-            }
-
-            var selected = layerStructure.selected;
-            if (selected.isEmpty()) {
-                return;
-            }
-
-            var previous = this._lastScrolledTo,
-                next = collection.difference(selected, previous),
-                visible = next.filterNot(function (layer) {
-                    return layerStructure.hasCollapsedAncestor(layer);
-                });
-
-            if (visible.isEmpty()) {
-                return;
-            }
-
-            var focusLayer = visible.first(),
-                childNode = ReactDOM.findDOMNode(this.refs[focusLayer.key]);
-
-            if (childNode) {
-                childNode.scrollIntoViewIfNeeded();
-                this._lastScrolledTo = next;
-            }
         },
 
         /**
@@ -215,61 +124,17 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var doc = this.props.document;
-
-            var layerComponents = doc.layers.allVisibleReversed
-                    .filter(function (layer) {
-                        // Do not render descendants of collapsed layers unless
-                        // they have been mounted previously
-                        if (this._mountedLayerIDs.has(layer.id)) {
-                            return true;
-                        } else if (doc.layers.hasCollapsedAncestor(layer)) {
-                            return false;
-                        } else {
-                            this._mountedLayerIDs.add(layer.id);
-                            return true;
-                        }
-                    }, this)
-                    .map(function (layer, visibleIndex) {
-                        return (
-                            <LayerFace
-                                ref={layer.key}
-                                key={layer.key}
-                                disabled={this.props.disabled}
-                                document={doc}
-                                layer={layer}
-                                visibleLayerIndex={visibleIndex}/>
-                        );
-                    }, this);
-
-            var bottomLayer = doc.layers.byIndex(1);
-            if (bottomLayer.isGroupEnd) {
-                layerComponents = layerComponents.push(
-                    <DummyLayerFace key="dummy" document={doc}/>
-                );
-            }
-
-            var layerListClasses = classnames({
-                "layer-list": true
-            });
-
-            var childComponents = (
-                <ul ref="parent" className={layerListClasses}>
-                    {layerComponents}
-                </ul>
-            );
-
-            var containerClasses = classnames({
-                "section-container": true,
-                "section-container__collapsed": !this.props.visible
-            });
-
-            var sectionClasses = classnames({
-                "layers": true,
-                "section": true,
-                "section__active": this.props.active,
-                "section__collapsed": !this.props.visible
-            });
+            var doc = this.props.document,
+                containerClasses = classnames({
+                    "section-container": true,
+                    "section-container__collapsed": !this.props.visible
+                }),
+                sectionClasses = classnames({
+                    "layers": true,
+                    "section": true,
+                    "section__active": this.props.active,
+                    "section__collapsed": !this.props.visible
+                });
 
             return (
                 <section
@@ -284,9 +149,12 @@ define(function (require, exports, module) {
                     <div
                         ref="container"
                         className={containerClasses}
-                        onClick={this._handleContainerClick}
-                        onClickCapture={this._handleContainerClickCapture}>
-                        {childComponents}
+                        onClick={this._handleContainerClick}>
+                        <LayersGroup
+                            isRoot={true}
+                            disabled={this.props.disabled}
+                            document={doc}
+                            layerNodes={doc.layers.roots}/>
                     </div>
                 </section>
             );

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -151,10 +151,9 @@ define(function (require, exports, module) {
                         className={containerClasses}
                         onClick={this._handleContainerClick}>
                         <LayerGroup
-                            isRoot={true}
-                            disabled={this.props.disabled}
+                            layerNodes={doc.layers.roots}
                             document={doc}
-                            layerNodes={doc.layers.roots}/>
+                            disabled={this.props.disabled}/>
                     </div>
                 </section>
             );

--- a/src/js/jsx/shared/Draggable.jsx
+++ b/src/js/jsx/shared/Draggable.jsx
@@ -154,6 +154,10 @@ define(function (require, exports, module) {
             window.removeEventListener("mouseup", this._handleMouseUp, true);
             
             this.getFlux().store("draganddrop").removeListener("start-drag", this._handleDNDStoreDrag);
+            
+            if (this._isDragging) {
+                this.getFlux().store("draganddrop").removeListener("change", this._handleDNDStoreChange);
+            }
         },
         
         /**

--- a/src/js/models/layer.js
+++ b/src/js/models/layer.js
@@ -384,6 +384,7 @@ define(function (require, exports, module) {
                 smartObject: this.smartObject
             });
         },
+
         /**
          * This layer is safe to be super-selected
          * @type {boolean}

--- a/src/js/stores/draganddrop.js
+++ b/src/js/stores/draganddrop.js
@@ -204,13 +204,17 @@ define(function (require, exports, module) {
          * End the current drag operation.
          */
         stopDrag: function () {
+            if (this._isDropping) {
+                return;
+            }
+            
+            this._isDropping = true;
+            
             var onDropPromise = Promise.resolve();
 
             if (this._dropTarget) {
                 onDropPromise = this._dropTarget.onDrop(this._dragTargets, this._dragPosition);
             }
-            
-            this._isDropping = true;
 
             onDropPromise
                 .bind(this)
@@ -219,7 +223,7 @@ define(function (require, exports, module) {
                     this._dragTargets = Immutable.List();
                     this._dropTarget = null;
                     this._hasValidDropTarget = false;
-                    this._dragPosition = null; // Removing this causes an offset
+                    this._dragPosition = null;
                     this._initialDragPosition = null;
                     this._isDropping = false;
                     this.emit("stop-drag");

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -104,24 +104,6 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     }
 }
 
-// lock state
-.face__locked {
-
-}
-
-// invisibility state
-.face__invisible {
-    
-}
-
-// Parity state
-.face__parity_odd {
-    
-}
-.face__parity_even {
-    
-}
-
 // Selection state
 .face:hover {
     background-color: @list-hover-color;
@@ -132,62 +114,64 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     }
 }
 
-.face__not-visible input[type="text"].face__name {
-    color: @item-hover;
-    opacity: @label-hidden-opacity;
-}
-
-.face__select_immediate input[type="text"].face__name {
-    color: @item;
-}
-
-.face__select_immediate:hover input[type="text"].face__name {
-    color: @item;
-}
-
-.face__select_immediate, .face__select_immediate:hover {
-    background-color: @list-select-color;
-}
-
-.face__select_immediate .face__name, .face__select_immediate:hover .face__name {
-    color: @item;
-}
-
-.face__group_start {
-    margin-bottom: 0;
-}
-
-.face__select_child, .face__select_child:hover,
-.face__select_descendant, .face__select_descendant:hover {
-    background-color: @list-select-child-color;
-    
-    input[type="text"], input[type="text"]:disabled {
-        border-bottom: solid @hairline transparent;
+// Layer visibility state
+.face__not-visible,
+.layer-group__not-visible + .layers-group {
+    input[type="text"].face__name {
+        color: @item-hover;
+        opacity: @label-hidden-opacity;
     }
 }
 
-.face__select_descendant .face__name, .face__select_descendant:hover .face__name {
-    color: @item-active;
+// Layer descendents selection state
+.layer-group__selected + .layers-group {
+    .face, .face:hover {
+        background-color: @list-select-child-color;
+        
+        input[type="text"], input[type="text"]:disabled {
+            border-bottom: solid @hairline transparent;
+        }
+    }
 }
 
-.face__select_immediate .face__leash {
+// Layer direct selection state
+.face__selected,
+.layer-group__selected + .layers-group .face__selected {
+    &, &:hover {
+        background-color: @list-select-color;
+    }
 
+    input[type="text"].face__name,
+    &:hover input[type="text"].face__name,
+    .face__name, &:hover .face__name {
+        color: @item;
+    }
+    
+    input[type="text"].face__name {
+        border-bottom: solid @hairline transparent;
+    }
+    
+    input[type="text"].face__name:focus,
+    input[type="text"].face__name:focus {
+        border-bottom: solid @hairline @focus-highlight;
+        color: @item;
+        -webkit-user-select: text;
+    }
+}
+
+// Layer Group collapsed state
+.layer-group__collapsed + .layers-group{
+    display: none;
+}
+
+.face__select_descendant .face__name,
+.face__select_descendant:hover .face__name {
+    color: @item-active;
 }
 
 .face__drop_target, .face__drop_target:hover {
     background-color: none;
     cursor: -webkit-grabbing;
-}
-
-.face__select_immediate input[type="text"].face__name {
-    border-bottom: solid @hairline transparent;
-}
-
-.face__select_immediate input[type="text"].face__name:focus,
-input[type="text"].face__name:focus {
-    border-bottom: solid @hairline @focus-highlight;
-    color: @item;
-    -webkit-user-select: text;
 }
 
 // Drop state
@@ -217,7 +201,7 @@ input[type="text"].face__name:focus {
 }
 
 // Drag state
-.face__drag_target {
+.face__drag-target {
     background-color: none;
     opacity: 0.5;
     position: fixed;
@@ -227,35 +211,6 @@ input[type="text"].face__name:focus {
     pointer-events: none;
 }
 
-// Group collapsed state
-.layer__ancestor_collapsed {
-    display: none;
-}
-
-.layer__group_start.layer__select.layer__group_collapsed {
-    background-color: inherit;
-}
-
-// Layer name focus/blur state
-.face__input_focus {
-
-}
-.face__input_none {
-    
-}
-
-// For unselected layers, whether the previous/next layer in the z-order is selected
-.face__transition_to_select {
-
-}
-.face__transition_from_select {
-
-}
-
-// Search match state
-.face__search_matched {
-    
-}
-.face__search_none {
-    
+.layer-group__drag-target {
+    padding-top: 2.8rem;
 }

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -21,9 +21,17 @@
  *
  */
 
-.layer {
+// Default style for LayerFace components
+.face {
     min-height: 2.8rem;
     cursor: pointer;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    height: 2.8rem;
+    position: relative;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 .layer__dummy {
@@ -34,17 +42,6 @@
 
 .layer__dummy_drop {
     border-top: .25rem inset @focus-highlight;
-}
-
-// Default style for LayerFace components
-.face {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    height: 2.8rem;
-    position: relative;
-    padding-left: 1rem;
-    padding-right: 1rem;
 }
 
 .face__separator {
@@ -116,7 +113,7 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
 
 // Layer visibility state
 .face__not-visible,
-.layer-group__not-visible + .layers-group {
+.layer-group__not-visible {
     input[type="text"].face__name {
         color: @item-hover;
         opacity: @label-hidden-opacity;
@@ -124,10 +121,10 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
 }
 
 // Layer descendents selection state
-.layer-group__selected + .layers-group {
+.layer-group__selected {
     .face, .face:hover {
         background-color: @list-select-child-color;
-        
+
         input[type="text"], input[type="text"]:disabled {
             border-bottom: solid @hairline transparent;
         }
@@ -135,8 +132,7 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
 }
 
 // Layer direct selection state
-.face__selected,
-.layer-group__selected + .layers-group .face__selected {
+.face__selected {
     &, &:hover {
         background-color: @list-select-color;
     }
@@ -150,7 +146,7 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     input[type="text"].face__name {
         border-bottom: solid @hairline transparent;
     }
-    
+
     input[type="text"].face__name:focus,
     input[type="text"].face__name:focus {
         border-bottom: solid @hairline @focus-highlight;
@@ -160,13 +156,8 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
 }
 
 // Layer Group collapsed state
-.layer-group__collapsed + .layers-group{
+.layer-group__collapsed > .layers-group{
     display: none;
-}
-
-.face__select_descendant .face__name,
-.face__select_descendant:hover .face__name {
-    color: @item-active;
 }
 
 .face__drop_target, .face__drop_target:hover {
@@ -211,6 +202,6 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
     pointer-events: none;
 }
 
-.layer-group__drag-target {
+.layer__drag-target {
     padding-top: 2.8rem;
 }

--- a/src/style/sections/layers/layers-section.less
+++ b/src/style/sections/layers/layers-section.less
@@ -21,7 +21,7 @@
  *
  */
 
-.layer-list {
+.layer-group {
     width: @panel-column-width;
 }
 

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -308,7 +308,7 @@ svg use {
 }
 
 .face__not-visible,
-.layer-group__not-visible + .layers-group .face {
+.layer-group__not-visible .face {
     .face__kind,
     &:hover .face__kind
     &.face[data-kind="group"]:hover .face__kind,

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -194,11 +194,23 @@ svg use {
     }
 }
 
-.face.face__select_immediate {
+.face__selected {
     .button-toggle,
     &:hover .button-toggle{
         svg {
             fill: @icon-hover;
+            stroke: none;
+            display: block;
+        }
+    }
+}
+
+.layer-group__invisible {
+    .face:hover .button-toggle,
+    .face .button-toggle {
+        svg {
+            fill: @icon-hover;
+            opacity: @label-hidden-opacity;
             stroke: none;
             display: block;
         }
@@ -295,8 +307,9 @@ svg use {
     }
 }
 
-.face__not-visible {
-    .face__kind, 
+.face__not-visible,
+.layer-group__not-visible + .layers-group .face {
+    .face__kind,
     &:hover .face__kind
     &.face[data-kind="group"]:hover .face__kind,
     &.face[data-kind="group"] .face__kind {
@@ -309,14 +322,14 @@ svg use {
 }
 
 // applies to the selected item
-.face__select_immediate .face__kind, .face__select_immediate:hover .face__kind {
+.face__selected .face__kind, .face__selected:hover .face__kind {
   svg {
       fill: @icon-hover;
       stroke: none;
   }
 }
 
-.face__select_immediate.face[data-kind="7"] .face__kind {
+.face__selected[data-kind="group"] .face__kind {
     svg {
         fill: @icon-hover;
         stroke: none;


### PR DESCRIPTION
This PR applies the following changes to the LayersPanel for better performance:

1. Convert to hierarchical layer structure so that we can make sure of browser rendering with CSS selectors, and thus eliminate the number of components needed to be updated when selecting/expanding a layer/group.

~~2. Stores layer's selected/expanded/visible attributes in LayerFace's internal state so that we can re-render (using `setState`) the component immediately without waiting for the flux cycle to be completed.~~

##### Result

~~* Since we skip the flux cycle, the duration for a layer to react to a select event has been reduced from `100ms-400ms` to `less than 10ms`. (time is measured between `LayerFace#handleLayerClick` and `LayerFace#componentDidUpdate` within the same instance)~~
* With the hierarchical structure, I also observed improvement when selecting/expanding/collapsing/hiding layer group (I did not take any measurement for them)

##### Known Issues

~~* Sometimes the previously selected layer (A) remains highlighted while the currently selected layer (B) is already selected. This is because A has to wait for the flux cycle and it takes longer than B. The solution is using an event emitter to notify A when B is selected.~~
* This is not the target of this PR, but I noticed that mouse over different layer / library asset appears to be lagging even we are not running any scripts.

@placegraphichere I am assigning to this you since you will work on the performance measurement, but anyone is welcomed to review and leave some comments :clap: 