### PR TITLE
Layer Panel: faster layer face selection/expansion/visibility

### DIFF
--- a/src/js/actions/groups.js
+++ b/src/js/actions/groups.js
@@ -70,7 +70,9 @@ define(function (require, exports) {
 
         var targetLayers = layers;
         if (recursive) {
-            layers = layers.flatMap(document.layers.descendants, document.layers);
+            layers = layers.flatMap(document.layers.descendants, document.layers).filter(function (layer) {
+                return layer.isGroup;
+            });
         }
 
         // When collapsing layers, if a visible descendent is selected then the selection

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -532,6 +532,7 @@ define(function (require, exports, module) {
         render: function () {
             var doc = this.props.document,
                 layer = this.props.layer,
+                hasChildren = this.props.hasChildren,
                 layerIndex = doc.layers.indexOf(layer),
                 layerDepth = doc.layers.depth(layer),
                 nameEditable = !layer.isBackground,
@@ -539,10 +540,14 @@ define(function (require, exports, module) {
                 isDropTarget = this.state.isDropTarget,
                 dropPosition = this.state.dropPosition,
                 selected = layer.selected,
-                visible = layer.visible;
+                visible = layer.visible,
+                expanded = layer.expanded;
             
             var layerClasses = classnames({
                 "layer": true,
+                "layer__selected": hasChildren && selected,
+                "layer__collapsed": hasChildren && !expanded,
+                "layer__not-visible": hasChildren && !visible,
                 "layer__drag-target": isDragging
             });
 

--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -40,12 +40,16 @@ define(function (require, exports, module) {
         mixins: [FluxMixin],
 
         /**
-         * True if the LayerGroup's components are rendered. Used to avoid
-         * rendering layer group until it is first visible.
+         * This is used by the root LayerGroup to control whether or not its child LayerGroups 
+         * should render their collapsed layers. At initial rendering, `renderCollapsedLayers` 
+         * is set to false to prevent child LayerGroups from rendering collapsed layers, which
+         * will reduce the initial load time. After the root LayerGroup is mounted , it will 
+         * set `renderCollapsedLayers` to true, and force update its child LayerGroups to 
+         * render the collapsed layers for faster future expand actions (in `componentDidMount`).
          * 
          * @type {Boolean}
          */
-        isRendered: false,
+        renderCollapsedLayers: false,
 
         propTypes: {
             /**
@@ -68,7 +72,26 @@ define(function (require, exports, module) {
             /**
              * @type {Boolean}
              */
-            disabled: React.PropTypes.bool
+            disabled: React.PropTypes.bool,
+
+            /**
+             * True if the LayerGroup should render collapsed layers. This is controlled by the 
+             * root LayerGroup.
+             * 
+             * @type {Boolean}
+             */
+            renderCollapsedLayers: React.PropTypes.bool
+        },
+        
+        componentDidMount: function () {
+            if (!this.props.parentLayer) {
+                // Wait for 2 seconds when the root LayerPanel is mounted, then force update to 
+                // render the collapsed layers.
+                this.renderCollapsedLayers = true;
+                window.setTimeout(function () {
+                    this.forceUpdate();
+                }.bind(this), 2000);
+            }
         },
         
         shouldComponentUpdate: function () {
@@ -81,13 +104,13 @@ define(function (require, exports, module) {
 
         render: function () {
             var parentLayer = this.props.parentLayer,
-                isRoot = !parentLayer;
+                isRoot = !parentLayer,
+                renderCollapsedLayers = isRoot ? this.renderCollapsedLayers : this.props.renderCollapsedLayers;
 
             // Do not render layer group of collapsed layer to reduce document load time.
-            if (!isRoot && !parentLayer.expanded && !this.isRendered) {
+            // when the root LayerGroup is mounted, it will 
+            if (!isRoot && !parentLayer.expanded && !renderCollapsedLayers) {
                 return false;
-            } else {
-                this.isRendered = true;
             }
 
             var layerFaces = this.props.layerNodes.reduce(function (results, layerNode) {
@@ -99,7 +122,8 @@ define(function (require, exports, module) {
                             parentLayer={layer}
                             layerNodes={layerNode.children}
                             document={this.props.document}
-                            disabled={this.props.disabled}/>
+                            disabled={this.props.disabled}
+                            renderCollapsedLayers={renderCollapsedLayers}/>
                     );
 
                     var className = classnames({

--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -103,10 +103,7 @@ define(function (require, exports, module) {
                     );
 
                     var className = classnames({
-                        "layer-group": layerGroup,
-                        "layer-group__selected": layerGroup && layer.selected,
-                        "layer-group__collapsed": layerGroup && !layer.expanded,
-                        "layer-group__not-visible": layerGroup && !layer.visible
+                        "layer-group": layerGroup
                     });
 
                     results.push(
@@ -116,7 +113,7 @@ define(function (require, exports, module) {
                                 disabled={this.props.disabled}
                                 document={this.props.document}
                                 layer={layer}
-                                childNodes={layerNode.children}/>
+                                hasChildren={!!layerNode.children}/>
                             {layerGroup}
                         </li>
                     );

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -33,9 +33,12 @@ define(function (require, exports) {
      *
      * @private
      * @param {Layer} layer
+     * @param {boolean=} expanded overwrite the default value from 'layer.expanded'
      * @return {string}
     */
-    var getSVGClassFromLayer = function (layer) {
+    var getSVGClassFromLayer = function (layer, expanded) {
+        expanded = typeof expanded === 'boolean' ? expanded : layer.expanded;
+
         var iconID = "layer-";
         if (layer.isArtboard) {
             iconID += "artboard";
@@ -55,7 +58,7 @@ define(function (require, exports) {
             iconID += layer.kind;
         }
 
-        if (layer.isGroup && !layer.expanded) {
+        if (layer.isGroup && !expanded) {
             iconID += "-collapsed";
         }
 

--- a/src/js/util/svg.js
+++ b/src/js/util/svg.js
@@ -37,7 +37,7 @@ define(function (require, exports) {
      * @return {string}
     */
     var getSVGClassFromLayer = function (layer, expanded) {
-        expanded = typeof expanded === 'boolean' ? expanded : layer.expanded;
+        expanded = typeof expanded === "boolean" ? expanded : layer.expanded;
 
         var iconID = "layer-";
         if (layer.isArtboard) {

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -98,7 +98,7 @@ input[type="text"].face__name {
 }
 
 // Layer group selection state
-.layer-group__selected {
+.layer__selected + .layer-group {
     .face, .face:hover {
         background-color: @list-select-child-color;
     }
@@ -106,7 +106,7 @@ input[type="text"].face__name {
 
 // Layer direct selection state
 .face__selected,
-.layer-group__selected .face__selected {
+.layer__selected + .layer-group .face__selected {
     &, &:hover {
         background-color: @list-select-color;
     }
@@ -118,8 +118,8 @@ input[type="text"].face__name {
 }
 
 // Layer visibility state
-.face__not-visible,
-.layer-group__not-visible {
+.layer__not-visible,
+.layer__not-visible + .layer-group {
     .face__name {
         color: @item-hover;
         opacity: @label-hidden-opacity;
@@ -127,7 +127,7 @@ input[type="text"].face__name {
 }
 
 // Layer Group collapsed state
-.layer-group__collapsed > .layer-group{
+.layer__collapsed + .layer-group{
     display: none;
 }
 

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -209,7 +209,8 @@ svg use {
     }
 }
 
-.layer-group__invisible {
+.layer__not-visible
+.layer__not-invisible + .layer-group {
     .face:hover .button-toggle,
     .face .button-toggle {
         svg {
@@ -312,7 +313,7 @@ svg use {
 }
 
 .face__not-visible,
-.layer-group__not-visible .face {
+.layer__not-visible + .layer-group .face {
     .face__kind,
     &:hover .face__kind
     &.face[data-kind="group"]:hover .face__kind,


### PR DESCRIPTION
**Update**
* rebased with master
* description is updated to inlcude result of latest experiment

This PR aims to make the layer selection/expand/collapse/visibility more responsive (UI wise) by promoting the browser's rendering event. Take layer selection as example. Below is the Timeline when select a layer. As you can see, before the browser starts rendering, it has to wait 70ms - 80ms for the Flux cycle and React rendering to be completed. So, what if we use `setState` to trigger React rendering directly, so that the browser can start rendering as soon as possible?
![1](https://cloud.githubusercontent.com/assets/118264/12497106/9de138fc-c04e-11e5-8096-5e436db5f389.png)

Below is the Timeline after applying the `setState` method. We store the layer selection/expand/visibility in component state, and update the state directly to skip the Flux cycle. The result is as expected, the browser render event got promoted. However, the `paint` event did not get promoted along with the render event, which make the optimization useless because the paint event is when the browser actually fill the pixels. 
![2](https://cloud.githubusercontent.com/assets/118264/12497340/13c9ea7c-c050-11e5-94ba-727e110bb001.png)

The next experiment is to promote the paint event as well. Based on my observation, the paint event starts when the scripting engine is idle. Usually A delay of 5ms - 10ms will be enough to nudge the browser paint the update style/layer. Here is the new Timeline:
![3](https://cloud.githubusercontent.com/assets/118264/12497627/cefe9238-c051-11e5-8fca-adb855766c68.png)

Here is the complete evaluation of the optimization.

  | Before   | After | Change
------------- | -------------| ----- | ----
Layer selection | 170ms      | **60ms** | -110ms
AB selection    | 195ms     | **98ms** | -97ms
Collapse AB     | 179ms     | **56ms** | -123ms
Expand AB       | 196ms     | **95ms** | -101ms
Collapse AB (recursively)     | 159ms     | **91ms** | -68ms
Expand AB  (recursively)      | 183ms     | **130ms** | -53ms
AB Visibility   | 186ms     | **110ms** | -76ms
(Numbers are the time needed to complete a frame.)

