### PR TITLE
Handle cmd+q quit gracefully, and a new action flag to prevent reset on failure

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -746,7 +746,8 @@ define(function (require, exports) {
         reads: [locks.JS_DOC],
         writes: [],
         transfers: [initializeLayers],
-        modal: true
+        modal: true,
+        allowFailure: true
     };
 
     /**


### PR DESCRIPTION
This PR is written to address #3541, but also implements a new action property. 

When user tries to quit Photoshop with dirty documents open, Photoshop pops up a modal dialog asking user if they want to save, not save, or cancel. There are multiple pathways this can take based on current open documents:

 - Asterisks imply dirty document which will pop the prompt):
 - Cases I don't account for are already handled well / are sub cases

## *Untitled-1 | *Untitled-2

 1. Don't Save Untitled-2 | Cancel Untitled-1

In this case we get a close event from Photoshop with saving:no field for Untitled-2, and nothing else. Which at this point we dispose of the Untitled-2 document in our models and continue

 2. Save Untitled-2 | Cancel Untitled-1

In this case, PS sends us a close event with saving:yes, a save event, and then another close event with saving:no. This is very unexpected, and the first event is equivalent of the next two events. **So as a solution, we ignore `close` events with saving:yes**

## Reason for `allowFailure` flag

This flag was added to action objects, because of this scenario, where it's done quick enough:

1. Create a new document, dirty it (Untitled-1)
2. Create a new document (Untitled-2)
3. Create a new document, dirty it (Untitled-3)
4. Quit Photoshop and click Don't Save really fast

In this scenario, since `initializeLayersBackground` for Untitled-3 is run `whenIdle`. And because Quit dialog is modal, by the time we cancel, Untitled-3 is already gone from Photoshop, the layer get calls to Photoshop fail with an `Unknown exception type`. 

So this error is expected, but should not reset the controller, since it doesn't affect anything. Close events later get emitted to us, where we dispose of our models correctly.

**Side note:** I wanted to keep `allowFailure` as simple and un-intrusive as possible, so during transfers, the parent's flag gets passed down to the transferred functions. This allows us to specify only one action to not reset on failure instead of the entire transfer chain.