### PR TITLE
LayerPanel: fix broken layer face drag-and-drop

### DIFF
--- a/src/js/jsx/sections/layers/DummyLayerFace.jsx
+++ b/src/js/jsx/sections/layers/DummyLayerFace.jsx
@@ -29,8 +29,6 @@ define(function (require, exports, module) {
         Promise = require("bluebird"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React);
-        
-    var collection = require("js/util/collection");
 
     var Droppable = require("js/jsx/shared/Droppable");
 
@@ -52,17 +50,16 @@ define(function (require, exports, module) {
          * @private
          * @type {Droppable~onDrop}
          */
-        _handleDropLayers: function (draggedLayers) {
+        _handleDropLayers: function (draggedLayerIds) {
             if (!this.state.isDropTarget) {
                 return Promise.resolve();
             }
             
             this.setState({ isDropTarget: false });
             
-            var dropIndex = 0, // put dragged layers to the bottom
-                dragSource = collection.pluck(draggedLayers, "id");
+            var dropIndex = 0; // put dragged layers to the bottom
 
-            return this.getFlux().actions.layers.reorder(this.props.document, dragSource, dropIndex);
+            return this.getFlux().actions.layers.reorder(this.props.document, draggedLayerIds, dropIndex);
         },
         
         /**
@@ -71,14 +68,14 @@ define(function (require, exports, module) {
          * @private
          * @type {Droppable~onDragTargetEnter}
          */
-        _handleDragTargetEnter: function (draggedLayers) {
+        _handleDragTargetEnter: function (draggedLayerIds) {
             // Dropping on the dummy layer is valid as long as a group is not
             // being dropped below itself. The dummy layer only exists
             // when there is a bottom group layer. Drop position is fixed.
 
             var bottomLayer = this.props.document.layers.top.last(),
                 isGroup = bottomLayer.isGroup,
-                isDropTarget = !isGroup || !draggedLayers.contains(bottomLayer);
+                isDropTarget = !isGroup || !draggedLayerIds.contains(bottomLayer.id);
 
             this.setState({ isDropTarget: isDropTarget });
         },

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
          * @private
          * @type {Droppable~onDrop}
          */
-        _handleDropLayers: function (draggedLayers) {
+        _handleDropLayers: function (draggedLayerIds) {
             if (!this.state.canDropLayer) {
                 this.setState({ isDropTarget: false });
                 return Promise.resolve();
@@ -128,6 +128,7 @@ define(function (require, exports, module) {
 
             var flux = this.getFlux(),
                 document = flux.store("application").getCurrentDocument(),
+                draggedLayers = document.layers.byIDs(draggedLayerIds),
                 selectedLayers = document.layers.selected,
                 promise = Promise.resolve();
 
@@ -147,10 +148,12 @@ define(function (require, exports, module) {
          * @private
          * @type {Droppable~onDragTargetEnter}
          */
-        _handleDragTargetEnter: function (draggedLayers) {
-            // Single linked layer is not accepted, but multiple linked (or mixed) layers are accepted.
-            var isSingleLinkedLayer = draggedLayers.size === 1 && draggedLayers.first().isLinked;
-            
+        _handleDragTargetEnter: function (draggedLayerIDs) {
+            var document = this.getFlux().store("application").getCurrentDocument(),
+                firstDraggedLayer = document.layers.byID(draggedLayerIDs.first()),
+                // Single linked layer is not accepted, but multiple linked (or mixed) layers are accepted.
+                isSingleLinkedLayer = draggedLayerIDs.size === 1 && firstDraggedLayer.isLinked;
+
             this.setState({
                 isDropTarget: true,
                 canDropLayer: this.state.selectedLibrary && !isSingleLinkedLayer

--- a/src/js/jsx/shared/Draggable.jsx
+++ b/src/js/jsx/shared/Draggable.jsx
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
             
             // The object passed to the Droppable component when dropped. This value can be overwritten by the 
             // optional callback "beforeDragStart".
-            target: React.PropTypes.object.isRequired,
+            target: React.PropTypes.any.isRequired,
             
             // If true, the Draggable component will be disabled.
             disabled: React.PropTypes.bool,

--- a/src/js/jsx/shared/Droppable.jsx
+++ b/src/js/jsx/shared/Droppable.jsx
@@ -40,33 +40,33 @@ define(function (require, exports, module) {
             accept: React.PropTypes.string.isRequired,
 
             /**
-             * @callback Draggable~handleDragTargetEnter
+             * @callback Droppable~onDragTargetEnter
              * @param {Immutable.List.<object>} draggedTargets
              * @param {{x: number, y:number}} position
              */
-            handleDragTargetEnter: React.PropTypes.func,
+            onDragTargetEnter: React.PropTypes.func,
             
             /**
-             * @callback Draggable~handleDragTargetMove
+             * @callback Droppable~onDragTargetMove
              * @param {Immutable.List.<object>} draggedTargets
              * @param {{x: number, y:number}} position
              */
-            handleDragTargetMove: React.PropTypes.func,
+            onDragTargetMove: React.PropTypes.func,
             
             /**
-             * @callback Draggable~handleDragTargetLeave
+             * @callback Droppable~onDragTargetLeave
              * @param {Immutable.List.<object>} draggedTargets
              * @param {{x: number, y:number}} position
              */
-            handleDragTargetLeave: React.PropTypes.func,
+            onDragTargetLeave: React.PropTypes.func,
             
             /**
-             * @callback Draggable~handleDrop
-             * @param {Immutable.List.<object>} draggedTargets
+             * @callback Droppable~onDrop
+             * @param {Immutable.List.<*>} draggedTargets
              * @param {{x: number, y:number}} position
              * @return {Promise}
              */
-            handleDrop: React.PropTypes.func
+            onDrop: React.PropTypes.func
         },
 
         getInitialState: function () {

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -609,6 +609,16 @@ define(function (require, exports, module) {
     LayerStructure.prototype.byID = function (id) {
         return this.layers.get(id, null);
     };
+    
+    /**
+     * Get a list of Layer models by layer IDs.
+     *
+     * @param {Immutable.Iterable.<number>} ids
+     * @return {Immutable.Iterable.<Layer|null>}
+     */
+    LayerStructure.prototype.byIDs = function (ids) {
+        return ids.map(this.byID, this);
+    };
 
     /**
      * Get a Layer model by layer index.


### PR DESCRIPTION
This PR fixes the drag-and-drop in the LayerPanel by changing the type of drag target in the `Draggable` component from `Layer` model to layer id, so that the `Draggable` won't hold a stale layer model. 

More details about the fix:

In the recent layer panel PR, `LayerFace` stores some `Layer` model attributes (`selected/expanded/visible`) in its state. When it receive a new layer prop, it will skip rendering if the change is the same as its state. As a result, the `Draggable` instance will hold the old version because the component is not re-rendered. This makes it fail when `Draggable` component needs to check whether it is the drag target when a drag event starts, which will always return false. The solution is to switch to layer id, which is a number and will never stale.

