### PR TITLE
Libraries panel: style issues

### DIFF
--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -37,6 +37,9 @@
     }
 
     .split-button__item {
+        width: @libraries-button-size;
+        flex-grow: 0;
+        flex-shrink: 0;
         svg {
             width: @libraries-button-size;
             height: @libraries-button-size;
@@ -126,7 +129,6 @@
                 justify-content: flex-end;
                 margin: 0;
                 margin-left: 1.5rem;
-                flex-grow: 0;
             }
 
             .libraries__split-button-collaborate {
@@ -244,8 +246,7 @@
         display: flex;
         flex-direction: row;
         align-items: center;
-        padding-top: .3rem;
-        padding-bottom: .3rem;
+        padding: .3rem 0;
         padding-left: 0rem;
         -webkit-user-select: none;
         cursor: pointer;
@@ -271,7 +272,7 @@
 
         &__title {
             display: flex;
-            flex-grow: 1;
+            flex-grow: 100;
             flex-shrink: 1;
             flex-direction: column;
             justify-content: center;
@@ -282,34 +283,29 @@
             min-width: 0;
 
             &__main {
+                line-height: 2rem;
+                height: 2rem;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 overflow: hidden;
+                margin-right: 0.5rem;
+                margin-top: -@hairline;
+                white-space: pre;
             }
 
             input[type="text"] {
                 font-size: @text-small;
-                color: @item-active;
+                color: @item;
                 -webkit-user-select: none;
-                border-bottom: @hairline solid transparent;
-                margin-left: -0.1rem;
-
-                &:focus, &:focus:hover {
-                    align-self: stretch;
-                    color: @item;
-                    -webkit-user-select: none;
-                    border-bottom: @hairline solid @focus-highlight;
-                }
-                
-                &:hover {
-                    color: @item-hover;
-                    border-bottom: @hairline solid transparent;
-                }
+                padding: 0;
+                margin-right: 0.5rem;
+                border-bottom: @hairline solid @focus-highlight;
             }
         }
 
         &__subtitle {
-            margin: .3rem 0 0 .2rem;
+            margin-top: .3rem;
+            margin-right: 0.5rem;
             padding-bottom: .3rem;
             font-size: 1rem;
             color: @mid-bg-alt;
@@ -493,7 +489,37 @@
     }
 }
 
-.split-button__item__syncing {
-    width: 1.6rem;
-    height: 1.6rem;
+// Fix Chrome's rendering bug when asset has fractional pixel. 
+// The updated height is rounded to the nearest pixel.
+// TODO find better way to handle fractional pixel.
+// 
+// For non-retina @base-8
+@media (-webkit-min-device-pixel-ratio: 1) and (min-device-width: 801px) and (max-device-width: 1440){
+    .libraries__asset__preview, .libraries__asset__title {
+        height: 34px;
+    }
+    .libraries__asset {
+        padding: 3px 0;
+    }
+    .libraries__asset__title__main {
+        margin-top: 0;
+    }
+}
+// For retina @base-8/@base-9
+@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 801px) and (max-device-width: 1680) {
+    .libraries__asset__preview, .libraries__asset__title {
+        height: 34px;
+    }
+    .libraries__asset {
+        padding: 3px 0;
+    }
+}
+// For retina @base-11
+@media (-webkit-min-device-pixel-ratio: 2) and (min-device-width: 2561px) {
+    .libraries__asset__preview, .libraries__asset__title {
+        height: 42px;
+    }
+    .libraries__asset {
+        padding: 3px 0;
+    }
 }


### PR DESCRIPTION
**Fix for #3560**

Things that I tested and fixed (on both retian and non-retian screen with different font-size): 

Regular Asset
<img width="340" alt="screen shot 2016-01-20 at 3 06 19 pm" src="https://cloud.githubusercontent.com/assets/118264/12466173/70ca32e6-bf87-11e5-9a39-a1fc05c9aa81.png">
<img width="329" alt="screen shot 2016-01-20 at 3 06 24 pm" src="https://cloud.githubusercontent.com/assets/118264/12466174/70ca5730-bf87-11e5-8ce8-8b673e948aa8.png">
<img width="327" alt="screen shot 2016-01-20 at 3 06 35 pm" src="https://cloud.githubusercontent.com/assets/118264/12466175/70ce4d4a-bf87-11e5-803f-ad56650deb62.png">
<img width="333" alt="screen shot 2016-01-20 at 3 06 29 pm" src="https://cloud.githubusercontent.com/assets/118264/12466172/70ca2d1e-bf87-11e5-9631-8630e3de38ab.png">

Color Theme (hover on preview to expand the colors)
<img width="307" alt="screen shot 2016-01-20 at 3 07 37 pm" src="https://cloud.githubusercontent.com/assets/118264/12466202/a0aa4686-bf87-11e5-9c25-792122d0588d.png">
<img width="325" alt="screen shot 2016-01-20 at 3 07 45 pm" src="https://cloud.githubusercontent.com/assets/118264/12466200/a0a8afe2-bf87-11e5-9caf-26bfa6824ffa.png">
<img width="329" alt="screen shot 2016-01-20 at 3 07 51 pm" src="https://cloud.githubusercontent.com/assets/118264/12466199/a0a84e3a-bf87-11e5-9534-45a13ebe6c34.png">
<img width="328" alt="screen shot 2016-01-20 at 3 07 57 pm" src="https://cloud.githubusercontent.com/assets/118264/12466201/a0a97774-bf87-11e5-820e-b11b812be07d.png">

Text Styles
<img width="346" alt="screen shot 2016-01-20 at 3 08 42 pm" src="https://cloud.githubusercontent.com/assets/118264/12466226/c78e916c-bf87-11e5-8a03-266d61820996.png">
<img width="333" alt="screen shot 2016-01-20 at 3 08 46 pm" src="https://cloud.githubusercontent.com/assets/118264/12466227/c78eddf2-bf87-11e5-96b4-c7af90b80ab1.png">

Long title
<img width="325" alt="screen shot 2016-01-20 at 3 09 08 pm" src="https://cloud.githubusercontent.com/assets/118264/12466228/c78f91ca-bf87-11e5-8b6a-d2598d1e0a57.png">