### PR TITLE
Fix layers panel width

### DIFF
--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
             }
             
             return (
-                <ul className="layers-group">
+                <ul className="layer-group">
                     {layerFaces}
                 </ul>
             );

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -140,7 +140,7 @@ input[type="text"].face__name:focus {
 }
 
 // Layer Group collapsed state
-.layer-group__collapsed > .layers-group{
+.layer-group__collapsed > .layer-group{
     display: none;
 }
 


### PR DESCRIPTION
This fixes a classname typo in `LayerGroup`: `layers-group` should be `layer-group`.

Addresses #3559.