### PR TITLE
Fix a duplicate menu entry on Windows.

### DIFF
--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -730,7 +730,7 @@
                     "debug": true
                 },
                 {
-                    "id": "RESET_FAILURE",
+                    "id": "TRANSFER_FAILURE",
                     "debug": true
                 },
                 {


### PR DESCRIPTION
There are two `Help > Test Reset Failure` entries on Windows. One should instead be `Help > Test Transfer Failure`.

Addresses #3579.

Over to @chadrolfs to test and merge.

