### PR TITLE
Automate layer panel performance test 

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -267,6 +267,156 @@ define(function (require, exports) {
     };
 
     /**
+     * Run layer panel performance tests.   
+     *
+     * @private
+     * @return {Promise}
+     */
+    var layerPanelPerformanceTest = function () {
+        var flux = this.flux,
+            applicationStore = flux.store("application"),
+            document = applicationStore.getCurrentDocument(),
+            openDocuments = applicationStore.getOpenDocuments();
+
+        if (openDocuments.size !== 1 || !document.name.match(/vermilion/i)) {
+            window.alert(
+                "To run the performance test, the current document must be " +
+                "the Vermilion file, and there should be only one open document");
+            return Promise.resolve();
+        }
+
+        var continueTest = window.confirm("Please start the Timeline recording, and then hit OK to begin the test.");
+
+        if (!continueTest) {
+            return Promise.resolve();
+        }
+
+        // Mute the other time stamps to make the timeline cleaner.
+        var timeStamp = log.timeStamp;
+        log.timeStamp = _.noop;
+
+        var layerFaceElements,
+            artboardElement,
+            artboardIconElement,
+            artboardVisibilityElement,
+            delayBetweenTest = 1500,
+            artboards = document.layers.roots.map(function (root) {
+                return document.layers.byID(root.id);
+            });
+
+        return flux.actions.groups.setGroupExpansion(document, artboards, true, true)
+            .then(function () {
+                flux.actions.layers.deselectAll(document);
+            })
+            .then(function () {
+                layerFaceElements = window.document.querySelectorAll(".face__depth-6");
+                artboardElement = window.document.querySelector(".face__depth-0");
+                artboardIconElement = window.document.querySelector(".face__depth-0 .face__kind");
+                artboardVisibilityElement = window.document.querySelector(".face__depth-0 .face__button_visibility");
+                layerFaceElements[0].scrollIntoViewIfNeeded();
+            })
+            // Test Layer Selection
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Layer selection 1");
+                layerFaceElements[0].click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Layer selection 2");
+                layerFaceElements[1].click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Layer selection 3");
+                layerFaceElements[2].click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Layer selection 4");
+                layerFaceElements[3].click();
+            })
+            .delay(delayBetweenTest)
+            // Test Art board Selection
+            .then(function () {
+                artboardElement.scrollIntoViewIfNeeded();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board selection 1");
+                artboardElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board deselection 1");
+                layerFaceElements[0].click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board selection 2");
+                artboardElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board deselection 2");
+                layerFaceElements[0].click();
+            })
+            .delay(delayBetweenTest)
+            // Test Art board expand/collapse
+            .then(function () {
+                timeStamp("Art board collapse 1");
+                artboardIconElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board expand 1");
+                artboardIconElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board collapse 2");
+                artboardIconElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board expand 2");
+                artboardIconElement.click();
+            })
+            .delay(delayBetweenTest)
+            // Test Art board visibility
+            .then(function () {
+                timeStamp("Art board not-visible 1");
+                artboardVisibilityElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board visible 1");
+                artboardVisibilityElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board not-visible 2");
+                artboardVisibilityElement.click();
+            })
+            .delay(delayBetweenTest)
+            .then(function () {
+                timeStamp("Art board visible 2");
+                artboardVisibilityElement.click();
+            })
+            .delay(delayBetweenTest)
+            // Done
+            .finally(function () {
+                timeStamp("End of test");
+                log.timeStamp = timeStamp;
+                window.alert("Please stop recording and check for the result");
+            });
+    };
+    layerPanelPerformanceTest.action = {
+        reads: [],
+        writes: []
+    };
+
+    /**
      * Resolve an action path into a callable action function
      *
      * @private
@@ -535,6 +685,7 @@ define(function (require, exports) {
     exports.transferFailure = transferFailure;
     exports.resetFailure = resetFailure;
     exports.corruptModel = corruptModel;
+    exports.layerPanelPerformanceTest = layerPanelPerformanceTest;
     exports.resetRecess = resetRecess;
     exports.handleExecutedPlaceCommand = handleExecutedPlaceCommand;
     exports._playMenuCommand = _playMenuCommand;

--- a/src/nls/en/menu.json
+++ b/src/nls/en/menu.json
@@ -234,6 +234,7 @@
         "TRANSFER_FAILURE": "Test Transfer Failure…",
         "RESET_FAILURE": "Test Reset Failure…",
         "CORRUPT_MODEL": "Test Model Corruption…",
+        "LAYER_PANEL_PERFORMANCE_TEST": "Test Layer Panel Performance",
         "UPDATE_CURRENT_DOCUMENT": "Update Current Document",
         "RESET_RECESS": "Reset Design Space",
         "TOGGLE_POLICY_FRAMES": "Show Policy Frames",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -491,6 +491,10 @@
             "$action": "menu.corruptModel",
             "$enable-rule": "always-except-modal"
         },
+        "LAYER_PANEL_PERFORMANCE_TEST": {
+            "$action": "menu.layerPanelPerformanceTest",
+            "$enable-rule": "always-except-modal"
+        },
         "UPDATE_CURRENT_DOCUMENT": {
             "$action": "documents.updateDocument",
             "$enable-rule": "have-document"

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -763,6 +763,10 @@
                     "debug": true
                 },
                 {
+                    "id": "LAYER_PANEL_PERFORMANCE_TEST",
+                    "debug": true
+                },
+                {
                     "separator": true,
                     "debug": true
                 },

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -742,6 +742,10 @@
                     "debug": true
                 },
                 {
+                    "id": "LAYER_PANEL_PERFORMANCE_TEST",
+                    "debug": true
+                },
+                {
                     "separator": true,
                     "debug": true
                 },


### PR DESCRIPTION
This PR adds the ability to run layer panel performance test automatically. The test is accessiable via the menu item `Help > Test Layer Panel Performance`. It works for the flat and hierarchical structure in the LayerPanel. Here is a video of how it works https://www.dropbox.com/s/slalhpmhjjf9a9o/layer-panel-performance-test.mov?dl=0

Benefits of adding the task:

* It includes most testing scenarios (layer selection, art board selection, collapse/expand/visibility), and we can add more in the future.
* It is easeir for us to keep monitoring the performance in each spring.
* It saves time!

PS: would it be a good idae to move the developer snippets into the menu item as well? Maybe under the menu item call `Snippets`?

