### PR TITLE
Correctly reference nested action paths

### DIFF
--- a/src/js/actions/tool/superselect/type.js
+++ b/src/js/actions/tool/superselect/type.js
@@ -69,7 +69,7 @@ define(function (require, exports) {
         if (_typeChangedHandler) {
             descriptor.removeListener("updateTextProperties", _typeChangedHandler);
         }
-        _typeChangedHandler = this.flux.actions.toolType.updateTextPropertiesHandlerThrottled.bind(this);
+        _typeChangedHandler = this.flux.actions["tool.type"].updateTextPropertiesHandlerThrottled.bind(this);
         descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
         return Promise.resolve();

--- a/src/js/actions/tool/type.js
+++ b/src/js/actions/tool/type.js
@@ -114,7 +114,7 @@ define(function (require, exports) {
             descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
         }
 
-        _typeChangedHandler = this.flux.actions.toolType.updateTextPropertiesHandlerThrottled.bind(this);
+        _typeChangedHandler = this.flux.actions["tool.type"].updateTextPropertiesHandlerThrottled.bind(this);
         descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
         _layerCreatedHandler = function (event) {
@@ -158,7 +158,7 @@ define(function (require, exports) {
 
         _layerDeletedHandler = function (event) {
             _layerDeleted = event.layerID;
-            this.flux.actions.typetool.handleDeletedLayer(event, _layersReplaced);
+            this.flux.actions["tool.type"].handleDeletedLayer(event, _layersReplaced);
         }.bind(this);
         descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
 
@@ -171,7 +171,7 @@ define(function (require, exports) {
                     return;
                 }
 
-                this.flux.actions.typetool.handleTypeModalStateCanceled();
+                this.flux.actions["tool.type"].handleTypeModalStateCanceled();
             }
         }.bind(this);
         descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);

--- a/src/js/models/tools/pen.js
+++ b/src/js/models/tools/pen.js
@@ -65,8 +65,8 @@ define(function (require, exports, module) {
             arrowLeftKeyPolicy
         ];
         
-        this.selectHandler = "toolPen.select";
-        this.deselectHandler = "toolPen.deselect";
+        this.selectHandler = "tool.pen.select";
+        this.deselectHandler = "tool.pen.deselect";
         this.activationKey = shortcutUtil.GLOBAL.TOOLS.PEN;
         this.handleVectorMaskMode = true;
     };

--- a/src/js/models/tools/sampler.js
+++ b/src/js/models/tools/sampler.js
@@ -44,8 +44,8 @@ define(function (require, exports, module) {
         this.icon = "eyedropper";
         this.activationKey = shortcuts.GLOBAL.TOOLS.SAMPLER;
 
-        this.selectHandler = "toolSampler.select";
-        this.deselectHandler = "toolSampler.deselect";
+        this.selectHandler = "tool.sampler.select";
+        this.deselectHandler = "tool.sampler.deselect";
 
         var pointerPolicy = new PointerEventPolicy(UI.policyAction.PROPAGATE_TO_BROWSER,
                 OS.eventKind.LEFT_MOUSE_DOWN);

--- a/src/js/models/tools/type.js
+++ b/src/js/models/tools/type.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
      * @constructor
      */
     var TypeTool = function () {
-        Tool.call(this, "typeCreateOrEdit", "Type", "typeCreateOrEditTool", "toolType.select", "tool.type.deselect");
+        Tool.call(this, "typeCreateOrEdit", "Type", "typeCreateOrEditTool", "tool.type.select", "tool.type.deselect");
 
         this.activationKey = shortcuts.GLOBAL.TOOLS.TYPE;
     };


### PR DESCRIPTION
Not the best change, but gets things back to working status.

Maybe instead of dot separated paths, we should use nested paths to camelCasedNestedPaths... but then there are chances of clashes.

For now, this will fix #3644