### PR TITLE
Manually add react-addons-perf shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -185,6 +185,11 @@
       "from": "react-dom@>=0.14.2 <0.15.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
     },
+    "react-addons-perf": {
+      "version": "0.14.3",
+      "from": "react-dom@>=0.14.2 <0.15.0",
+      "resolved": "https://registry.npmjs.org/react-addons-perf/-/react-addons-perf-0.14.3.tgz"
+    },
     "scriptjs": {
       "version": "2.5.8",
       "from": "scriptjs@>=2.5.8 <3.0.0",


### PR DESCRIPTION
Newer versions of react-addons got released, and because our shrinkwrap.json did not account for react-addons-perf, npm install would fail. This is a short term relief for this problem while we figure out how to move forward.