### PR TITLE
Policy area validation and border update on resize

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -855,8 +855,10 @@ define(function (require, exports) {
             appStore = flux.store("application"),
             uiStore = this.flux.store("ui"),
             toolStore = this.flux.store("tool"),
+            panelStore = this.flux.store("panel"),
             documentLayerBounds,
             activeTool,
+            canvasRectangle,
             uiTransformMatrix;
 
         var throttledResetBorderPolicies =
@@ -871,14 +873,17 @@ define(function (require, exports) {
                 if (currentDocument) {
                     var nextDocumentLayerBounds = currentDocument.layers.selectedChildBounds,
                         newxUiTransformMatrix = uiStore.getCurrentTransformMatrix(),
+                        newCanvasRectangle = panelStore.getCloakRect(),
                         newTool = toolStore.getCurrentTool();
                     
                     if (!Immutable.is(documentLayerBounds, nextDocumentLayerBounds) ||
                             !_.isEqual(uiTransformMatrix, newxUiTransformMatrix) ||
+                            !_.isEqual(canvasRectangle, newCanvasRectangle) ||
                             activeTool !== newTool) {
                         documentLayerBounds = nextDocumentLayerBounds;
                         uiTransformMatrix = newxUiTransformMatrix;
                         activeTool = newTool;
+                        canvasRectangle = newCanvasRectangle;
                         throttledResetBorderPolicies();
                     }
                 } else {
@@ -891,6 +896,7 @@ define(function (require, exports) {
         this.flux.store("application").on("change", _borderPolicyChangeHandler);
         this.flux.store("ui").on("change", _borderPolicyChangeHandler);
         this.flux.store("tool").on("change", _borderPolicyChangeHandler);
+        this.flux.store("panel").on("change", _borderPolicyChangeHandler);
 
         // Listen for modal tool state entry/exit events
         _toolModalStateChangedHandler = this.flux.actions.tools.handleToolModalStateChanged.bind(this);

--- a/src/js/jsx/tools/PolicyOverlay.jsx
+++ b/src/js/jsx/tools/PolicyOverlay.jsx
@@ -105,9 +105,11 @@ define(function (require, exports, module) {
          */
         drawPolicies: function (policies) {
             policies.forEach(function (policy) {
-                if (policy.area) {
-                    var area = policy.area,
-                        policyRect = this._scrimGroup
+                var area = policy.area,
+                    areaIsValid = area && area[2] > 0 && area[3] > 0;
+
+                if (areaIsValid) {
+                    var policyRect = this._scrimGroup
                         .append("rect")
                         .attr("x", area[0])
                         .attr("y", area[1])


### PR DESCRIPTION
For policy overlay, makes sure area trying to be drawn has positive width/height, skips otherwise, this problem manifested itself if user resized the PS app window to the smallest size possible.

For border policy change listener, we also listen to panel store for canvas rectangle size differences, which helps update all policies on resize, if top left stayed put.

Addresses #3351 and #3533