### PR TITLE
Grunt: better notification for WebPack and LESS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@ module.exports = function (grunt) {
         watch: {
             styles: {
                 files: ["src/style/**/*"],
-                tasks: ["less"],
+                tasks: ["less", "notify:less"],
                 options: {
                     spawn: false,
                     interrupt: true,
@@ -235,6 +235,14 @@ module.exports = function (grunt) {
                     logConcurrentOutput: true
                 }
             }
+        },
+        notify: {
+            less: {
+                options: {
+                    title: "LESS",
+                    message: "Build Successful"
+                }
+            }
         }
     });
 
@@ -255,6 +263,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-concurrent");
     grunt.loadNpmTasks("grunt-concat-json");
     grunt.loadNpmTasks("grunt-merge-json");
+    grunt.loadNpmTasks("grunt-notify");
 
     grunt.registerTask("seqtest", "Runs the linter tests sequentially",
         ["jshint", "jscs", "jsdoc", "jsonlint", "lintspaces"]

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "grunt-jsxhint": "^0.6.0",
     "grunt-lintspaces": "^0.7.0",
     "grunt-merge-json": "^0.9.5",
+    "grunt-notify": "^0.4.3",
     "grunt-webpack": "^1.0.11",
     "jscs": "^2.6.0",
     "jscs-jsdoc": "^1.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,4 +123,16 @@ var buildConfigs = languages.map(function (lang) {
     return options;
 });
 
+// Hack: add Timestamp to the WebPack build message.
+WebpackNotifierPlugin.prototype._compileMessage = WebpackNotifierPlugin.prototype.compileMessage;
+WebpackNotifierPlugin.prototype.compileMessage = function (stats) {
+    var msg = this._compileMessage(stats);
+    
+    if (msg === "Build successful") {
+        msg += " @ " + (new Date()).toLocaleTimeString();
+    }
+
+    return msg;
+};
+
 module.exports = buildConfigs;


### PR DESCRIPTION
**needs `npm install`**

Show notification for LESS task. It will show both successful and error message.
<img width="415" alt="screen shot 2016-01-27 at 1 56 35 pm" src="https://cloud.githubusercontent.com/assets/118264/12629699/db2cb6d8-c4fd-11e5-9a2a-6f8a83e72f5c.png">
<img width="401" alt="screen shot 2016-01-27 at 1 57 20 pm" src="https://cloud.githubusercontent.com/assets/118264/12629717/eb9d3c90-c4fd-11e5-8d8a-60af821b4884.png">


* Show timestamp in the WebPack's successful build message. This would be easier to know when the latest build is done if you make changes constantly.
<img width="403" alt="screen shot 2016-01-27 at 1 56 21 pm" src="https://cloud.githubusercontent.com/assets/118264/12629748/0fc54a36-c4fe-11e5-831d-d9073f15d9f2.png">


