### PR TITLE
Do not attempt to dispatch layer-selection-changed events for uninitialized documents

### DIFF
--- a/src/js/stores/document.js
+++ b/src/js/stores/document.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
             }
 
             // Notify change of layer state.
-            if (oldDocument) {
+            if (oldDocument && oldDocument.layers && nextDocument.layers) {
                 oldDocument.layers.layers.forEach(function (layer) {
                     var nextLayer = nextDocument.layers.byID(layer.id),
                         callback = this._layerIDToStateListener[layer.id];


### PR DESCRIPTION
What it says! This was causing an unrecoverable error when opening the search dialog with an uninitialized document (i.e., one for which `document.layers === null`).

@shaoshing: can you let me know if this looks like the right fix?

Addresses #3619. 