### PR TITLE
Anticipate null documents in SuperselectOverlay and ArtboardAdderOvelay

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -128,6 +128,15 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
+            var getProps = function (state) {
+                var document = state.document;
+                if (!document || !document.layers) {
+                    return null;
+                }
+
+                return collection.pluckAll(document.layers.selected, ["id", "bounds"]);
+            };
+
             // We check for the cheaper flags before plucking layers from document models
             if (this.state.marqueeEnabled !== nextState.marqueeEnabled ||
                 this.state.leafBounds !== nextState.leafBounds ||
@@ -137,13 +146,10 @@ define(function (require, exports, module) {
                 return true;
             }
 
-            var lastLayers = this.state.document.layers.selected,
-                nextLayers = nextState.document.layers.selected,
-                lastLayerProps = collection.pluckAll(lastLayers, ["id", "bounds"]),
-                nextLayerProps = collection.pluckAll(nextLayers, ["id", "bounds"]),
-                layersChanged = !Immutable.is(lastLayerProps, nextLayerProps);
+            var lastLayerProps = getProps(this.state),
+                nextLayerProps = getProps(nextState);
 
-            return layersChanged;
+            return !Immutable.is(lastLayerProps, nextLayerProps);
         },
 
         componentWillMount: function () {


### PR DESCRIPTION
Recent overlays changes caused them to throw in `shouldComponentUpdate` when the document state is null. This would happen when the controller resets, which causes all unhandled errors to be unrecoverable errors. The intent of this change is just to handle that additional case more gracefully.

Addresses #3561.