### PR TITLE
Guide fixes

### DIFF
--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -154,13 +154,13 @@ define(function (require, exports) {
                     x: canvasBounds.left,
                     y: Math.floor(guideTL.y - policyThickness - 1),
                     width: canvasBounds.right - canvasBounds.left,
-                    height: Math.ceil(policyThickness * 2 + 1)
+                    height: Math.ceil(policyThickness * 2 + 2)
                 };
             } else {
                 guideArea = {
                     x: Math.floor(guideTL.x - policyThickness - 1),
                     y: canvasBounds.top,
-                    width: Math.ceil(policyThickness * 2 + 1),
+                    width: Math.ceil(policyThickness * 2 + 2),
                     height: canvasBounds.bottom - canvasBounds.top
                 };
             }

--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -286,6 +286,10 @@ define(function (require, exports, module) {
                 highlightFound = false,
                 self = this;
 
+            if (self._currentMouseDown) {
+                return;
+            }
+            
             d3.selectAll(".guide-edges").each(function () {
                 var guideZone = d3.select(this),
                     orientation = guideZone.attr("orientation"),


### PR DESCRIPTION
This PR addresses two issues:
#3520 - we make sure to not highlight a guide zone while mouse is down.
#3270 - Increase the right/bottom policy area of guides by one pixel, this allows for symmetrical guide policy zones around the guide.