### PR TITLE
D3 Overlay shouldComponentUpdate methods

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -228,7 +228,7 @@ module.exports = function (grunt) {
         concurrent: {
             test: ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
             build: {
-                tasks: ["watch:styles", "watch:dictionaries", "webpack:watch"],
+                tasks: ["watch:styles", "watch:dictionaries", "watch:sources", "webpack:watch"],
                 options: {
                     logConcurrentOutput: true
                 }

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -37,19 +37,6 @@ define(function (require, exports, module) {
     var PolicyOverlay = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("policy", "panel")],
 
-        getStateFromFlux: function () {
-            var flux = this.getFlux(),
-                policyStore = flux.store("policy"),
-                panelStore = flux.store("panel"),
-                pointerPolicies = policyStore.getMasterPointerPolicyList(),
-                canvasBounds = panelStore.getCloakRect();
-
-            return {
-                policies: pointerPolicies,
-                canvasBounds: canvasBounds
-            };
-        },
-
         /**
          * D3 element where policies are being drawn
          *
@@ -63,6 +50,25 @@ define(function (require, exports, module) {
          * @type {function()}
          */
         _drawDebounced: null,
+
+        getStateFromFlux: function () {
+            var flux = this.getFlux(),
+                policyStore = flux.store("policy"),
+                panelStore = flux.store("panel"),
+                pointerPolicies = policyStore.getMasterPointerPolicyList(),
+                canvasBounds = panelStore.getCloakRect();
+
+            return {
+                policies: pointerPolicies,
+                canvasBounds: canvasBounds
+            };
+        },
+
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return this.props.transformString !== nextProps.transformString ||
+                this.state.policies !== nextState.policies ||
+                this.state.canvasBounds !== nextState.canvasBounds;
+        },
 
         componentWillMount: function () {
             this._drawDebounced = _.debounce(this.drawOverlay, 100, false);

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
+        Immutable = require("immutable"),
         d3 = require("d3"),
         _ = require("lodash");
 
@@ -124,6 +125,21 @@ define(function (require, exports, module) {
                 leafBounds: leafModifier,
                 vectorMaskMode: vectorMaskMode
             };
+        },
+
+        shouldComponentUpdate: function (nextProps, nextState) {
+            var lastLayers = this.state.document.layers.selected,
+                nextLayers = nextState.document.layers.selected,
+                lastLayerProps = collection.pluckAll(lastLayers, ["id", "bounds"]),
+                nextLayerProps = collection.pluckAll(nextLayers, ["id", "bounds"]),
+                layersChanged = !Immutable.is(lastLayerProps, nextLayerProps);
+
+            return layersChanged ||
+                this.state.marqueeEnabled !== nextState.marqueeEnabled ||
+                this.state.leafBounds !== nextState.leafBounds ||
+                this.state.vectorMaskMode !== nextState.vectorMaskMode ||
+                this.state.modalState !== nextState.modalState ||
+                this.props.transformString !== nextProps.transformString;
         },
 
         componentWillMount: function () {

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -128,18 +128,22 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
+            // We check for the cheaper flags before plucking layers from document models
+            if (this.state.marqueeEnabled !== nextState.marqueeEnabled ||
+                this.state.leafBounds !== nextState.leafBounds ||
+                this.state.vectorMaskMode !== nextState.vectorMaskMode ||
+                this.state.modalState !== nextState.modalState ||
+                this.props.transformString !== nextProps.transformString) {
+                return true;
+            }
+
             var lastLayers = this.state.document.layers.selected,
                 nextLayers = nextState.document.layers.selected,
                 lastLayerProps = collection.pluckAll(lastLayers, ["id", "bounds"]),
                 nextLayerProps = collection.pluckAll(nextLayers, ["id", "bounds"]),
                 layersChanged = !Immutable.is(lastLayerProps, nextLayerProps);
 
-            return layersChanged ||
-                this.state.marqueeEnabled !== nextState.marqueeEnabled ||
-                this.state.leafBounds !== nextState.leafBounds ||
-                this.state.vectorMaskMode !== nextState.vectorMaskMode ||
-                this.state.modalState !== nextState.modalState ||
-                this.props.transformString !== nextProps.transformString;
+            return layersChanged;
         },
 
         componentWillMount: function () {


### PR DESCRIPTION
- For superselect, policy and sampler overlays
- Correct the guides overlay existing SCU
- Change Sampler behavior so it highlgihts/samples leaf layers
- Re-add file watcher that just prints out file changes

Addresses #3491, and some sampler behavior issues.