### PR TITLE
Integrate Adobe Stock search into search bar within DS

### DIFF
--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -60,11 +60,16 @@ define(function (require, exports) {
         transfers: [dialog.openDialog, dialog.closeDialog]
     };
 
+    /**
+     * Registers the search payloads to the search store to load the search bar
+     *
+     * @return {Promise}
+     */
     var beforeStartup = function () {
         var searchStore = this.flux.store("search");
 
         searchStore.registerSearch(ID,
-            ["CURRENT_DOC", "RECENT_DOC", "ALL_LAYER", "MENU_COMMAND", "LIBRARY", "GLOBAL_SHORTCUT"]);
+            ["ADOBE_STOCK", "CURRENT_DOC", "RECENT_DOC", "ALL_LAYER", "MENU_COMMAND", "LIBRARY", "GLOBAL_SHORTCUT"]);
 
         return Promise.resolve();
     };

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -201,8 +201,7 @@ define(function (require, exports) {
             "displayFilters": displayFilters,
             "handleExecute": _confirmSearch.bind(this),
             "shortenPaths": false,
-            "getSVGClass": _getSVGClass,
-            "noOptionsString": nls.localize("strings.SEARCH.NO_OPTIONS")
+            "getSVGClass": _getSVGClass
         };
         
         return this.dispatchAsync(events.search.REGISTER_SEARCH_PROVIDER, payload);

--- a/src/js/actions/search/stock.js
+++ b/src/js/actions/search/stock.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports) {
+    "use strict";
+
+    var Immutable = require("immutable");
+
+    var events = require("js/events"),
+        locks = require("js/locks"),
+        adapter = require("adapter"),
+        nls = require("js/util/nls");
+
+    var SEARCH_STOCK_URL = "https://stock.adobe.com/search?k=",
+        ADOBE_STOCK_URL = "https://stock.adobe.com/";
+    
+    /**
+     * Executes Adobe Stock search by opening a URL with the search term
+     *
+     * @return {Promise}
+     */
+    var _confirmStockSearch = function (searchTerm) {
+        var searchURL;
+        
+        if (searchTerm) {
+            searchURL = encodeURI(SEARCH_STOCK_URL + searchTerm);
+        } else {
+            searchURL = encodeURI(ADOBE_STOCK_URL);
+        }
+
+        return adapter.openURLInDefaultBrowser(searchURL);
+    };
+
+    /**
+     * Find SVG class for Adobe Stock
+     * If this needs to vary based on the item, use category list as parameter 
+     * (see getSVGCallback type in search store)
+     * 
+     * @return {string}
+     */
+    var _getSVGClass = function () {
+        return "libraries-stock";
+    };
+
+    /**
+     * Make list for Stock options to choose from, currently empty
+     * 
+     * @private
+     * @return {Immutable.List.<object>}
+     */
+    var _adobeStockSearchOptions = function () {
+        return Immutable.List();
+    };
+
+    /**
+     * Creates an object with properties to populate the search bar 
+     * datalist when there are no options present. 
+     * 
+     * @private
+     * @return {object}
+     */
+    var _createNoOptionsDefault = function () {
+        return {
+            "noOptionsString": nls.localize("strings.SEARCH.NO_OPTIONS_STOCK"),
+            "noOptionsExecute": _confirmStockSearch,
+            "noOptionsType": "filter"
+        };
+    };
+
+    /**
+     * Register Adobe Stock payload information for search
+     *
+     * @return {Promise}
+     */
+    var registerAdobeStock = function () {
+        var adobeStockPayload = {
+            "type": "ADOBE_STOCK",
+            "getOptions": _adobeStockSearchOptions,
+            "filters": Immutable.List.of("ADOBE_STOCK"),
+            "handleExecute": _confirmStockSearch,
+            "shortenPaths": false,
+            "getSVGClass": _getSVGClass,
+            "noOptionsDefault": _createNoOptionsDefault
+        };
+
+        return this.dispatchAsync(events.search.REGISTER_SEARCH_PROVIDER, adobeStockPayload);
+    };
+    registerAdobeStock.action = {
+        reads: [],
+        writes: [locks.JS_SEARCH]
+    };
+
+    /**
+     * Send information about Adobe Stock to search store
+     *
+     * @return {Promise}
+     */
+    var afterStartup = function () {
+        return this.transfer("search.stock.registerAdobeStock");
+    };
+    afterStartup.action = {
+        reads: [],
+        writes: [],
+        transfers: ["search.stock.registerAdobeStock"]
+    };
+
+    exports.registerAdobeStock = registerAdobeStock;
+    exports.afterStartup = afterStartup;
+});

--- a/src/js/jsx/Search.jsx
+++ b/src/js/jsx/Search.jsx
@@ -53,14 +53,26 @@ define(function (require, exports, module) {
          * 
          * @private
          * @param {string} itemID ID of selected option
+         * @param {function=} noOptionsFn function to execute if there are no options
          */
-        _handleOption: function (itemID) {
+        _handleOption: function (itemID, noOptionsFn) {
+            var searchStore = this.getFlux().store("search");
             this._closeSearchBar()
                 .bind(this)
                 .then(function () {
-                    if (itemID) {
-                        var searchStore = this.getFlux().store("search");
-                        searchStore.handleExecute(itemID);
+                    // If there is a noOptionsFn, this indicates we want the default option,
+                    // that is present in the datalist when there are no results available,
+                    // to execute some behavior if selected. E.g. Selecting the filter
+                    // "Adobe Stock" defaults into "Search Adobe Stock..." and upon selection
+                    // we want it to execute a function to open the Stock homepage 
+                    if (noOptionsFn) {
+                        noOptionsFn(itemID);
+                    }
+                    // If there is noOptionsFn, this indicates the datalist has results available.
+                    else {
+                        if (itemID) {
+                            searchStore.handleExecute(itemID);
+                        }
                     }
                 });
         },

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -139,6 +139,12 @@ define(function (require, exports, module) {
                 });
             }
         },
+
+        componentWilUnmount: function () {
+            if (this._acquireFocusPromise && this._acquireFocusPromise.isPending()) {
+                this._acquireFocusPromise.cancel();
+            }
+        },
         
         /**
          * Return the text input's current value
@@ -151,6 +157,7 @@ define(function (require, exports, module) {
         
         /**
          * Update the text input's current value
+         * @param {string} value updated
          */
         setValue: function (value) {
             this.setState({
@@ -333,13 +340,16 @@ define(function (require, exports, module) {
                 return;
             }
 
-            this.acquireFocus()
+            this._acquireFocusPromise = this.acquireFocus()
                 .bind(this)
                 .then(function () {
                     this.setState({
                         editing: true,
                         selectDisabled: false
                     });
+                })
+                .finally(function () {
+                    this._acquireFocusPromise = null;
                 });
         },
 

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -468,7 +468,9 @@
         "PLACEHOLDER": "Search, open & select",
         "PLACEHOLDER_INITIALIZING": "Initializing…",
         "PLACEHOLDER_FILTER": "Search ",
+        "NO_OPTIONS_STOCK": "Search Adobe Stock…",
         "NO_OPTIONS": "No results match your search",
+        "UNTITLED": "Untitled",
         "HEADERS": {
             "ALL_LAYER": "Layers",
             "CURRENT_LAYER": "Layers",
@@ -480,6 +482,7 @@
             "GLOBAL_SHORTCUT": "Global Shortcuts"
         },
         "CATEGORIES": {
+            "ADOBE_STOCK": "Adobe Stock",
             "CURRENT_DOC": "Open Documents",
             "RECENT_DOC": "Recent Documents",
             "MENU_COMMAND": "Menu Commands",


### PR DESCRIPTION
This PR adds the option to search Adobe Stock via the search bar. (JIRA PS-656) 
It also solves issues #3610, #3529, #3524. 

Testing: 

- The category "Adobe Stock" is now added to the search bar as a potential category the user can choose

- If the user selects the category "Adobe Stock", the user can: 
      > - Enter a string, press `enter` and adobestock.com will open to the results page of the user search 
      > - Enter no string, press `enter` and adobestock.com homepage will open 
      > - Enter a string, click the option `Search Adobe Stock...` and adobestock.com will open to the results page of the user search 
      > - Enter no string, click the option `Search Adobe Stock...` and adobestock.com homepage will open

- If the user selects any or no category within the search bar: 
      >  - If the user types in any string to the search bar and there are no results found, pressing `enter` should execute no action and nothing should happen to the state of the search bar.
      >  - If the user types in a string to the search bar and there are no results, and the user clicks the option `No Results Match`, nothing should happen to the state of the search bar. 
      >  - If the user presses `tab` to autocomplete and there is a a suggestion, the user inputted string should autocomplete. 
      >  - If the user presses `tab` to autocomplete and there is a a suggestion, the user inputted string should autocomplete. 
     >  - If the user presses `tab` to autocomplete and there is no suggestion, the user inputted string not change.
     > - If the user searches for a partial match of the option string, and then presses `enter`, the first option out of the list of options should select. Example: User types `documents`, the options list returns with "Open Documents", "Recent Documents", "documents-1353.psd", pressing enter should choose the option "Open Documents". 


- The category "Adobe Stock" is now added and after selecting it, entering a string within the input field and pressing "Enter" should open a new tab in the browser with the executed search and its results. 
- Searching Adobe Stock from DS will only happen when the "Adobe Stock" filter is applied. 
- When the "Adobe Stock" filter is applied, only the search bar is present, "No options for this result" should not be shown.
- From the browser, the user can choose an image and drag it directly into their document, save it to their local machine, or add it to their library.
