### PR TITLE
Only check for document.guidesVisible in guidesOverlay

### DIFF
--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -24,8 +24,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var Immutable = require("immutable"),
-        React = require("react"),
+    var React = require("react"),
         ReactDOM = require("react-dom"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
@@ -86,8 +85,11 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
+            var visibilityChanged = (this.state.document && this.state.document.guidesVisible) !==
+                (nextState.document && nextState.document.guidesVisible);
+
             return !_.isEqual(this.state.overlaysEnabled, nextState.overlaysEnabled) ||
-                !Immutable.is(this.state.document, nextState.document) ||
+                visibilityChanged ||
                 this.state.tool !== nextState.tool ||
                 this.state.modalState !== nextState.modalState;
         },


### PR DESCRIPTION
While looking at Timeline, I realized that instead of comparing documents (which, admittedly, will always be different), we should just compare the `guidesVisible` property as it's the only thing we care about in GuidesOverlay. 

This change prevents guidesOverlay from being redrawn everytime something happens in the document, helps with performance a little.