### PR TITLE
Format non-finite values in NumberInput

### DIFF
--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
     var Focusable = require("../mixin/Focusable"),
         math = require("js/util/math"),
         collection = require("js/util/collection"),
-        headlights = require("js/util/headlights");
+        headlights = require("js/util/headlights"),
+        log = require("js/util/log");
 
     var NumberInput = React.createClass({
         mixins: [Focusable, FluxMixin],
@@ -187,14 +188,25 @@ define(function (require, exports, module) {
                 }
             }
 
+            var formattedValue;
             switch (typeof value) {
             case "number":
-                return String(mathjs.round(value, this.props.precision)) + this.props.suffix;
+                if (_.isFinite(value)) {
+                    formattedValue = String(mathjs.round(value, this.props.precision)) + this.props.suffix;
+                } else {
+                    formattedValue = "";
+                    log.warn("Non-finite value in NumberInput: ", value);
+                }
+                break;
             case "string":
-                return value + this.props.suffix;
+                formattedValue = value + this.props.suffix;
+                break;
             default:
-                return "";
+                formattedValue = "";
+                log.warn("Non-finite value in NumberInput: ", value);
             }
+
+            return formattedValue;
         },
 
         /**


### PR DESCRIPTION
Currently `NumberInput` throws if its value is a non-finite number. It's hard to prevent this from ever happening, so instead I'm just changing `NumberInput` to format a non-finite number as the empty string instead of throwing.

This is vaguely related to #3542.

