### PR TITLE
use top most layer to avoid group confusion

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -612,7 +612,7 @@ define(function (require, exports) {
         }
 
         var currentLayers = currentDocument.layers.selected,
-            currentLayer = currentLayers.first();
+            currentLayer = currentLayers.last();
 
         // vector mask mode requires an active layer
         if (!currentLayer) {


### PR DESCRIPTION
It seems like in some cases our number of selected layers is different than expected when groups are selected. Using the top layer instead should resolve that issue. 

fix for issue #3267 