### PR TITLE
Styles: more efficient browser rendering when mouse over (layers/libraries list)

### DIFF
--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -125,7 +125,6 @@ input[type="text"].face__name, input[type="text"]:disabled.face__name {
 // Selection state
 .face:hover {
     background-color: @list-hover-color;
-    z-index: 99;
     
     input[type="text"], input[type="text"]:disabled {
         color: @item-hover;

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -199,7 +199,7 @@
     }
 
     &__content {
-        flex-shrink: 1;
+        height: 5.4rem;
         flex-grow: 1;
         overflow-y: auto;
         overflow-x: hidden;


### PR DESCRIPTION
This PR improves the browser rendering performance when mouse over layers/libraries list. 

### Layers List
Before the fix, mouse over a layer face will invalidate large number of unrelated layer faces and cause the browser to spend more time on rendering. The fix is removing the style `.face:hover {z-index: 99}`, and my test shows it doesn't cause other style issue.
![layer-panel-hovering-before](https://cloud.githubusercontent.com/assets/118264/12281954/372f0cde-b94f-11e5-8a08-ed3a641f3f88.gif)

After the fix
![layer-panel-hovering-after](https://cloud.githubusercontent.com/assets/118264/12281990/8110d986-b94f-11e5-9a6f-79ee647f4903.gif)


### Liraries List
The cause is related to the flexbox view: with the combination of `flex-shrink:1` and `flex-grow:1`, it seems force the libraries list to reflow when mouse over its children. 
![libraries-before](https://cloud.githubusercontent.com/assets/118264/12282068/2262d276-b950-11e5-8629-f20aa04ce7dc.gif)

After the fix
![libraries-after](https://cloud.githubusercontent.com/assets/118264/12282071/26ea8f82-b950-11e5-930b-98e84ef0407a.gif)

Performance has a significant boost:
Before
![libraries-before](https://cloud.githubusercontent.com/assets/118264/12282095/4f9273d2-b950-11e5-9dbb-632648081ef4.png)
After
![libraries-after](https://cloud.githubusercontent.com/assets/118264/12282082/3ce401b0-b950-11e5-8dad-fce3f3e50aac.png)


