### PR TITLE
Padding on formlines first-child removed to fix clipping of color swatch

### DIFF
--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -134,7 +134,7 @@
 
 .formline__no-padding {
     padding-top: 0.2rem;
-    padding-bottom: 0.2rem;    
+    padding-bottom: 0.1rem;    
 }
 
 .formline:first-child {


### PR DESCRIPTION
References issue #3549 

Before: 
![](https://www.dropbox.com/s/ddpvqpk46mmpc4b/Screenshot%202016-01-22%2014.06.07.png?raw=1)

After: 
![](https://www.dropbox.com/s/25fc45vcahwahpp/Screenshot%202016-01-22%2014.06.26.png?raw=1)


One thing to note, is that the padding in other panels changes slightly with this fix. Can @placegraphichere or @designedbyscience give their opinion about the change? I made this image to try and show the slight difference. If this doesn't help, you can just check out toggling the CSS change on this branch. 

![](https://www.dropbox.com/s/rv5mof6oxu4tsyh/panels.jpg?raw=1)
