### PR TITLE
Fix scrubbing on no layers / failures

### DIFF
--- a/src/js/jsx/mixin/Scrubby.js
+++ b/src/js/jsx/mixin/Scrubby.js
@@ -95,6 +95,7 @@ define(function (require, exports, module) {
             window.document.addEventListener("touchmove", this._handleScrubMove);
             window.document.addEventListener("mouseup", this._stopScrubUpdates);
             window.document.addEventListener("touchend", this._stopScrubUpdates);
+            this.getFlux().store("application").on("reset", this._resetScrubbing);
         },
 
         /**
@@ -107,6 +108,19 @@ define(function (require, exports, module) {
             window.document.removeEventListener("touchmove", this._handleScrubMove);
             window.document.removeEventListener("mouseup", this._stopScrubUpdates);
             window.document.removeEventListener("touchend", this._stopScrubUpdates);
+            this.getFlux().store("application").off("reset", this._resetScrubbing);
+        },
+
+        /**
+         * Resets the scrubbing flag to avoid unwanted
+         * scrub calls after a reset
+         *
+         * @private
+         */
+        _resetScrubbing: function () {
+            this.setState({
+                scrubbing: false
+            });
         },
 
         /**

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -139,11 +139,11 @@ define(function (require, exports, module) {
         _handleWScrubBegin: function () {
             var currentWidth = collection.uniformValue(this.state.widths);
             
-            if (currentWidth !== null) {
-                this.setState({
-                    scrubWidth: currentWidth
-                });
+            this.setState({
+                scrubWidth: currentWidth
+            });
 
+            if (currentWidth !== null) {
                 this.startCoalescing();
             }
         },
@@ -190,11 +190,11 @@ define(function (require, exports, module) {
         _handleHScrubBegin: function () {
             var currentHeight = collection.uniformValue(this.state.heights);
             
-            if (currentHeight !== null) {
-                this.setState({
-                    scrubHeight: currentHeight
-                });
+            this.setState({
+                scrubHeight: currentHeight
+            });
 
+            if (currentHeight !== null) {
                 this.startCoalescing();
             }
         },

--- a/src/js/stores/application.js
+++ b/src/js/stores/application.js
@@ -79,6 +79,7 @@ define(function (require, exports, module) {
             this._hostVersion = null;
             this._recentFiles = Immutable.List();
             this._initialized = Immutable.Set();
+            this.emit("reset");
         },
         
         getState: function () {


### PR DESCRIPTION
#3563 is addressed with dcb4575, where we set the scrub value to null so we skip scrubbing it.

Either way, when scrub failed, the scrubby state would never be reset, causing extra mouse moves to keep things broken. 2a2cd70 fixes that by listening to `"reset"` events from application store, which gets emitted when controller resets.