### PR TITLE
Reload style watcher on changes so fails don't stop it

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,7 +165,8 @@ module.exports = function (grunt) {
                 tasks: ["less"],
                 options: {
                     spawn: false,
-                    interrupt: true
+                    interrupt: true,
+                    reload: true
                 }
             },
             dictionaries: {


### PR DESCRIPTION
Addresses #3567, re-starting less watcher every time files change so it doesn't stop working after an error.

Since less does not do incremental re-build, there is no loss from restarting it.