### PR TITLE
Changed the color of the libraries dropdown

### DIFF
--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -160,6 +160,7 @@ dialog::backdrop {
     left: 1.1rem;
     margin: -0.1rem 0 0 0;
     box-shadow: none;
+    background: @bg-app;
     
     .select__header {
         padding: 0;


### PR DESCRIPTION
References issue #3406 

Here is what the libraries dropdown looks like in each color stop. Note - the searchbar dropdown and the libraries dropdown are now the same color. 

![](https://www.dropbox.com/s/mhisitld5xr3hj5/Screenshot%202016-01-13%2010.15.58.png?raw=1)
![](https://www.dropbox.com/s/duutdzszvknq187/Screenshot%202016-01-13%2010.15.49.png?raw=1)
![](https://www.dropbox.com/s/3lh99hmkynxnydx/Screenshot%202016-01-13%2010.15.41.png?raw=1)
![](https://www.dropbox.com/s/v9v277h1rnhbnkk/Screenshot%202016-01-13%2010.15.32.png?raw=1)
