### PR TITLE
Timestamp actions and transfers

### DIFF
--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -725,6 +725,10 @@ define(function (require, exports, module) {
             actionTitle = "action " + actionName;
         }
 
+        if (__PG_DEBUG__) {
+            log.timeStamp("Executing " + actionTitle);
+        }
+
         if (hideOverlays) {
             actionReceiver.dispatch(events.panel.START_CANVAS_UPDATE);
         }
@@ -765,6 +769,10 @@ define(function (require, exports, module) {
 
                 if (lockUI && !uiWasLocked) {
                     this._unlockUI();
+                }
+
+                if (__PG_DEBUG__) {
+                    log.timeStamp("Finished " + actionTitle);
                 }
 
                 if (__PG_DEBUG__ && post && post.length > 0 &&

--- a/src/js/util/log.js
+++ b/src/js/util/log.js
@@ -30,13 +30,17 @@ define(function (require, exports, module) {
     if (__PG_DEBUG__) {
         // If the debug global is set, log messages at and below debug level
         loglevel.enableAll();
+
+        if (!loglevel.hasOwnProperty("table")) {
+            loglevel.table = console.table.bind(console);
+        }
+
+        if (!loglevel.hasOwnProperty("timeStamp")) {
+            loglevel.timeStamp = console.timeStamp.bind(console);
+        }
     } else {
         // Otherwise, only log information, warnings and errors
         loglevel.setLevel(loglevel.levels.INFO);
-    }
-
-    if (!loglevel.hasOwnProperty("table")) {
-        loglevel.table = console.table.bind(console);
     }
 
     module.exports = loglevel;


### PR DESCRIPTION
This adds timestamps to the Chromium timeline corresponding to action and transfer execution boundaries. This only happens in debug mode. It results in little yellow lines in the timeline with tooltips to indicate what action is starting or finishing execution:

![image](https://cloud.githubusercontent.com/assets/1075154/12245717/1ed3e9fc-b85f-11e5-9500-62495d5702ba.png)

(Above, the line is next to the 3540ms time marker.)

More info: https://developer.chrome.com/devtools/docs/console-api#consoletimestamplabel