### PR TITLE
Babel, generator package updates

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
     },
     "classnames": {
       "version": "2.2.3",
-      "from": "classnames@2.2.3",
+      "from": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz"
     },
     "d3": {
@@ -19,25 +19,25 @@
     },
     "fluxxor": {
       "version": "1.7.3",
-      "from": "fluxxor@>=1.7.3 <2.0.0",
+      "from": "https://registry.npmjs.org/fluxxor/-/fluxxor-1.7.3.tgz",
       "resolved": "https://registry.npmjs.org/fluxxor/-/fluxxor-1.7.3.tgz",
       "dependencies": {
         "eventemitter3": {
           "version": "0.1.6",
-          "from": "eventemitter3@>=0.1.5 <0.2.0",
+          "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
         },
         "object-path": {
           "version": "0.6.0",
-          "from": "object-path@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz"
         }
       }
     },
     "generator-connection": {
-      "version": "2.3.0",
-      "from": "git+https://github.com/adobe-photoshop/generator-connection.git#ee383cad86ac4fceb2dc4211c4c2185302ec547d",
-      "resolved": "git+https://github.com/adobe-photoshop/generator-connection.git#ee383cad86ac4fceb2dc4211c4c2185302ec547d"
+      "version": "2.4.0",
+      "from": "adobe-photoshop/generator-connection#v2.4.0",
+      "resolved": "git://github.com/adobe-photoshop/generator-connection.git#944ee65ec36a2edb04c84f09746b9f6a6464fce7"
     },
     "immutable": {
       "version": "3.7.6",
@@ -46,79 +46,79 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@>=3.10.1 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "loglevel": {
       "version": "1.4.0",
-      "from": "loglevel@>=1.4.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.0.tgz"
     },
     "mathjs": {
       "version": "2.6.0",
-      "from": "mathjs@2.6.0",
+      "from": "https://registry.npmjs.org/mathjs/-/mathjs-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-2.6.0.tgz",
       "dependencies": {
         "decimal.js": {
           "version": "4.0.3",
-          "from": "decimal.js@>=4.0.2 <5.0.0",
+          "from": "https://registry.npmjs.org/decimal.js/-/decimal.js-4.0.3.tgz",
           "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-4.0.3.tgz"
         },
         "fraction.js": {
           "version": "3.0.0",
-          "from": "fraction.js@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/fraction.js/-/fraction.js-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-3.0.0.tgz"
         },
         "tiny-emitter": {
           "version": "1.0.2",
-          "from": "tiny-emitter@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz"
         },
         "typed-function": {
           "version": "0.10.3",
-          "from": "typed-function@>=0.10.3 <0.11.0",
+          "from": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.3.tgz"
         }
       }
     },
     "react": {
       "version": "0.14.6",
-      "from": "react@0.14.6",
+      "from": "https://registry.npmjs.org/react/-/react-0.14.6.tgz",
       "resolved": "https://registry.npmjs.org/react/-/react-0.14.6.tgz",
       "dependencies": {
         "envify": {
           "version": "3.4.0",
-          "from": "envify@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.4 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "jstransform": {
               "version": "10.1.0",
-              "from": "jstransform@>=10.0.1 <11.0.0",
+              "from": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "base62@0.1.1",
+                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "source-map@0.1.31",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -129,46 +129,46 @@
         },
         "fbjs": {
           "version": "0.6.1",
-          "from": "fbjs@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             },
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
                   "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
                 }
               }
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@>=7.0.3 <8.0.0",
+              "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
-                  "from": "asap@>=2.0.3 <2.1.0",
+                  "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
                 }
               }
             },
             "ua-parser-js": {
               "version": "0.7.10",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "from": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz",
               "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
             },
             "whatwg-fetch": {
               "version": "0.9.0",
-              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
             }
           }
@@ -177,23 +177,23 @@
     },
     "react-addons-pure-render-mixin": {
       "version": "0.14.6",
-      "from": "react-addons-pure-render-mixin@0.14.6",
+      "from": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.6.tgz",
       "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.6.tgz"
     },
     "react-dom": {
       "version": "0.14.6",
-      "from": "react-dom@0.14.6",
+      "from": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.6.tgz",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.6.tgz"
     },
     "scriptjs": {
       "version": "2.5.8",
-      "from": "scriptjs@>=2.5.8 <3.0.0",
+      "from": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.8.tgz",
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.8.tgz"
     },
     "spaces-adapter": {
       "version": "1.1.0",
-      "from": "git+https://github.com/adobe-photoshop/spaces-adapter.git#v1.1.0",
-      "resolved": "git+https://github.com/adobe-photoshop/spaces-adapter.git#dbe0ca6c04756d659320b918f2fc54265ab33838",
+      "from": "adobe-photoshop/spaces-adapter#v1.1.0",
+      "resolved": "git://github.com/adobe-photoshop/spaces-adapter.git#dbe0ca6c04756d659320b918f2fc54265ab33838",
       "dependencies": {
         "qunitjs": {
           "version": "1.20.0",
@@ -204,12 +204,12 @@
     },
     "tinycolor2": {
       "version": "1.3.0",
-      "from": "tinycolor2@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.3.0.tgz"
     },
     "wolfy87-eventemitter": {
       "version": "4.3.0",
-      "from": "wolfy87-eventemitter@>=4.3.0 <5.0.0",
+      "from": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-4.3.0.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "homepage": "https://github.com/adobe-photoshop/spaces-design",
   "devDependencies": {
-    "babel-core": "^6.1.2",
-    "babel-loader": "volfied/babel-loader",
-    "babel-preset-react": "^6.1.2",
+    "babel-core": "^6.4.0",
+    "babel-loader": "^6.2.1",
+    "babel-preset-react": "^6.3.13",
     "es6-promise": "^3.0.2",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "expose-loader": "^0.7.1",


### PR DESCRIPTION
1. The shrinkwrapped version of generator-connection was behind the version in package.json by a minor step. This updates the shrinkwrap to fix that. I don't know why npm chooses a different format for the "from" line in the shrinkwrap file sometimes.... I think it's harmless, but maybe @mcilroyc knows.
2. The the `babel-loader` dependency has been switched from @volfied's fork back to the main repository. I noticed a few weeks ago that the main project had incorporated the small fix from @volfied's branch. I also updated and tested the other babel dependencies while I was in there.