### PR TITLE
Basic number localization

### DIFF
--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
                 var stable = asset.status === ExportAsset.STATUS.STABLE,
                     requested = asset.status === ExportAsset.STATUS.REQUESTED,
                     errored = asset.status === ExportAsset.STATUS.ERROR,
-                    assetTitle = asset.scale + "x";
+                    assetTitle = asset.scale.toLocaleString() + "x";
 
                 var assetClasses = classnames({
                     "exports-panel__layer-asset": true,

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
         .map(function (scale) {
             var obj = {
                 id: scale.toString(),
-                title: scale.toString()
+                title: scale.toLocaleString()
             };
             return [scale.toString(), obj];
         }));

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
         math = require("js/util/math"),
         collection = require("js/util/collection"),
         headlights = require("js/util/headlights"),
-        log = require("js/util/log");
+        log = require("js/util/log"),
+        nls = require("js/util/nls");
 
     var NumberInput = React.createClass({
         mixins: [Focusable, FluxMixin],
@@ -152,10 +153,17 @@ define(function (require, exports, module) {
             var value;
             try {
                 var trimValue = _.trimRight(rawValue, this.props.suffix);
+
+                if (nls.commaDecimalSeparator) {
+                    // Replace decimal separator , with . and replace argument separator ; with ,
+                    trimValue.replace(new RegExp("\\,|\\;", "g"), function (match) {
+                        return match === "," ? "." : ",";
+                    });
+                }
                 /*jslint evil: true */
                 value = mathjs.eval(trimValue);
                 /*jslint evil: false */
-                
+
                 // Run it through our simple parser to get rid of complex and big numbers
                 value = math.parseNumber(value);
             } catch (err) {
@@ -192,7 +200,10 @@ define(function (require, exports, module) {
             switch (typeof value) {
             case "number":
                 if (_.isFinite(value)) {
-                    formattedValue = String(mathjs.round(value, this.props.precision)) + this.props.suffix;
+                    var roundedValue = mathjs.round(value, this.props.precision),
+                        localeValue = roundedValue.toLocaleString();
+
+                    formattedValue = String(localeValue) + this.props.suffix;
                 } else {
                     formattedValue = "";
                     log.warn("Non-finite value in NumberInput: ", value);

--- a/src/js/models/exportasset.js
+++ b/src/js/models/exportasset.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
          */
         derivedSuffix: function () {
             var qualitySuffix = (this.quality === 32 || this.quality === 100) ? "" : "-" + this.quality.toString(),
-                scaleSuffix = "@" + this.scale + "x";
+                scaleSuffix = "@" + this.scale.toLocaleString() + "x";
 
             return scaleSuffix + qualitySuffix;
         },

--- a/src/js/util/nls.js
+++ b/src/js/util/nls.js
@@ -52,5 +52,13 @@ define(function (require, exports) {
         }
     };
 
+    /**
+     * The following tests whether or not decimals are separated by comma in the current locale.
+     *
+     * @type {boolean}
+     */
+    var commaDecimalSeparator = Number(0.5).toLocaleString().indexOf(",") > 0;
+
     exports.localize = localize;
+    exports.commaDecimalSeparator = commaDecimalSeparator;
 });


### PR DESCRIPTION
This provides extremely basic number localization for `NumberInput` mainly, and also for the scale values used by export. The display of numbers is handled by the browser by the [`toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) method of `Number` objects, and relies on the browser's locale being correctly set, as it has been. The somewhat more complicated issue is parsing arithmetic expressions in `NumberInput`. This is handled with a hack: we determine if the browser wants to format decimals with a comma, and if so we swap out commas for periods and semicolons (which often separate arguments to mathematical functions in the same locale) with commas. Hence, you `sum(1,5; 2,5)` is translated to `sum(1.5, 2.5)` before a handoff to `mathjs.eval`. After that, it's translated back using `toLocaleString` again. This doesn't seem great, but it's the approach suggested by the mathjs developer. See josdejong/mathjs#421 and http://mathjs.org/examples/browser/custom_separators.html.html.

Note that this does _not_ attempt to localize color expressions returned by `tinycolor`. So, for example, you'll see `rgba(0, 0, 0, 0.5)` instead of, say, `rgba(0; 0; 0; 0,5)`. This is because these are intended to be CSS color expressions, which by definition are not localized. This might be debatable, of course, but I thought I'd start here without digging a hole that didn't seem to need digging.

I'm also vaguely aware that in some locales, percentages are formatted slightly differently, like `50 %` instead of `50%`. I'll handle that, and any other issues that come up, separately.

Partially addresses #3136.