### PR TITLE
Debounce moveToArtboard events with a nonzero delay

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -60,6 +60,12 @@ define(function (require, exports) {
     };
 
     /**
+     * @const
+     * @type {number}
+     */
+    var EVENT_DEBOUNCE_DELAY = 100;
+
+    /**
      * Filter out layers that can't generally be transformed like empty,
      * adjustment and background layers.
      *
@@ -1398,7 +1404,7 @@ define(function (require, exports) {
         _moveToArtboardHandler = synchronization.debounce(function () {
             // Undefined makes it use the most recent document model
             return this.flux.actions.layers.resetIndex(undefined);
-        }, this);
+        }, this, EVENT_DEBOUNCE_DELAY);
 
         descriptor.addListener("transform", _layerTransformHandler);
         descriptor.addListener("move", _layerTransformHandler);


### PR DESCRIPTION
We already debounce the handling of incoming moveToArtboard events from PS, but it currently uses the default delay of zero.  This seems to *occasionally* handle the first event in a series almost immediately, which results in an error in the case of option+drag artboard duplication (see #1613).

background...
After the end of an option+drag gesture, we receive a series of event from PS in this order: moveToArtboard(several), historyState, move.

moveToArtboard is handled simply by calling (debounced) `layers.resetIndex`.  An index reset will fail, however, if it is performed *after* the duplication has occurred in PS but *before* DS has handled the `move: newDuplicateSheets` event.

By adding a 100ms delay, we increase the chance that the the `resetIndex()` will be enqueued after the move event handler.  This is still a bit janky, but it seems like a safe/quick fix for this infrequent pesky error.

