### PR TITLE
Customizable "No options" messages for registered search modules

### DIFF
--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -201,7 +201,8 @@ define(function (require, exports) {
             "displayFilters": displayFilters,
             "handleExecute": _confirmSearch.bind(this),
             "shortenPaths": false,
-            "getSVGClass": _getSVGClass
+            "getSVGClass": _getSVGClass,
+            "noOptionsString": nls.localize("strings.SEARCH.NO_OPTIONS")
         };
         
         return this.dispatchAsync(events.search.REGISTER_SEARCH_PROVIDER, payload);

--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -500,20 +500,27 @@ define(function (require, exports, module) {
 
         render: function () {
             var searchStrings = nls.localize("strings.SEARCH"),
-                noMatchesOption = {
-                    id: PLACEHOLDER_ID,
-                    title: nls.localize("strings.SEARCH.NO_OPTIONS"),
-                    type: "placeholder"
-                };
-
-            var filter = this.state.filter,
+                filters = this.state.filter,
                 placeholderText,
                 clearInputBtn;
 
+            var flux = this.getFlux(),
+                searchStore = flux.store("search"),
+                lastFilter = filters[filters.length - 1];
+
+            var searchPayload = searchStore.getPayloadFromFilter(lastFilter),
+                noOptionsString = searchPayload ? searchPayload.noOptionsString : null,
+                defaultNoOptions = nls.localize("strings.SEARCH.NO_OPTIONS");
+
+            var noMatchesOption = {
+                    id: PLACEHOLDER_ID,
+                    title: noOptionsString ? noOptionsString : defaultNoOptions,
+                    type: "placeholder"
+                };
+
             // If we have applied a filter, change the placeholder text
-            if (filter.length > 0) {
-                var lastFilter = filter[filter.length - 1],
-                    categoryString = searchStrings.CATEGORIES[lastFilter],
+            if (filters.length > 0) {
+                var categoryString = searchStrings.CATEGORIES[lastFilter],
                     category = categoryString ?
                         categoryString.toLowerCase() : this.state.safeFilterNameMap[lastFilter];
                 placeholderText = searchStrings.PLACEHOLDER_FILTER + category;

--- a/src/js/stores/search.js
+++ b/src/js/stores/search.js
@@ -233,7 +233,9 @@ define(function (require, exports, module) {
                 // If we need a document to have any options for the type, defaults to false
                 "haveDocument": payload.haveDocument,
                 // Function to get properly named class for the svg icon
-                "getSVGClass": payload.getSVGClass
+                "getSVGClass": payload.getSVGClass,
+                // String to display if datalist does not have any options to present
+                "noOptionsString": payload.noOptionsString
             };
         },
 
@@ -326,6 +328,17 @@ define(function (require, exports, module) {
                 searchInfo = this._registeredSearchTypes[header];
 
             return searchInfo.getSVGClass(categories);
+        },
+
+        /**
+         * Find the associated payload from a registered search module
+         * given the filter applied within the Search Bar 
+         * 
+         * @param {string} filter
+         * @return {payload=}
+         */
+        getPayloadFromFilter: function (filter) {
+            return this._registeredSearchTypes[filter];
         },
 
         /**


### PR DESCRIPTION
This creates an option property on registered search modules for a custom string to be shown when no datalist options are available for that category in the search bar. If no value is passed in for the property, a default string will be applied and shown. 

Provides a better solution for some of the concerns raised in #3479. Once this is merged, then we can integrate Adobe Stock search in a much more stable way. 

Note: For some of the payloads, I have added the property `noOptionsString`. For others I have no provided the property. This is to prove to whoever tests this branch that both cases work. Also, a string has been added specific to no options when the Adobe Stock filter is applied. This is in preparation for #3479, as stated above. 