### PR TITLE
Set appendCopy and skipTransform on startup

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -32,6 +32,7 @@ define(function (require, exports) {
         descriptor = require("adapter").ps.descriptor,
         documentLib = require("adapter").lib.document,
         layerLib = require("adapter").lib.layer,
+        appLib = require("adapter").lib.application,
         OS = require("adapter").os;
 
     var Layer = require("js/models/layer"),
@@ -2052,15 +2053,23 @@ define(function (require, exports) {
             }
         ];
 
-        var shortcutPromise = this.transfer(shortcuts.addShortcuts, shortcutSpecs),
+        var preferencesObjects = [
+            appLib.setAddCopyToLayerNames(false),
+            appLib.setGlobalPreferences({
+                skipTransformSOFromLibrary: true
+            })
+        ];
+
+        var preferencesPromise = descriptor.batchPlayObjects(preferencesObjects),
+            shortcutPromise = this.transfer(shortcuts.addShortcuts, shortcutSpecs),
             searchAllPromise = this.transfer("searchLayers.registerAllLayerSearch"),
             searchCurrentPromise = this.transfer("searchLayers.registerCurrentLayerSearch");
 
-        return Promise.join(shortcutPromise, searchAllPromise, searchCurrentPromise);
+        return Promise.join(preferencesPromise, shortcutPromise, searchAllPromise, searchCurrentPromise);
     };
     afterStartup.action = {
         reads: [],
-        writes: [],
+        writes: [locks.PS_APP],
         transfers: [shortcuts.addShortcuts, "searchLayers.registerAllLayerSearch",
             "searchLayers.registerCurrentLayerSearch"]
     };


### PR DESCRIPTION
This will require pg-dev-mac#996 or later builds. Also will require https://github.com/adobe-photoshop/spaces-adapter/pull/182, and will address #3246 and #3543 

I've exposed the Layers Panel option "Add "copy" to layer names" in Photoshop to us, and added an lib/application method to set it. I've also set it up as a auto-restored property. So now, when we option drag / duplicate layers, they don't get "copy" added to their names. #3543

Skip transform when placing SOs from library was already an existing preference in Photoshop, so I've added a new `setGlobalPreferences` API to lib/application to set it. This was a conscious decision, instead of having one function to set an option, for future uses of this API. #3246
