### PR TITLE
Define process.env.NODE_ENV for React

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,9 +91,13 @@ var buildConfigs = languages.map(function (lang) {
             extensions: ["", ".js", ".jsx", ".json", ".less"]
         },
         plugins: [
-            // This passes __PG_DEBUG__ variable to the bundle
             new webpack.DefinePlugin({
-                __PG_DEBUG__: devMode
+                // This passes __PG_DEBUG__ variable to the bundle
+                __PG_DEBUG__: devMode,
+                // React uses this to enable production mode
+                "process.env": {
+                    NODE_ENV: devMode ? "\"development\"" : "\"production\""
+                }
             }),
             new WebpackNotifierPlugin({ alwaysNotify: true })
         ],


### PR DESCRIPTION
This defines `process.env.NODE_ENV` to be `"development"` in debug builds and `"production" in compiled builds.` This is required for React to use a more optimized production mode in our compiled builds. 

Addresses #3486. 