### PR TITLE
Don't handle a history event if document is not current

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -726,6 +726,7 @@ define(function (require, exports) {
      */
     var initFontList = function (force) {
         var fontStore = this.flux.store("font"),
+            historyStore = this.flux.store("history"),
             fontState = fontStore.getState(),
             initialized = fontState.initialized;
 
@@ -761,7 +762,7 @@ define(function (require, exports) {
                     .getOpenDocuments()
                     .filter(function (document) {
                         // Skip uninitialized documents
-                        return document.layers;
+                        return document.layers && historyStore.hasInitializedHistory(document.id);
                     })
                     .map(function (document) {
                         var layers = document.layers.all,

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -131,6 +131,16 @@ define(function (require, exports, module) {
         },
 
         /**
+         * Checks to see if a history log exists for the given document
+         *
+         * @param {number} documentID
+         * @return {boolean}
+         */
+        hasInitializedHistory: function (documentID) {
+            return this._history.has(documentID);
+        },
+
+        /**
          * Is there a next state which has a valid document model
          * TODO this could use an isValid boolean on the HistoryState?
          *
@@ -644,7 +654,8 @@ define(function (require, exports, module) {
                     nextState;
 
                 if (!history || !currentState || current < 0) {
-                    throw new Error("Could not amend history, document not properly initialized: " + documentID);
+                    log.warn("[History] Could not amend history, document history not found: " + documentID);
+                    return;
                 }
 
                 nextState = currentState.merge(stateProps);


### PR DESCRIPTION
When we open multiple documents at once, we get multiple `open` and `historyState` events. When we try to handle the `historyState` events for the non-active documents, because they're not allocated/initialized yet, `_handleHistoryAmendment` fails. With this PR, we check to make sure the history we're amending is of the active document.

This works for the other documents, because during allocation we initialize history. Addresses #3510