### PR TITLE
Delay React render on drags by blocking dispatch

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -363,9 +363,10 @@ define(function (require, exports) {
      * @param {number} y Offset from the top window edge
      * @param {boolean} deep Whether to choose all layers or not
      * @param {boolean} add Whether to add/remove layer to selection
+     * @param {boolean} quiet If true, select action will not cause any dispatches
      * @return {Promise.<boolean>} True if any layers are selected after this command, used for dragging
      */
-    var click = function (doc, x, y, deep, add) {
+    var click = function (doc, x, y, deep, add, quiet) {
         var uiStore = this.flux.store("ui"),
             coords = uiStore.transformWindowToCanvas(x, y),
             layerTree = doc.layers;
@@ -428,7 +429,7 @@ define(function (require, exports) {
                         _logSuperselect("click_" + modifier);
                     }
 
-                    return this.transfer(layerActions.select, doc, topLayer, modifier)
+                    return this.transfer(layerActions.select, doc, topLayer, modifier, quiet)
                         .return(true);
                 } else if (!doc.layers.selected.isEmpty()) {
                     _logSuperselect("deselect_all");
@@ -659,7 +660,7 @@ define(function (require, exports) {
                 return descriptor.playObject(toolLib.setToolOptions("moveTool", { "$Abbx": false }))
                     .bind(this)
                     .then(function () {
-                        return this.transfer(click, doc, x, y, diveIn, false);
+                        return this.transfer(click, doc, x, y, diveIn, false, true);
                     })
                     .then(function (anySelected) {
                         if (anySelected) {
@@ -670,6 +671,8 @@ define(function (require, exports) {
                             };
 
                             return adapterOS.postEvent(dragEvent);
+                        } else {
+                            return Promise.resolve();
                         }
                     })
                     .catch(function () {}) // Move should silently fail if there are no selected layers

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1317,12 +1317,12 @@ define(function (require, exports) {
 
             return Promise.join(modelPromise, transformPromise);
         } else {
-            var dragUpdatePromise,
-                dragLayerIDs = this.flux.store("tool").getState().draggedLayerIDs;
+            var draggedLayerIDs = this.flux.store("tool").getState().draggedLayerIDs,
+                dragUpdatePromise;
 
-            if (dragLayerIDs) {
-                var dragLayers = dragLayerIDs.map(currentDoc.layers.byID.bind(currentDoc.layers));
-                dragUpdatePromise = this.transfer("layers.select", currentDoc, dragLayers);
+            if (draggedLayerIDs) {
+                var draggedLayers = draggedLayerIDs.map(currentDoc.layers.byID.bind(currentDoc.layers));
+                dragUpdatePromise = this.transfer("layers.select", currentDoc, draggedLayers);
             } else {
                 dragUpdatePromise = Promise.resolve();
             }
@@ -1335,7 +1335,7 @@ define(function (require, exports) {
                     .bind(this)
                     .then(function () {
                         // This doesn't cause a re-render
-                        this.dispatch(events.tool.SELECT_TOOL_DRAG, { selectedIDs: null });
+                        this.dispatch(events.tool.SUPERSELECT_DRAG_UPDATE, { selectedIDs: null });
 
                         // The history event may arrive before or after the transform event. The
                         // following ensures correct behavior w.r.t. history amendment by reset
@@ -1365,8 +1365,8 @@ define(function (require, exports) {
         }
     };
     handleTransformLayer.action = {
-        read: [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL],
-        writes: [],
+        read: [locks.JS_APP, locks.JS_DOC],
+        writes: [locks.JS_TOOL],
         transfers: ["layers.addLayers", "ui.updateTransform", "layers.resetLayers", "layers.resetBounds",
             "history.newHistoryStateRogueSafe", "layers.select"],
         modal: true,

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1317,16 +1317,36 @@ define(function (require, exports) {
 
             return Promise.join(modelPromise, transformPromise);
         } else {
+            var dragUpdatePromise,
+                dragLayerIDs = this.flux.store("tool").getState().draggedLayerIDs;
+
+            if (dragLayerIDs) {
+                var dragLayers = dragLayerIDs.map(currentDoc.layers.byID.bind(currentDoc.layers));
+                dragUpdatePromise = this.transfer("layers.select", currentDoc, dragLayers);
+            } else {
+                dragUpdatePromise = Promise.resolve();
+            }
+
             // short circuit based on this trackerEndedWithoutBreakingHysteresis event flag
             if (event.trackerEndedWithoutBreakingHysteresis) {
-                return Promise.resolve();
+                return dragUpdatePromise;
             } else {
-                // The history event may arrive before or after the transform event. The
-                // following ensures correct behavior w.r.t. history amendment by reset
-                // actions for either case.
-                return this.transfer("history.newHistoryStateRogueSafe", currentDoc.id)
+                return dragUpdatePromise
                     .bind(this)
                     .then(function () {
+                        // This doesn't cause a re-render
+                        this.dispatch(events.tool.SELECT_TOOL_DRAG, { selectedIDs: null });
+
+                        // The history event may arrive before or after the transform event. The
+                        // following ensures correct behavior w.r.t. history amendment by reset
+                        // actions for either case.
+                        return this.transfer("history.newHistoryStateRogueSafe", currentDoc.id);
+                    })
+                    .then(function () {
+                        // We need to get the updated document model since selection may have changed
+                        // due to drag optimization
+                        currentDoc = appStore.getCurrentDocument();
+
                         var textLayers = currentDoc.layers.allSelected.filter(function (layer) {
                                 // Reset these layers completely because their impliedFontSize may have changed
                                 // FIXME: does this need event for events like "move"?
@@ -1345,10 +1365,10 @@ define(function (require, exports) {
         }
     };
     handleTransformLayer.action = {
-        read: [locks.JS_APP, locks.JS_DOC],
+        read: [locks.JS_APP, locks.JS_DOC, locks.JS_TOOL],
         writes: [],
         transfers: ["layers.addLayers", "ui.updateTransform", "layers.resetLayers", "layers.resetBounds",
-            "history.newHistoryStateRogueSafe"],
+            "history.newHistoryStateRogueSafe", "layers.select"],
         modal: true,
         post: ["verifyLayers.verifySelectedBounds"],
         hideOverlays: true

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -108,6 +108,7 @@ define(function (require, exports, module) {
         tool: {
             SELECT_TOOL_START: "selectToolStart",
             SELECT_TOOL_END: "selectToolEnd",
+            SELECT_TOOL_DRAG: "selectToolDrag",
             MODAL_STATE_CHANGE: "modalStateChange",
             VECTOR_MASK_MODE_CHANGE: "vectorMaskModeChange",
             VECTOR_MASK_POLICY_CHANGE: "vectorMaskPolicyChange"

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -108,10 +108,10 @@ define(function (require, exports, module) {
         tool: {
             SELECT_TOOL_START: "selectToolStart",
             SELECT_TOOL_END: "selectToolEnd",
-            SELECT_TOOL_DRAG: "selectToolDrag",
             MODAL_STATE_CHANGE: "modalStateChange",
             VECTOR_MASK_MODE_CHANGE: "vectorMaskModeChange",
-            VECTOR_MASK_POLICY_CHANGE: "vectorMaskPolicyChange"
+            VECTOR_MASK_POLICY_CHANGE: "vectorMaskPolicyChange",
+            SUPERSELECT_DRAG_UPDATE: "superselectDragUpdate"
         },
         ui: {
             TRANSFORM_UPDATED: "transformUpdated",

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -198,9 +198,12 @@ define(function (require, exports, module) {
             var documentID = this.props.document.id,
                 documentStore = this.getFlux().store("document"),
                 currentDocument = documentStore.getDocument(documentID),
-                currentLayer = currentDocument.layers.byID(this.props.layer.id);
+                currentLayer = currentDocument.layers.byID(this.props.layer.id),
+                options = {
+                    modifier: modifier
+                };
 
-            this.getFlux().actions.layers.select(currentDocument, currentLayer, modifier);
+            this.getFlux().actions.layers.select(currentDocument, currentLayer, options);
         },
 
         /**

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
 
             // Select the dragged layers if they are not selected
             if (!Immutable.is(selectedLayers, draggedLayers)) {
-                promise = flux.actions.layers.select(document, draggedLayers, "select");
+                promise = flux.actions.layers.select(document, draggedLayers, { modifier: "select" });
             }
 
             return promise.then(function () {

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -99,12 +99,19 @@ define(function (require, exports, module) {
         _inVectorMode: false,
 
         /**
-         * stored ID of pointer policy created while in vector mask mode
+         * Stored ID of pointer policy created while in vector mask mode
          *
          * @private
          * @type {number}
          */
         _vectorMaskPolicyID: null,
+
+        /**
+         * IDs of layers that are being dragged by superselect tool drag
+         *
+         * @type {Immutable.Iterable<number>}
+         */
+        _draggedLayerIDs: null,
 
         /**
          * Initialize the ToolStore
@@ -114,6 +121,7 @@ define(function (require, exports, module) {
                 events.RESET, this._handleReset,
                 events.tool.SELECT_TOOL_START, this._handleSelectTool,
                 events.tool.SELECT_TOOL_END, this._handleSelectTool,
+                events.tool.SELECT_TOOL_DRAG, this._handleSelectToolDrag,
                 events.tool.MODAL_STATE_CHANGE, this._handleModalStateChange,
                 events.tool.VECTOR_MASK_MODE_CHANGE, this._handleVectorMaskModeChange,
                 events.tool.VECTOR_MASK_POLICY_CHANGE, this._handleVectorMaskPolicyChange
@@ -170,7 +178,8 @@ define(function (require, exports, module) {
             return {
                 current: this._currentTool,
                 previous: this._previousTool,
-                vectorMaskMode: this._inVectorMode
+                vectorMaskMode: this._inVectorMode,
+                draggedLayerIDs: this._draggedLayerIDs
             };
         },
 
@@ -250,6 +259,18 @@ define(function (require, exports, module) {
             this._vectorMaskPolicyID = payload;
 
             this.emit("change");
+        },
+
+        /**
+         * Saves the layers that will be affected by drag so their selection event
+         * can be emitted afterwards
+         * 
+         * @private
+         *
+         * @param {{selectedIDs: Immutable.Iterable<number>}} payload Layers that are being moved by drag
+         */
+        _handleSelectToolDrag: function (payload) {
+            this._draggedLayerIDs = payload.selectedIDs;
         },
 
         /**

--- a/src/js/stores/tool.js
+++ b/src/js/stores/tool.js
@@ -121,10 +121,10 @@ define(function (require, exports, module) {
                 events.RESET, this._handleReset,
                 events.tool.SELECT_TOOL_START, this._handleSelectTool,
                 events.tool.SELECT_TOOL_END, this._handleSelectTool,
-                events.tool.SELECT_TOOL_DRAG, this._handleSelectToolDrag,
                 events.tool.MODAL_STATE_CHANGE, this._handleModalStateChange,
                 events.tool.VECTOR_MASK_MODE_CHANGE, this._handleVectorMaskModeChange,
-                events.tool.VECTOR_MASK_POLICY_CHANGE, this._handleVectorMaskPolicyChange
+                events.tool.VECTOR_MASK_POLICY_CHANGE, this._handleVectorMaskPolicyChange,
+                events.tool.SUPERSELECT_DRAG_UPDATE, this._handleSuperselectDragUpdate
             );
 
             this._handleReset();
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
          *
          * @param {{selectedIDs: Immutable.Iterable<number>}} payload Layers that are being moved by drag
          */
-        _handleSelectToolDrag: function (payload) {
+        _handleSuperselectDragUpdate: function (payload) {
             this._draggedLayerIDs = payload.selectedIDs;
         },
 


### PR DESCRIPTION
On `superselect.drag`, we first run the `superselect.click` action to select whatever layer the user might be clicking on / wants to move. This calls `layers.select`, which dispatches optimistically to update our models and re-render everything on React side, before drag happens. This causes a visible delay on drags until our models/views update to send the drag operation to Photoshop to start dragging. (On average, 200 ms)

With this change, I save the selected layer IDs in the tool store, and instead of dispatching a select event, we just store those IDs, and wait for the move event to reach us before grabbing these stored IDs and emitting a select event for them, updating our models. This saves us on average 150 ms, bringing down the drag action length to 50 ms before Photoshop starts dragging.