### PR TITLE
Updated npm-shrinkwrap for sprint 3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,17 +4,17 @@
   "dependencies": {
     "bluebird": {
       "version": "3.1.1",
-      "from": "bluebird@>=3.0.5 <4.0.0",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.1.1.tgz"
     },
     "classnames": {
-      "version": "2.2.1",
-      "from": "classnames@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.1.tgz"
+      "version": "2.2.3",
+      "from": "classnames@2.2.3",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz"
     },
     "d3": {
       "version": "3.5.12",
-      "from": "d3@>=3.5.9 <4.0.0",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.12.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.12.tgz"
     },
     "fluxxor": {
@@ -36,12 +36,12 @@
     },
     "generator-connection": {
       "version": "2.3.0",
-      "from": "git+https://github.com/adobe-photoshop/generator-connection.git#v2.4.0",
+      "from": "git+https://github.com/adobe-photoshop/generator-connection.git#ee383cad86ac4fceb2dc4211c4c2185302ec547d",
       "resolved": "git+https://github.com/adobe-photoshop/generator-connection.git#ee383cad86ac4fceb2dc4211c4c2185302ec547d"
     },
     "immutable": {
       "version": "3.7.6",
-      "from": "immutable@>=3.7.5 <4.0.0",
+      "from": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
     },
     "lodash": {
@@ -55,9 +55,9 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.0.tgz"
     },
     "mathjs": {
-      "version": "2.5.0",
-      "from": "mathjs@>=2.4.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-2.5.0.tgz",
+      "version": "2.6.0",
+      "from": "mathjs@2.6.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-2.6.0.tgz",
       "dependencies": {
         "decimal.js": {
           "version": "4.0.3",
@@ -82,9 +82,9 @@
       }
     },
     "react": {
-      "version": "0.14.3",
-      "from": "react@>=0.14.2 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.14.3.tgz",
+      "version": "0.14.6",
+      "from": "react@0.14.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.6.tgz",
       "dependencies": {
         "envify": {
           "version": "3.4.0",
@@ -128,9 +128,9 @@
           }
         },
         "fbjs": {
-          "version": "0.3.2",
-          "from": "fbjs@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.3.2.tgz",
+          "version": "0.6.1",
+          "from": "fbjs@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
@@ -150,9 +150,9 @@
               }
             },
             "promise": {
-              "version": "7.0.4",
+              "version": "7.1.1",
               "from": "promise@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
@@ -176,19 +176,14 @@
       }
     },
     "react-addons-pure-render-mixin": {
-      "version": "0.14.3",
-      "from": "react-addons-pure-render-mixin@>=0.14.2 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.3.tgz"
+      "version": "0.14.6",
+      "from": "react-addons-pure-render-mixin@0.14.6",
+      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.6.tgz"
     },
     "react-dom": {
-      "version": "0.14.3",
-      "from": "react-dom@>=0.14.2 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
-    },
-    "react-addons-perf": {
-      "version": "0.14.3",
-      "from": "react-dom@>=0.14.2 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react-addons-perf/-/react-addons-perf-0.14.3.tgz"
+      "version": "0.14.6",
+      "from": "react-dom@0.14.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.6.tgz"
     },
     "scriptjs": {
       "version": "2.5.8",
@@ -196,13 +191,13 @@
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.8.tgz"
     },
     "spaces-adapter": {
-      "version": "0.32.0",
-      "from": "git+https://github.com/adobe-photoshop/spaces-adapter.git#v0.32.0",
-      "resolved": "git+https://github.com/adobe-photoshop/spaces-adapter.git#165a74d3f06ca0b1ef6346d08e612063de108e1e",
+      "version": "1.1.0",
+      "from": "git+https://github.com/adobe-photoshop/spaces-adapter.git#v1.1.0",
+      "resolved": "git+https://github.com/adobe-photoshop/spaces-adapter.git#dbe0ca6c04756d659320b918f2fc54265ab33838",
       "dependencies": {
         "qunitjs": {
           "version": "1.20.0",
-          "from": "qunitjs@>=1.20.0 <2.0.0",
+          "from": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.20.0.tgz",
           "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.20.0.tgz"
         }
       }


### PR DESCRIPTION
This is the version of npm-shrinkwrap that was pushed to perforce with the sprint 3.1 release.