### PR TITLE
Put a timer on adding event listeners to the window

### DIFF
--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -128,7 +128,12 @@ define(function (require, exports, module) {
                     dialogEl.showModal();
                 }
 
-                this._addListeners();
+                // Ensure that handlers are added asynchronously to avoid incorrectly
+                // handling the event that opened the dialog initially. See #3532.
+                window.setTimeout(function () {
+                    this._addListeners();
+                }.bind(this), 0);
+
                 this._positionDialog(dialogEl);
                 this.props.onOpen();
             } else if (!this.state.open && prevState.open) {


### PR DESCRIPTION
References #3532 

With the previous version of bluebird, the call to `_addListeners()` was working asynchronously behind the scenes. Therefore the click events on the document header we handled before an event listener was added on the window. With this recent change to bluebird, https://github.com/petkaantonov/bluebird/issues/915, this became synchronous and the event listener on the window was added before the click to open the document header buttons were interpreted, resulting in the automatic toggle. This PR makes the addition of event listeners in the `componentDidUpdate` asynchronous again.
