### PR TITLE
Delay headlights logging until browser is idle

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -52,10 +52,9 @@ define(function (require, exports) {
      *
      * @private
      * @param {string} eventName
-     * @return {Promise}
      */
     var _logSuperselect = function (eventName) {
-        return headlights.logEvent("tools", "superselect", _.kebabCase(eventName));
+        headlights.logEvent("tools", "superselect", _.kebabCase(eventName));
     };
 
     /**

--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -28,12 +28,12 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
         
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights");
 
     var BlendMode = require("./BlendMode"),
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
      * @private
      * @type {function(*)}
      */
-    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
+    var logEventDebounced = _.debounce(headlights.logEvent, 10000);
 
     var ColorOverlay = React.createClass({
         mixins: [FluxMixin],

--- a/src/js/jsx/sections/style/LayerBlendMode.jsx
+++ b/src/js/jsx/sections/style/LayerBlendMode.jsx
@@ -27,11 +27,11 @@ define(function (require, exports, module) {
     var React = require("react"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        Immutable = require("immutable");
+        Immutable = require("immutable"),
+        _ = require("lodash");
 
     var BlendMode = require("./BlendMode"),
         nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         collection = require("js/util/collection");
 
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
      * @private
      * @type {function(*)}
      */
-    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
+    var logEventDebounced = _.debounce(headlights.logEvent, 10000);
 
     var LayerBlendMode = React.createClass({
         mixins: [FluxMixin],

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -34,8 +34,7 @@ define(function (require, exports) {
     var LayerEffect = require("js/models/effects/layereffect"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
-        nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization");
+        nls = require("js/util/nls");
 
     var Label = require("js/jsx/shared/Label"),
         NumberInput = require("js/jsx/shared/NumberInput"),
@@ -50,7 +49,7 @@ define(function (require, exports) {
      * @private
      * @type {function(*)}
      */
-    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
+    var logEventDebounced = _.debounce(headlights.logEvent, 10000);
 
     var MIN_SPREAD = 0,
         MAX_SPREAD = 100,

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -28,14 +28,14 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         Immutable = require("immutable"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
         
     var LayerEffect = require("js/models/effects/layereffect"),
         StrokeEffect = require("js/models/effects/stroke"),
         collection = require("js/util/collection"),
         nls = require("js/util/nls"),
-        headlights = require("js/util/headlights"),
-        synchronization = require("js/util/synchronization");
+        headlights = require("js/util/headlights");
 
     var Label = require("js/jsx/shared/Label"),
         NumberInput = require("js/jsx/shared/NumberInput"),
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      * @private
      * @type {function(*)}
      */
-    var logEventDebounced = synchronization.debounce(headlights.logEvent, null, 10000);
+    var logEventDebounced = _.debounce(headlights.logEvent, 10000);
         
     /**
      * Limits of stroke size.

--- a/src/js/util/headlights.js
+++ b/src/js/util/headlights.js
@@ -24,8 +24,6 @@
 define(function (require, exports) {
     "use strict";
 
-    var Promise = require("bluebird");
-
     var adapterPS = require("adapter").ps;
 
     /**
@@ -39,14 +37,12 @@ define(function (require, exports) {
      * @param {string} category
      * @param {string} subcategory
      * @param {string} event
-     *
-     * @return {Promise}
      */
     var logEvent = function (category, subcategory, event) {
-        if (__PG_DEBUG__) {
-            return Promise.resolve();
-        } else {
-            return adapterPS.logHeadlightsEvent(category, subcategory, String(event));
+        if (!__PG_DEBUG__) {
+            window.requestIdleCallback(function () {
+                adapterPS.logHeadlightsEvent(category, subcategory, String(event));
+            });
         }
     };
 


### PR DESCRIPTION
This PR defers posting headlights events until the browser is idle, and removes the return value from `headlights.logEvent` to clarify that clients should not wait for any results. This is just a nit fix.