### PR TITLE
Allow nested actions

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -35,6 +35,7 @@ define(function (require, exports) {
     var events = require("js/events"),
         locks = require("js/locks"),
         system = require("js/util/system"),
+        objUtil = require("js/util/object"),
         log = require("js/util/log"),
         headlights = require("js/util/headlights"),
         policyActions = require("./policy"),
@@ -428,7 +429,7 @@ define(function (require, exports) {
             actionModuleName = actionNameParts[0],
             actionName = actionNameParts[1],
             actionNameThrottled = actionName + "Throttled",
-            actionThrottled = this.flux.actions[actionModuleName][actionNameThrottled];
+            actionThrottled = objUtil.getPath(this.flux.actions, actionModuleName)[actionNameThrottled];
 
         return actionThrottled;
     };

--- a/src/js/actions/tool/superselect/type.js
+++ b/src/js/actions/tool/superselect/type.js
@@ -69,7 +69,7 @@ define(function (require, exports) {
         if (_typeChangedHandler) {
             descriptor.removeListener("updateTextProperties", _typeChangedHandler);
         }
-        _typeChangedHandler = this.flux.actions["tool.type"].updateTextPropertiesHandlerThrottled.bind(this);
+        _typeChangedHandler = this.flux.actions.tool.type.updateTextPropertiesHandlerThrottled.bind(this);
         descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
         return Promise.resolve();

--- a/src/js/actions/tool/type.js
+++ b/src/js/actions/tool/type.js
@@ -114,7 +114,7 @@ define(function (require, exports) {
             descriptor.removeListener("toolModalStateChanged", _toolModalStateChangedHandler);
         }
 
-        _typeChangedHandler = this.flux.actions["tool.type"].updateTextPropertiesHandlerThrottled.bind(this);
+        _typeChangedHandler = this.flux.actions.tool.type.updateTextPropertiesHandlerThrottled.bind(this);
         descriptor.addListener("updateTextProperties", _typeChangedHandler);
 
         _layerCreatedHandler = function (event) {
@@ -158,7 +158,7 @@ define(function (require, exports) {
 
         _layerDeletedHandler = function (event) {
             _layerDeleted = event.layerID;
-            this.flux.actions["tool.type"].handleDeletedLayer(event, _layersReplaced);
+            this.flux.actions.tool.type.handleDeletedLayer(event, _layersReplaced);
         }.bind(this);
         descriptor.addListener("deleteTextLayer", _layerDeletedHandler);
 
@@ -171,7 +171,7 @@ define(function (require, exports) {
                     return;
                 }
 
-                this.flux.actions["tool.type"].handleTypeModalStateCanceled();
+                this.flux.actions.tool.type.handleTypeModalStateCanceled();
             }
         }.bind(this);
         descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
         AsyncDependencyQueue = require("./util/async-dependency-queue"),
         synchronization = require("./util/synchronization"),
         performance = require("./util/performance"),
+        objUtil = require("./util/object"),
         log = require("./util/log");
 
     // Using contexts, we load action files automatically
@@ -917,6 +918,17 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Given a module name, gets the module in the action tree
+     *
+     * @param {string} moduleName dot separated path to the module
+     *
+     * @return {object} Synchronized module
+     */
+    FluxController.prototype.getModule = function (moduleName) {
+        return objUtil.getPath(this._flux.actions, moduleName);
+    };
+
+    /**
      * Given a module, returns a copy in which the methods have been synchronized.
      *
      * @private
@@ -958,9 +970,31 @@ define(function (require, exports, module) {
      */
     FluxController.prototype._synchronizeAllModules = function (modules) {
         return Object.keys(modules).reduce(function (exports, moduleName) {
-            var rawModule = modules[moduleName];
+            var rawModule = modules[moduleName],
+                syncModule = this._synchronizeModule(moduleName, rawModule);
 
-            exports[moduleName] = this._synchronizeModule(moduleName, rawModule);
+            var modulePathArray = moduleName.split("."),
+                modulePath = _.initial(modulePathArray),
+                moduleBasename = _.last(modulePathArray),
+                moduleObject = {},
+                root = exports;
+
+            moduleObject[moduleBasename] = syncModule;
+
+            // If the path to this module does not yet exist
+            // we create empty objects using the folder structure
+            modulePath.forEach(function (path) {
+                if (!root.hasOwnProperty(path)) {
+                    root[path] = {};
+                }
+
+                root = root[path];
+            });
+            
+            // Using Object.assign here guarantees that if we 
+            // run into an action module on the path to one of the sub modules
+            // we don't delete all those ("search.select" then "search")
+            Object.assign(root, moduleObject);
 
             return exports;
         }.bind(this), {});
@@ -1006,13 +1040,13 @@ define(function (require, exports, module) {
 
         var allMethodPromises = Object.keys(actionIndex)
                 .filter(function (moduleName) {
-                    if (this._flux.actions[moduleName].hasOwnProperty(methodName)) {
+                    if (this.getModule(moduleName).hasOwnProperty(methodName)) {
                         return true;
                     }
                 }, this)
                 .sort(_actionModuleComparator)
                 .map(function (moduleName) {
-                    var module = this._flux.actions[moduleName],
+                    var module = this.getModule(moduleName),
                         methodPromise = module[methodName].call(module, getParam(moduleName));
 
                     return Promise.all([moduleName, methodPromise]);


### PR DESCRIPTION
Continuation of #3645, this will allow us to refer to actions by dot separated path names in `this.flux.actions` object.

So instead of `this.flux.actions["tool.type"].select`, we can type `this.flux.actions.tool.type.select`