### PR TITLE
Add bottom dialog pointer to color picker and fix positioning

### DIFF
--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -254,17 +254,16 @@ define(function (require, exports, module) {
                         offsetParentBounds = this._target.offsetParent.getBoundingClientRect(),
                         placedDialogTop = Math.round(targetBounds.bottom) - Math.round(offsetParentBounds.top),
                         placedDialogBottom = placedDialogTop + Math.round(dialogBounds.height),
+                        pointerAbove = false,
+                        pointerBelow = false,
                         topPosition,
-                        bottomPosition,
-                        placedAbove;
+                        bottomPosition;
                     
                     // If there is space below the target, place the dialog below.
                     if (placedDialogBottom <= clientHeight) {
-                        placedAbove = false;
+                        pointerAbove = true;
                         topPosition = placedDialogTop + "px";
                     } else {
-                        placedAbove = true;
-                        
                         // Need to account for element margin
                         var dialogComputedStyle = window.getComputedStyle(dialogEl),
                             dialogMarginTop = math.pixelDimensionToNumber(dialogComputedStyle.marginTop),
@@ -272,8 +271,10 @@ define(function (require, exports, module) {
 
                         // If there is space above the target, let's place the dialog above it
                         if (dialogBounds.height + dialogMarginTop + dialogMarginBottom < targetBounds.top) {
-                            bottomPosition = (clientHeight - targetBounds.top - dialogMarginBottom) + "px";
+                            pointerBelow = true;
+                            topPosition = (targetBounds.top - dialogBounds.height) + "px";
                         } else {
+                            // Otherwise, it floats with no pointers at top or bottom
                             topPosition = (clientHeight -
                                 dialogBounds.height - dialogMarginTop - dialogMarginBottom) + "px";
                         }
@@ -282,7 +283,8 @@ define(function (require, exports, module) {
                     this.setState({
                         "topPosition": topPosition,
                         "bottomPosition": bottomPosition,
-                        "placedAbove": placedAbove
+                        "pointerAbove": pointerAbove,
+                        "pointerBelow": pointerBelow
                     });
                 } else {
                     throw new Error("Could not determine target by which to render this dialog: " + this.displayName);
@@ -358,8 +360,10 @@ define(function (require, exports, module) {
         render: function () {
             var children,
                 globalClass = (this.props.position === POSITION_METHODS.CENTER) ? "dialog__center" : "dialog__target",
+                // We reverse the pointerAbove/Below classes as they remove the dialog pointer rather than add it
                 classes = classnames(globalClass, this.props.className || "",
-                    { "placed-above": this.state.placedAbove }),
+                    { "hide-bottom-pointer": !this.state.pointerBelow },
+                    { "hide-top-pointer": !this.state.pointerAbove }),
                 props = {
                     className: classes,
                     style: {

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -383,7 +383,7 @@
     width: 100%;
     
     &:before {
-        .dialog-pointer(5.4rem);
+        .dialog-pointer(5.4rem, true);
     }
 }
 

--- a/src/style/shared/color-picker.less
+++ b/src/style/shared/color-picker.less
@@ -99,11 +99,19 @@
     justify-content: flex-end;
     overflow: visible;
     &:before {
-        .dialog-pointer(1.6rem);
+        .dialog-pointer(1.6rem, true);
+    }
+
+    &:after {
+        .dialog-pointer(1.6rem, false);
     }
     
-    &.placed-above:before {
+    &.hide-top-pointer:before {
         display: none;
+    }
+
+    &.hide-bottom-pointer:after {
+        display: none
     }
 }
 

--- a/src/style/shared/dialog.less
+++ b/src/style/shared/dialog.less
@@ -190,10 +190,20 @@ dialog::backdrop {
     width: 100%;
 }
 
-.dialog-pointer(@left) {
+.pointerMixin (@atTop) when (@atTop) {
+    top: -0.9rem;
+    transform: rotate(45deg);
+}
+
+.pointerMixin (@atTop) when (default()) {
+    bottom: -0.9rem;
+    transform: rotate(-135deg);
+}
+
+.dialog-pointer(@left, @atTop) {
+    .pointerMixin(@atTop);
     content: "";
     position: absolute;
-    top: -0.9rem;
     left: @left;
     width: 1.5rem;
     height: 1.5rem;
@@ -202,7 +212,6 @@ dialog::backdrop {
     border-left: @hairline*1.5 solid @underlines;
     border-top: @hairline*1.5 solid @underlines;
     border-top-left-radius: 0.2rem;
-    transform: rotate(45deg);
     -webkit-clip-path: polygon(0% 0%, 1.8rem 0%, 0% 1.8rem);
 }
 


### PR DESCRIPTION
Using [CSS Mixin Guards](http://lesscss.org/features/#mixin-guards-feature), we now position the dialog pointer either at the top or the bottom of color picker dialog.

Also, addressing #3550, we now position the color picker correctly when there is no room below the clicked color input and color picker appears above it.