### PR TITLE
Support same key diff. modifier dialog closers, add shift+tab to ColorInput

### DIFF
--- a/src/js/jsx/shared/ColorInput.jsx
+++ b/src/js/jsx/shared/ColorInput.jsx
@@ -51,7 +51,8 @@ define(function (require, exports, module) {
     var DISMISS_ON_KEYS = [
         { key: os.eventKeyCode.ESCAPE, modifiers: null },
         { key: os.eventKeyCode.ENTER, modifiers: null },
-        { key: os.eventKeyCode.TAB, modifiers: null }
+        { key: os.eventKeyCode.TAB, modifiers: null },
+        { key: os.eventKeyCode.TAB, modifiers: { shift: true } }
     ];
     
     /**

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
 
     var os = require("adapter").os;
 
-    var math = require("js/util/math");
+    var math = require("js/util/math"),
+        keyUtil = require("js/util/key");
 
     /**
      * Valid methods of positioning the dialog
@@ -329,8 +330,10 @@ define(function (require, exports, module) {
             if (this.props.dismissOnKeys && _.isArray(this.props.dismissOnKeys)) {
                 var flux = this.getFlux();
                 this.props.dismissOnKeys.forEach(function (keyObj) {
+                    var modifiers = keyObj.modifiers || {};
+
                     flux.actions.shortcuts.addShortcut(keyObj.key,
-                        keyObj.modifiers || {}, this.toggle, this.props.id + keyObj.key, true);
+                        modifiers, this.toggle, this.props.id + keyUtil.modifiersToBits(modifiers) + keyObj.key, true);
                 }, this);
             }
         },
@@ -355,7 +358,10 @@ define(function (require, exports, module) {
             if (this.props.dismissOnKeys && _.isArray(this.props.dismissOnKeys)) {
                 var flux = this.getFlux();
                 this.props.dismissOnKeys.forEach(function (keyObj) {
-                    flux.actions.shortcuts.removeShortcut(this.props.id + keyObj.key);
+                    var modifiers = keyObj.modifiers || {},
+                        modifierKey = keyUtil.modifiersToBits(modifiers);
+
+                    flux.actions.shortcuts.removeShortcut(this.props.id + modifierKey + keyObj.key);
                 }, this);
             }
         },


### PR DESCRIPTION
Addresses #3281, problem was that we had Tab with no modifiers as a closer, but not shift+tab. And on `Map` focus, it was body that had the focus, so shift tab would be handled by active tool, while tab handled by dialog.

Then I realized, we don't allow same key shortcuts, but this was same key / different modifier. So I changed that code to support same key different modifier shortcuts, using modifiers as a way to come up with unique ID.