### PR TITLE
SuperHack: force search UI to maintain focus when activating application

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -118,8 +118,14 @@ define(function (require, exports, module) {
          * @param {{becameActive: boolean}} event
          */
         _handleActivationChanged: function (event) {
-            if (this.state.ready && event && event.becameActive) {
-                this.refs.datalist.focus();
+            if (event.becameActive) {
+                // SuperHack: Work around a Chromium bug in which activating the window
+                // blurs (at some point) the focused input. See #3519.
+                window.setTimeout(function () {
+                    if (this.state.ready) {
+                        this.refs.datalist.focus();
+                    }
+                }.bind(this), 100);
             }
         },
 


### PR DESCRIPTION
This works around what I assume is a Chromium bug that is causing the active text input to be blurred when the application window is activated. I don't know for sure that this is a Chromium bug, but I can't figure out any other reason why this would be happening. This is surely a SuperHack.

Addresses #3519 miserably.