### PR TITLE
Make grunt tasks check for dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,6 +184,10 @@ module.exports = function (grunt) {
                 options: {
                     interval: 500
                 }
+            },
+            dependencies: {
+                files: ["package.json"],
+                tasks: ["checkDependencies"]
             }
         },
         // Build tasks
@@ -230,9 +234,9 @@ module.exports = function (grunt) {
             }
         },
         concurrent: {
-            test: ["checkDependencies", "eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
+            test: ["eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
             build: {
-                tasks: ["watch:styles", "watch:dictionaries", "watch:sources", "webpack:watch"],
+                tasks: ["watch:styles", "watch:dictionaries", "watch:sources", "webpack:watch", "watch:dependencies"],
                 options: {
                     logConcurrentOutput: true
                 }
@@ -247,7 +251,7 @@ module.exports = function (grunt) {
             }
         },
         checkDependencies: {
-            this: {},
+            this: {}
         }
     });
 
@@ -269,13 +273,13 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-concat-json");
     grunt.loadNpmTasks("grunt-merge-json");
     grunt.loadNpmTasks("grunt-notify");
-    grunt.loadNpmTasks('grunt-check-dependencies');
+    grunt.loadNpmTasks("grunt-check-dependencies");
 
     grunt.registerTask("seqtest", "Runs the linter tests sequentially",
         ["eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"]
     );
     grunt.registerTask("test", "Runs linter tests",
-        ["concurrent:test"]
+        ["checkDependencies", "concurrent:test"]
     );
     grunt.registerTask("i18n", "Prepares the localization dictionaries",
         ["clean:i18n", "concat-json", "merge-json"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -230,7 +230,7 @@ module.exports = function (grunt) {
             }
         },
         concurrent: {
-            test: ["eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
+            test: ["checkDependencies", "eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"],
             build: {
                 tasks: ["watch:styles", "watch:dictionaries", "watch:sources", "webpack:watch"],
                 options: {
@@ -245,6 +245,9 @@ module.exports = function (grunt) {
                     message: "Build Successful"
                 }
             }
+        },
+        checkDependencies: {
+            this: {},
         }
     });
 
@@ -266,6 +269,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-concat-json");
     grunt.loadNpmTasks("grunt-merge-json");
     grunt.loadNpmTasks("grunt-notify");
+    grunt.loadNpmTasks('grunt-check-dependencies');
 
     grunt.registerTask("seqtest", "Runs the linter tests sequentially",
         ["eslint", "jscs", "jsdoc", "jsonlint", "lintspaces"]
@@ -277,11 +281,11 @@ module.exports = function (grunt) {
         ["clean:i18n", "concat-json", "merge-json"]
     );
     grunt.registerTask("compile", "Bundles Design Space in Release mode, for all locales",
-        ["test", "clean:build", "i18n", "copy:img", "copy:htmlRelease",
+        ["checkDependencies", "test", "clean:build", "i18n", "copy:img", "copy:htmlRelease",
          "less", "webpack:compile", "uglify", "clean:i18n"]
     );
     grunt.registerTask("debug", "Bundles Design Space in Debug mode, for English only",
-        ["clean", "i18n", "copy:img", "copy:htmlDebug", "less", "concurrent:build"]
+        ["checkDependencies", "clean", "i18n", "copy:img", "copy:htmlDebug", "less", "concurrent:build"]
     );
     grunt.registerTask("default", "Runs linter tests", ["test"]);
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "expose-loader": "^0.7.1",
     "file-loader": "^0.8.4",
     "grunt": "^0.4.5",
+    "grunt-check-dependencies": "^0.11.2",
     "grunt-concat-json": "0.0.10",
     "grunt-concurrent": "^2.0.4",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
**`npm install` is required**

This PR uses the `grunt-check-dependencies` package to add the ability to check for package dependencies before running some grunt tasks, and will inform you when `npm install` is needed. Below are the tasks that will check dependencies:

* grunt test (npm test)
* grunt compile
* grunt debug
* when running `grunt debug`, it will keep monitoring the `package.json` file for change of dependencies.

<img width="956" alt="screen shot 2016-02-01 at 11 43 02 am" src="https://cloud.githubusercontent.com/assets/118264/12728930/074517fe-c8d9-11e5-8b80-2131f3b5a6b6.png">
