### PR TITLE
Search: placing libraries graphic results in error

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-notifier": "^1.2.1"
   },
   "dependencies": {
-    "bluebird": "^3.0.5",
+    "bluebird": "^3.1.1",
     "classnames": "^2.2.0",
     "d3": "^3.5.9",
     "fluxxor": "^1.7.3",

--- a/src/js/actions/search/libraries.js
+++ b/src/js/actions/search/libraries.js
@@ -146,7 +146,8 @@ define(function (require, exports) {
             switch (elementInfo.type) {
                 case "GRAPHIC":
                     var uiStore = this.flux.stores.ui,
-                        centerOffsets = uiStore.getState().centerOffsets,
+                        panelStore = this.flux.stores.panel,
+                        centerOffsets = panelStore.getState().centerOffsets,
                         midX = (window.document.body.clientWidth + centerOffsets.left - centerOffsets.right) / 2,
                         midY = (window.document.body.clientHeight + centerOffsets.top - centerOffsets.bottom) / 2,
                         location = uiStore.transformWindowToCanvas(midX, midY);


### PR DESCRIPTION
Fix: search for libraries graphic and hit return to place any graphic will result in error. 

I fixed this earlier but got distracted by a bluebird@3.0.6 bug (https://github.com/petkaantonov/bluebird/issues/841) which will silent unhandled errors and exceptions (error is not shown in the console). Now it has been fixed in 3.1.0 and I saw we are already using 3.1.1 in `npm-shrinkwrap.json`, so the problem no longer exists. 
