### PR TITLE
Expose ReactPerf and make it disabled by default.

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -121,7 +121,8 @@ define(function (require, exports) {
             window.__PS_ADAPTER__ = adapter;
             window.__FLUX_CONTROLLER__ = _controller;
             window.__LOG_UTIL__ = log;
-            window.__PERF_UTIL = performanceUtil;
+            window.__PERF_UTIL__ = performanceUtil;
+            window.__REACT_PERF__ = ReactPerf;
         }
 
         var startupPromises = _controller.start()
@@ -171,8 +172,6 @@ define(function (require, exports) {
         Promise.onPossiblyUnhandledRejection(function (err) {
             throw err;
         });
-
-        ReactPerf.start();
 
         /* global _spaces */
         _spaces._debug.enableDebugContextMenu(true, function () {});


### PR DESCRIPTION
Expose `ReactPerf` to the global for easier access of the React's profiling tool (https://facebook.github.io/react/docs/perf.html). Also removed `ReactPerf.start()`, otherwise it will measure our components endlessly (which will increase rendering time and memory usage in dev mode)