### PR TITLE
Get rid of synchronization.debounce and use _.debounce instead

### DIFF
--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -35,7 +35,6 @@ define(function (require, exports) {
 
     var events = require("js/events"),
         locks = require("js/locks"),
-        synchronization = require("js/util/synchronization"),
         log = require("js/util/log");
 
     /**
@@ -416,7 +415,7 @@ define(function (require, exports) {
      */
     var beforeStartup = function () {
         var debouncedHandleHistoryStateAfterSelect =
-            synchronization.debounce(this.flux.actions.history.handleHistoryStateAfterSelect, this, 200);
+            _.debounce(this.flux.actions.history.handleHistoryStateAfterSelect.bind(this), 200);
 
         // We get these every time there is a new history state being created
         _historyStateHandler = function (event) {

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -49,8 +49,7 @@ define(function (require, exports) {
         locking = require("js/util/locking"),
         headlights = require("js/util/headlights"),
         nls = require("js/util/nls"),
-        global = require("js/util/global"),
-        synchronization = require("js/util/synchronization");
+        global = require("js/util/global");
 
     /**
      * Properties to be included when requesting layer
@@ -1927,7 +1926,7 @@ define(function (require, exports) {
 
         // Listens to layer shift events caused by auto canvas resize feature of artboards
         // and shifts all the layers correctly
-        _autoCanvasResizeShiftHandler = synchronization.debounce(function (event) {
+        _autoCanvasResizeShiftHandler = _.debounce(function (event) {
             return this.flux.actions.layers.handleCanvasShift(event);
         }.bind(this), 500);
         descriptor.addListener("autoCanvasResizeShift", _autoCanvasResizeShiftHandler);

--- a/src/js/actions/panel.js
+++ b/src/js/actions/panel.js
@@ -24,7 +24,8 @@
 define(function (require, exports) {
     "use strict";
 
-    var Promise = require("bluebird");
+    var Promise = require("bluebird"),
+        _ = require("lodash");
 
     var adapter = require("adapter"),
         descriptor = require("adapter").ps.descriptor,
@@ -35,7 +36,6 @@ define(function (require, exports) {
     var events = require("js/events"),
         locks = require("js/locks"),
         preferences = require("./preferences"),
-        synchronization = require("js/util/synchronization"),
         headlights = require("js/util/headlights"),
         uiUtil = require("js/util/ui");
 
@@ -327,9 +327,9 @@ define(function (require, exports) {
         }.bind(this);
         adapterOS.addListener("activationChanged", _activationChangeHandler);
 
-        var windowResizeDebounced = synchronization.debounce(function () {
+        var windowResizeDebounced = _.debounce(function () {
             return this.flux.actions.panel.setOverlayCloaking();
-        }, this, DEBOUNCE_DELAY, false);
+        }.bind(this), DEBOUNCE_DELAY);
 
         // Handles window resize for resetting superselect tool policies
         _resizeHandler = function (event) {

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -45,8 +45,7 @@ define(function (require, exports) {
         locking = require("js/util/locking"),
         layerActionsUtil = require("js/util/layeractions"),
         headlights = require("js/util/headlights"),
-        nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization");
+        nls = require("js/util/nls");
 
     /**
      * play/batchPlay options that allow the canvas to be continually updated.
@@ -1393,18 +1392,18 @@ define(function (require, exports) {
     var beforeStartup = function () {
         // TODO does this still need to debounce?  Are there cases where we get several events that correspond to
         // one history state?
-        _artboardTransformHandler = synchronization.debounce(function () {
+        _artboardTransformHandler = _.debounce(function () {
             return this.flux.actions.transform.handleTransformArtboard();
-        }, this);
+        }.bind(this));
 
         _layerTransformHandler = function (event) {
             this.flux.actions.transform.handleTransformLayer(event);
         }.bind(this);
 
-        _moveToArtboardHandler = synchronization.debounce(function () {
+        _moveToArtboardHandler = _.debounce(function () {
             // Undefined makes it use the most recent document model
             return this.flux.actions.layers.resetIndex(undefined);
-        }, this, EVENT_DEBOUNCE_DELAY);
+        }.bind(this), EVENT_DEBOUNCE_DELAY);
 
         descriptor.addListener("transform", _layerTransformHandler);
         descriptor.addListener("move", _layerTransformHandler);

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1392,9 +1392,9 @@ define(function (require, exports) {
     var beforeStartup = function () {
         // TODO does this still need to debounce?  Are there cases where we get several events that correspond to
         // one history state?
-        _artboardTransformHandler = _.debounce(function () {
+        _artboardTransformHandler = function () {
             return this.flux.actions.transform.handleTransformArtboard();
-        }.bind(this));
+        }.bind(this);
 
         _layerTransformHandler = function (event) {
             this.flux.actions.transform.handleTransformLayer(event);

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -41,8 +41,7 @@ define(function (require, exports) {
         locking = require("js/util/locking"),
         math = require("js/util/math"),
         nls = require("js/util/nls"),
-        layerActionsUtil = require("js/util/layeractions"),
-        synchronization = require("js/util/synchronization");
+        layerActionsUtil = require("js/util/layeractions");
 
     /**
      * Minimum and maximum Photoshop-supported font sizes
@@ -799,7 +798,7 @@ define(function (require, exports) {
      * @return {Promise}
      */
     var beforeStartup = function () {
-        _fontListChangedHandler = synchronization.debounce(function () {
+        _fontListChangedHandler = _.debounce(function () {
             var fontStore = this.flux.store("font"),
                 fontState = fontStore.getState(),
                 initialized = fontState.initialized;
@@ -809,7 +808,7 @@ define(function (require, exports) {
             } else {
                 return Promise.resolve();
             }
-        }, this, 500);
+        }.bind(this), 500);
 
         descriptor.addListener("fontListChanged", _fontListChangedHandler);
 

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -36,7 +36,6 @@ define(function (require, exports) {
         events = require("js/events"),
         locks = require("js/locks"),
         shortcuts = require("./shortcuts"),
-        synchronization = require("js/util/synchronization"),
         system = require("js/util/system");
 
     /**
@@ -353,7 +352,7 @@ define(function (require, exports) {
      */
     var beforeStartup = function () {
         var scrolling = false,
-            updateTransformDebounced = synchronization.debounce(function () {
+            updateTransformDebounced = _.debounce(function () {
                 return this.flux.actions.ui.updateTransform()
                     .bind(this)
                     .then(function () {
@@ -363,7 +362,7 @@ define(function (require, exports) {
                         // Reenable overlays
                         this.dispatch(events.panel.END_CANVAS_UPDATE);
                     });
-            }, this, EVENT_DEBOUNCE_DELAY, false);
+            }.bind(this), EVENT_DEBOUNCE_DELAY);
 
         // Handles spacebar + drag, scroll and window resize events
         _scrollHandler = function (event) {
@@ -384,8 +383,10 @@ define(function (require, exports) {
         }.bind(this);
         descriptor.addListener("scroll", _scrollHandler);
 
-        _displayConfigurationChangedHandler = synchronization.debounce(
-            this.flux.actions.ui.handleDisplayConfigurationChanged, this, EVENT_DEBOUNCE_DELAY);
+        _displayConfigurationChangedHandler = _.debounce(
+            this.flux.actions.ui.handleDisplayConfigurationChanged.bind(this),
+            EVENT_DEBOUNCE_DELAY
+        );
         adapterOS.addListener("displayConfigurationChanged", _displayConfigurationChangedHandler);
 
         // Enable over-scroll mode

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -68,14 +68,6 @@ define(function (require, exports, module) {
     var THROTTLED_ACTION_SUFFIX = "Throttled";
 
     /**
-     * Suffix used to name debounced actions.
-     *
-     * @const
-     * @type {String}
-     */
-    var DEBOUNCED_ACTION_SUFFIX = "Debounced";
-
-    /**
      * Maximum delay after which reset retry will continue
      *  before failing definitively.
      *  
@@ -933,14 +925,11 @@ define(function (require, exports, module) {
             }
 
             var throttledName = name + THROTTLED_ACTION_SUFFIX,
-                debouncedName = name + DEBOUNCED_ACTION_SUFFIX,
                 synchronizedAction = this._synchronize(namespace, module, name),
-                throttledAction = synchronization.throttle(synchronizedAction),
-                debouncedAction = _.debounce(synchronizedAction);
+                throttledAction = synchronization.throttle(synchronizedAction);
 
             exports[name] = synchronizedAction;
             exports[throttledName] = throttledAction;
-            exports[debouncedName] = debouncedAction;
 
             this._synchronizedActions.set(module[name], synchronizedAction);
 

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -936,7 +936,7 @@ define(function (require, exports, module) {
                 debouncedName = name + DEBOUNCED_ACTION_SUFFIX,
                 synchronizedAction = this._synchronize(namespace, module, name),
                 throttledAction = synchronization.throttle(synchronizedAction),
-                debouncedAction = synchronization.debounce(synchronizedAction);
+                debouncedAction = _.debounce(synchronizedAction);
 
             exports[name] = synchronizedAction;
             exports[throttledName] = throttledAction;

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -30,7 +30,8 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        Immutable = require("immutable");
+        Immutable = require("immutable"),
+        _ = require("lodash");
 
     var os = require("adapter").os;
 
@@ -38,7 +39,6 @@ define(function (require, exports, module) {
         Button = require("js/jsx/shared/Button"),
         SVGIcon = require("js/jsx/shared/SVGIcon"),
         nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization"),
         searchStore = require("js/stores/search"),
         headlights = require("js/util/headlights"),
         exportStore = require("js/stores/export");
@@ -157,11 +157,11 @@ define(function (require, exports, module) {
             this._updateTabContainerScroll();
             this._updateTabSize();
 
-            this._updatePanelSizesDebounced = synchronization.debounce(this._updatePanelSizes, this, 500);
+            this._updatePanelSizesDebounced = _.debounce(this._updatePanelSizes, 500);
             os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
             this._updatePanelSizes();
             
-            this._handleWindowResizeDebounced = synchronization.debounce(this._handleWindowResize, this, 500);
+            this._handleWindowResizeDebounced = _.debounce(this._handleWindowResize, 500);
             window.addEventListener("resize", this._handleWindowResizeDebounced);
         },
 

--- a/src/js/jsx/Guard.jsx
+++ b/src/js/jsx/Guard.jsx
@@ -25,11 +25,10 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var os = require("adapter").os;
-
-    var synchronization = require("js/util/synchronization");
 
     /**
      * Input events to block when the component becomes inactive.
@@ -63,7 +62,7 @@ define(function (require, exports, module) {
      * @private
      * @type {function}
      */
-    var _resetCursorDebounced = synchronization.debounce(os.resetCursor, os, 500);
+    var _resetCursorDebounced = _.debounce(os.resetCursor.bind(os), 500);
 
     var Guard = React.createClass({
 

--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -28,15 +28,15 @@ define(function (require, exports, module) {
         ReactDOM = require("react-dom"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var os = require("adapter").os;
 
     var Button = require("js/jsx/shared/Button"),
         SVGIcon = require("js/jsx/shared/SVGIcon"),
         nls = require("js/util/nls"),
-        headlights = require("js/util/headlights"),
-        synchronization = require("js/util/synchronization");
+        headlights = require("js/util/headlights");
 
     var PanelSet = React.createClass({
         mixins: [FluxMixin],
@@ -74,9 +74,9 @@ define(function (require, exports, module) {
         _updatePanelSizesDebounced: null,
 
         componentDidMount: function () {
-            this._updatePanelSizesDebounced = synchronization.debounce(function () {
+            this._updatePanelSizesDebounced = _.debounce(function () {
                 return this._updatePanelSizes();
-            }, this, 500);
+            }.bind(this), 500);
 
             os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
             this._updatePanelSizes();

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -48,7 +48,6 @@ define(function (require, exports, module) {
         LayersPanel = require("./sections/layers/LayersPanel"),
         LibrariesPanel = require("./sections/libraries/LibrariesPanel"),
         nls = require("js/util/nls"),
-        synchronization = require("js/util/synchronization"),
         system = require("js/util/system"),
         headlights = require("js/util/headlights");
 
@@ -135,7 +134,7 @@ define(function (require, exports, module) {
         _updatePanelSizesDebounced: null,
 
         componentDidMount: function () {
-            this._updatePanelSizesDebounced = synchronization.debounce(this._updatePanelSizes, this, 500);
+            this._updatePanelSizesDebounced = _.debounce(this._updatePanelSizes, 500);
             os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
         },
 

--- a/src/js/jsx/Toolbar.jsx
+++ b/src/js/jsx/Toolbar.jsx
@@ -29,13 +29,13 @@ define(function (require, exports, module) {
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
         StoreWatchMixin = Fluxxor.StoreWatchMixin,
-        classnames = require("classnames");
+        classnames = require("classnames"),
+        _ = require("lodash");
 
     var os = require("adapter").os;
 
     var ToolbarIcon = require("js/jsx/ToolbarIcon"),
-        Zoom = require("js/jsx/Zoom"),
-        synchronization = require("js/util/synchronization");
+        Zoom = require("js/jsx/Zoom");
 
     var Toolbar = React.createClass({
         mixins: [FluxMixin, StoreWatchMixin("tool", "application", "preferences")],
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
 
         // On startup, we want to make sure center offsets take pinned toolbar
         componentDidMount: function () {
-            this._updateToolbarWidthDebounced = synchronization.debounce(this._updateToolbarWidth, this, 500);
+            this._updateToolbarWidthDebounced = _.debounce(this._updateToolbarWidth, 500);
             os.addListener("displayConfigurationChanged", this._updateToolbarWidthDebounced);
             this._updateToolbarWidth();
         },

--- a/src/js/util/synchronization.js
+++ b/src/js/util/synchronization.js
@@ -80,59 +80,5 @@ define(function (require, exports) {
         return throttledFn;
     };
 
-    /**
-     * Debounce a promise-returning asynchronous function. Synchronous functions should
-     * use _.debounce instead.
-     *
-     * @param {function(*):Promise=} fn The function to debounce. May either return
-     *  a promise, or undefined.
-     * @param {object=} receiver Optional receiver for the debounced function.
-     * @param {number=} delay Optional number of milliseconds to wait after last call
-     * @param {boolean=} immediate Flag to call debounced function at the beginning
-     * @return {function(*)} The debounced function.
-     */
-    var debounce = function (fn, receiver, delay, immediate) {
-        var debounceTimer = null,
-            pending = null;
-
-        // Handle omitted receiver
-        if (typeof receiver === "number") {
-            immediate = delay;
-            delay = receiver;
-            receiver = undefined;
-        }
-
-        // Handle omitted delay/immediate flag
-        delay = delay || 0;
-        immediate = immediate || false;
-
-        var debouncedFn = function () {
-            var self = receiver;
-            if (self === undefined) {
-                self = this;
-            }
-
-            pending = arguments;
-
-            if (debounceTimer) {
-                window.clearTimeout(debounceTimer);
-                debounceTimer = null;
-            } else if (immediate) {
-                immediate = false;
-                fn.apply(self, pending);
-            }
-
-            debounceTimer = window.setTimeout(function () {
-                fn.apply(self, pending)
-                    .finally(function () {
-                        debounceTimer = null;
-                    });
-            }, delay);
-        };
-
-        return debouncedFn;
-    };
-
     exports.throttle = throttle;
-    exports.debounce = debounce;
 });


### PR DESCRIPTION
After realizing that in Mar 19, 2015, we got rid of the async waiting nature of our own debounce function, and it's identical to `_.debounce`, this cleans it up so we use lodash.

Addresses #3639, @iwehrman please review. @mcilroyc it would be nice to have your eyes on this, as well.