### PR TITLE
Delay guide zone highlighting by debouncing

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-addons-pure-render-mixin": "^0.14.2",
     "react-dom": "^0.14.2",
     "scriptjs": "^2.5.8",
-    "spaces-adapter": "adobe-photoshop/spaces-adapter.git#v1.0.0",
+    "spaces-adapter": "adobe-photoshop/spaces-adapter.git#v1.1.0",
     "tinycolor2": "^1.1.2",
     "wolfy87-eventemitter": "^4.3.0"
   }


### PR DESCRIPTION
On mouse over for the guide zones, we call a debounced function that delays highlight of the zone area by 30 ms. At the end of the delay, we use the `OS.getMousePosition` API to make sure the mouse is still over the zone, and otherwise cancel highlighting.

Addresses #3495

Requires https://github.com/adobe-photoshop/spaces-adapter/pull/181 and playground-dev-mac#971 or later. (CL 1059051))

