### PR TITLE
For scrubbing position, use absolute values

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -449,7 +449,7 @@ define(function (require, exports) {
         var dispatchPromise = this.dispatchAsync(events.document.history.REPOSITION_LAYERS, payload),
             translateLayerActions = layerSpec.reduce(function (actions, layer) {
                 var layerActions = _getMoveLayerActions.call(this,
-                        document, layer, position, refPoint, payload.positions, !options.coalesce);
+                        document, layer, position, refPoint, payload.positions, !!options.translate);
                 return actions.concat(layerActions);
             }, Immutable.List(), this);
 


### PR DESCRIPTION
While scrubbing, we would wrongfully pass the `coalesce` flag as the `translate` flag into `_getMoveLayerActions`, this was causing all scrubs besides the first one to be absolute, and cause the issue seen in #3536 

To fix this issue, I first fixed the flag being passed while scrubbing. However, we still had the problems that if we set absolute position while scrubbing, we would get huge jumps as the layer is being scrubbed across artboard boundaries. So we now use the absolute bounds of the layer to calculate where to scrub it next, which correctly scrubs the layer across boundaries.

Addresses #3536 