### PR TITLE
Prevent Size and Position components from blinking on mount

### DIFF
--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -53,8 +53,9 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            return !this.state ||
+            return this.props.active !== nextProps.active ||
                 this.state.disabled !== nextState.disabled ||
+                this.props.referencePoint !== nextProps.referencePoint ||
                 !Immutable.is(this.state.xValues, nextState.xValues) ||
                 !Immutable.is(this.state.yValues, nextState.yValues) ||
                 !Immutable.is(this.state.absoluteXValues, nextState.absoluteXValues) ||
@@ -62,23 +63,6 @@ define(function (require, exports, module) {
         },
 
         componentWillReceiveProps: function (nextProps) {
-            var getSelectedChildBounds = function (props) {
-                return props.document.layers.selectedRelativeChildBounds;
-            };
-
-            var getRelevantProps = function (props) {
-                var layers = props.document.layers.selected;
-
-                return collection.pluckAll(layers, ["kind", "locked", "isBackground"]);
-            };
-
-            if (this.state &&
-                this.props.referencePoint === nextProps.referencePoint &&
-                Immutable.is(getSelectedChildBounds(this.props), getSelectedChildBounds(nextProps)) &&
-                Immutable.is(getRelevantProps(this.props), getRelevantProps(nextProps))) {
-                return;
-            }
-
             var document = nextProps.document,
                 layers = document.layers.selected,
                 bounds = document.layers.selectedRelativeChildBounds,
@@ -97,6 +81,11 @@ define(function (require, exports, module) {
                 absoluteXValues: absoluteXValues,
                 absoluteYValues: absoluteYValues
             });
+        },
+
+        componentWillMount: function () {
+            // Needed to correctly initialize this.state.
+            this.componentWillReceiveProps(this.props);
         },
 
         /**
@@ -289,10 +278,6 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            if (!this.state) {
-                return null;
-            }
-
             return (
                 <div className="control-group__horizontal">
                     <Label

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -28,7 +28,8 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        Immutable = require("immutable");
 
     var AlignDistribute = require("./AlignDistribute"),
         Size = require("./Size"),
@@ -50,12 +51,11 @@ define(function (require, exports, module) {
             };
         },
 
-        shouldComponentUpdate: function (nextProps) {
-            if (!this.props.active && !nextProps.active) {
-                return false;
-            }
-            
-            return true;
+        shouldComponentUpdate: function (nextProps, nextState) {
+            return this.state.referencePoint !== nextState.referencePoint ||
+                this.props.active !== nextProps.active ||
+                this.props.disabled !== nextProps.disabled ||
+                !Immutable.is(this.props.document, nextProps.document);
         },
 
         /**
@@ -98,7 +98,9 @@ define(function (require, exports, module) {
                     <div className="section-container__no-collapse transform__body">
                         <div className="formline formline__padded-first-child formline__space-between">
                             <div className="control-group">
-                                <Size document={this.props.document}
+                                <Size
+                                    active={this.props.active}
+                                    document={this.props.document}
                                     referencePoint={this.state.referencePoint}/>
                             </div>
                             <div className="control-group reference-mark" title={referencePointTooltip}>
@@ -178,7 +180,9 @@ define(function (require, exports, module) {
                         </div>
                         <div className={positionRotateClasses}>
                             <div className="control-group">
-                                <Position document={this.props.document}
+                                <Position
+                                    active={this.props.active}
+                                    document={this.props.document}
                                     referencePoint={this.state.referencePoint} />
                             </div>
                             <div className="control-group">


### PR DESCRIPTION
The `Size` and `Position` components currently blink when first showing a document. This is entirely due to quirks in their `shouldComponentUpdate` methods. In particular, it seems like the components weren't rendering until their first state _change_ after mounting.

@volfied: I ended up removing a bunch of code that you wrote recently, so I'd like your feedback on this to make sure I didn't screw something up. I've removed some of your optimizations because I think they were partially responsible for the blinking.

Addresses #3613.