### PR TITLE
Pass valid modifier to select from marqueeselect

### DIFF
--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -702,7 +702,7 @@ define(function (require, exports) {
         }
         
         var layers = Immutable.List(ids.map(doc.layers.byID.bind(doc.layers))),
-            modifier = add ? "add" : undefined;
+            modifier = add ? "add" : "select";
 
         if (layers.isEmpty() && !add) {
             _logSuperselect("marqueeDeselect");


### PR DESCRIPTION
Addresses #3547 

I made the modifier explicit, but forgot to set it during marquee select without shift.