### PR TITLE
Layer Panel: fix style issues

### DIFF
--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -82,14 +82,10 @@
 
 input[type="text"].face__name {
     font-size: 1.2rem;
-    color: @item-active;
+    color: @item;
     margin-top: -0.1rem;
     width: 100%;
-}
-
-input[type="text"].face__name:focus {
     border-bottom: solid @hairline @focus-highlight;
-    color: @item;
     -webkit-user-select: text;
 }
 
@@ -118,16 +114,6 @@ input[type="text"].face__name:focus {
     .face__name, 
     &:hover .face__name {
         color: @item;
-    }
-    
-    input[type="text"].face__name {
-        border-bottom: solid @hairline transparent;
-    }
-
-    input[type="text"].face__name:focus  {
-        border-bottom: solid @hairline @focus-highlight;
-        color: @item;
-        -webkit-user-select: text;
     }
 }
 

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -73,7 +73,7 @@
     flex-grow: 1;
     flex-shrink: 1;
     -webkit-user-select: none;
-    white-space: nowrap;
+    white-space: pre;
     text-overflow: ellipsis;
     overflow-x: hidden;
     height: 2rem;
@@ -83,7 +83,7 @@
 input[type="text"].face__name {
     font-size: 1.2rem;
     color: @item;
-    margin-top: -0.1rem;
+    margin-top: -0.2rem;
     width: 100%;
     border-bottom: solid @hairline @focus-highlight;
     -webkit-user-select: text;
@@ -175,4 +175,31 @@ input[type="text"].face__name {
 
 .layer__drag-target {
     padding-top: 2.8rem;
+}
+
+// Fix Chrome's rendering bug when layer's height has decimal. 
+// The updated number is the nearest pixel to the original.
+// 
+// For non-retina @base-8, retina @base-8/@base-9
+@media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 801px) and (max-device-width: 1440),
+(-webkit-min-device-pixel-ratio: 2) and (min-device-width: 801px) and (max-device-width: 1680) {
+    .face {
+        height: 25px; // from 25.1875px to 25px
+        min-height: 25px;
+    }
+    
+    input[type="text"].face__name {
+        margin-top: -1px;
+    }
+}
+// For retina @base-11
+@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) {
+    .face {
+        height: 31px; // from 30.815px to 31px
+        min-height: 31px;
+    }
+    
+    input[type="text"].face__name {
+        margin-top: -3px;
+    }
 }

--- a/src/style/sections/layers/face.less
+++ b/src/style/sections/layers/face.less
@@ -76,7 +76,8 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow-x: hidden;
-    padding: 0.2rem 0;
+    height: 2rem;
+    padding: 0.4rem 0;
 }
 
 input[type="text"].face__name {


### PR DESCRIPTION
This PR fix the following style issues:

#3558 Descenders are clipped a little in Layer names on Retina. Happens on some layer elements when `font-size` is `@base-8` (when `device-width <= 1440px`). 

<img width="280" alt="screen shot 2016-01-19 at 5 29 40 pm" src="https://cloud.githubusercontent.com/assets/118264/12437371/4c939990-bed2-11e5-910d-f1b0bbe0110f.png">
(the first line is not clipped, the sconed one is clipped slightly)

Another issue I found was that when element's height has decimal  (e.g. 25.1875px), their layout may be inconsistent in the screen. The picture below demonstrate the problem.

<img width="300" alt="after" src="https://cloud.githubusercontent.com/assets/118264/12437465/04e2dd80-bed3-11e5-9722-d44bd1d7d1d3.png">
(when face's height is 25.1875px, the two folder icons has different relative position)

<img width="297" alt="after-fixed" src="https://cloud.githubusercontent.com/assets/118264/12437683/c7b84dda-bed4-11e5-9133-130c19a74015.png">
(If change height to 25px, everything looks fine.)

As a result, when double-click to edit title, some input will shift up by 1px.
![layer-panel-offset](https://cloud.githubusercontent.com/assets/118264/12437454/ee370dc2-bed2-11e5-844e-57f561f3013f.gif)

I cannot find an easy way to fix this, except for using the `@media` rule to tweak the face's rem height for a rounded pixel number in different screen resolution. @designedbyscience can you review and let me know if you will approve the solution? :hammer: 