### PR TITLE
More modal-safe actions

### DIFF
--- a/src/js/actions/application.js
+++ b/src/js/actions/application.js
@@ -43,7 +43,8 @@ define(function (require, exports) {
     };
     hostVersion.action = {
         reads: [locks.PS_APP],
-        writes: [locks.JS_APP]
+        writes: [locks.JS_APP],
+        modal: true
     };
 
     /** 
@@ -69,7 +70,8 @@ define(function (require, exports) {
     };
     updateRecentFiles.action = {
         reads: [locks.PS_APP],
-        writes: [locks.JS_APP]
+        writes: [locks.JS_APP],
+        modal: true
     };
 
     /**

--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -243,7 +243,8 @@ define(function (require, exports) {
     };
     initInactiveDocuments.action = {
         reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC]
+        writes: [locks.JS_DOC],
+        modal: true
     };
 
     /**
@@ -321,6 +322,7 @@ define(function (require, exports) {
     initActiveDocument.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC, locks.JS_APP],
+        modal: true,
         transfers: [historyActions.queryCurrentHistory, "layers.deselectAll", "application.updateRecentFiles"],
         hideOverlays: true
     };
@@ -376,6 +378,7 @@ define(function (require, exports) {
         reads: [locks.PS_DOC, locks.PS_APP],
         writes: [locks.JS_DOC],
         transfers: [historyActions.queryCurrentHistory],
+        modal: true,
         lockUI: true,
         hideOverlays: true
     };
@@ -398,6 +401,7 @@ define(function (require, exports) {
     };
     initializeDocuments.action = {
         reads: [locks.JS_APP, locks.JS_DOC],
+        modal: true,
         writes: [],
         transfers: [updateDocument]
     };
@@ -464,8 +468,9 @@ define(function (require, exports) {
             });
     };
     disposeDocument.action = {
-        reads: [],
+        reads: [locks.PS_DOC],
         writes: [locks.JS_DOC, locks.JS_APP],
+        modal: true,
         transfers: [updateDocument, "layers.resetLinkedLayers", "history.queryCurrentHistory",
             "ui.updateTransform", "application.updateRecentFiles", "libraries.deleteGraphicTempFiles"],
         lockUI: true,
@@ -507,6 +512,7 @@ define(function (require, exports) {
     allocateDocument.action = {
         reads: [locks.PS_APP],
         writes: [locks.JS_APP],
+        modal: true,
         transfers: [updateDocument, historyActions.queryCurrentHistory, ui.updateTransform],
         lockUI: true,
         hideOverlays: true
@@ -751,7 +757,7 @@ define(function (require, exports) {
     };
     selectDocument.action = {
         reads: [locks.JS_TOOL],
-        writes: [locks.JS_APP],
+        writes: [locks.JS_APP, locks.PS_APP],
         transfers: ["layers.resetLinkedLayers", historyActions.queryCurrentHistory,
             ui.updateTransform, toolActions.select, "panel.cloak", guideActions.queryCurrentGuides,
             toolActions.changeVectorMaskMode, updateDocument],
@@ -1126,6 +1132,7 @@ define(function (require, exports) {
     beforeStartup.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [initActiveDocument]
     };
 
@@ -1148,6 +1155,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [initInactiveDocuments, "search.documents.registerCurrentDocumentSearch",
             "search.documents.registerRecentDocumentSearch"]
     };

--- a/src/js/actions/export.js
+++ b/src/js/actions/export.js
@@ -341,6 +341,7 @@ define(function (require, exports) {
     openExportPanel.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [dialog.openDialog]
     };
 
@@ -355,6 +356,7 @@ define(function (require, exports) {
     closeExportPanel.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [dialog.closeDialog]
     };
 
@@ -412,7 +414,8 @@ define(function (require, exports) {
     };
     updateExportAsset.action = {
         reads: [locks.JS_DOC],
-        writes: [locks.JS_EXPORT, locks.PS_DOC]
+        writes: [locks.JS_EXPORT, locks.PS_DOC],
+        modal: true
     };
 
     /**
@@ -430,6 +433,7 @@ define(function (require, exports) {
     updateLayerAssetScale.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [updateExportAsset]
     };
 
@@ -448,6 +452,7 @@ define(function (require, exports) {
     updateLayerAssetSuffix.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [updateExportAsset]
     };
 
@@ -466,6 +471,7 @@ define(function (require, exports) {
     updateLayerAssetFormat.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [updateExportAsset]
     };
 
@@ -576,6 +582,7 @@ define(function (require, exports) {
     addDefaultAsset.action = {
         reads: [locks.JS_DOC, locks.JS_EXPORT],
         writes: [],
+        modal: true,
         transfers: [updateExportAsset]
     };
 
@@ -684,7 +691,8 @@ define(function (require, exports) {
     };
     setServiceAvailable.action = {
         reads: [],
-        writes: [locks.JS_EXPORT]
+        writes: [locks.JS_EXPORT],
+        modal: true
     };
 
     /**
@@ -802,6 +810,7 @@ define(function (require, exports) {
     exportLayerAssets.action = {
         reads: [locks.JS_DOC],
         writes: [locks.JS_EXPORT],
+        modal: true,
         transfers: [promptForFolder, addAsset, setServiceAvailable]
     };
 
@@ -861,6 +870,7 @@ define(function (require, exports) {
     exportDocumentAssets.action = {
         reads: [locks.JS_DOC, locks.JS_EXPORT],
         writes: [],
+        modal: true,
         transfers: [promptForFolder, addAsset, setServiceAvailable]
     };
     
@@ -881,6 +891,7 @@ define(function (require, exports) {
     copyFile.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [setServiceAvailable]
     };
     
@@ -900,6 +911,7 @@ define(function (require, exports) {
     deleteFiles.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [setServiceAvailable]
     };
 
@@ -918,6 +930,7 @@ define(function (require, exports) {
     setUseArtboardPrefix.action = {
         reads: [],
         writes: [locks.JS_EXPORT, locks.JS_PREF],
+        modal: true,
         transfers: [preferences.setPreference]
     };
 
@@ -1012,7 +1025,8 @@ define(function (require, exports) {
     };
     afterStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**

--- a/src/js/actions/groups.js
+++ b/src/js/actions/groups.js
@@ -135,7 +135,7 @@ define(function (require, exports) {
 
         playObjects.push(expandPlayObject);
 
-        var expansionPromise = descriptor.batchPlayObjects(playObjects),
+        var expansionPromise = descriptor.batchPlayObjects(playObjects, { canExecuteWhileModal: true }),
             dispatchPromise = this.dispatchAsync(events.document.SET_GROUP_EXPANSION, {
                 documentID: document.id,
                 layerIDs: collection.pluck(layers, "id"),
@@ -156,6 +156,7 @@ define(function (require, exports) {
     setGroupExpansion.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
+        modal: true,
         transfers: ["layers.initializeLayers"]
     };
 

--- a/src/js/actions/guides.js
+++ b/src/js/actions/guides.js
@@ -225,7 +225,7 @@ define(function (require, exports) {
     };
     createGuideAndTrack.action = {
         reads: [locks.JS_UI],
-        writes: [locks.JS_DOC]
+        writes: [locks.JS_DOC, locks.PS_DOC]
     };
 
     /**
@@ -298,7 +298,7 @@ define(function (require, exports) {
     };
     deleteGuide.action = {
         reads: [],
-        writes: [locks.JS_DOC],
+        writes: [locks.JS_DOC, locks.PS_DOC],
         transfers: [resetGuidePolicies]
     };
 
@@ -405,7 +405,8 @@ define(function (require, exports) {
     };
     queryCurrentGuides.action = {
         reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC]
+        writes: [locks.JS_DOC],
+        modal: true
     };
 
     // Event handlers for guides
@@ -458,9 +459,9 @@ define(function (require, exports) {
         return Promise.resolve();
     };
     beforeStartup.action = {
-        modal: true,
         reads: [],
         writes: [],
+        modal: true,
         transfers: []
     };
     

--- a/src/js/actions/help.js
+++ b/src/js/actions/help.js
@@ -40,6 +40,7 @@ define(function (require, exports) {
     openFirstLaunch.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [dialog.openDialog]
     };
 
@@ -54,6 +55,7 @@ define(function (require, exports) {
     openKeyboardShortcuts.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [dialog.openDialog]
     };
 
@@ -75,6 +77,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [locks.JS_PREF],
         writes: [],
+        modal: true,
         transfers: [openFirstLaunch]
     };
 

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -390,7 +390,8 @@ define(function (require, exports) {
     handleHistoryStateAfterSelect.action = {
         reads: [locks.JS_DOC],
         writes: [],
-        transfers: ["documents.updateDocument"]
+        transfers: ["documents.updateDocument"],
+        modal: true
     };
 
     /**
@@ -461,7 +462,8 @@ define(function (require, exports) {
     };
     beforeStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
     
     /** @ignore */

--- a/src/js/actions/keyevents.js
+++ b/src/js/actions/keyevents.js
@@ -138,7 +138,8 @@ define(function (require, exports) {
     };
     beforeStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**

--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -308,9 +308,9 @@ define(function (require, exports) {
             });
     };
     getLayerIDsForDocumentID.action = {
-        modal: true,
         reads: [locks.PS_DOC],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**
@@ -376,9 +376,9 @@ define(function (require, exports) {
             });
     };
     addLayers.action = {
-        modal: true,
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC],
+        modal: true,
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
     };
 
@@ -556,6 +556,7 @@ define(function (require, exports) {
     resetBounds.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC],
+        modal: true,
         transfers: [guides.queryCurrentGuides]
     };
 
@@ -574,6 +575,7 @@ define(function (require, exports) {
     resetBoundsQuietly.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: [resetBounds]
     };
 
@@ -602,6 +604,7 @@ define(function (require, exports) {
     resetLinkedLayers.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [resetBounds]
     };
 
@@ -638,7 +641,8 @@ define(function (require, exports) {
     };
     resetLayersByIndex.action = {
         reads: [locks.PS_DOC],
-        writes: [locks.JS_DOC]
+        writes: [locks.JS_DOC],
+        modal: true
     };
 
     /**
@@ -780,6 +784,7 @@ define(function (require, exports) {
     revealLayers.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: ["groups.setGroupExpansion"]
     };
 
@@ -810,6 +815,7 @@ define(function (require, exports) {
     resetSelection.action = {
         reads: [locks.PS_DOC, locks.JS_DOC],
         writes: [locks.JS_DOC],
+        modal: true,
         transfers: [initializeLayers]
     };
 
@@ -1089,6 +1095,7 @@ define(function (require, exports) {
     removeLayers.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC],
+        modal: true,
         transfers: ["history.queryCurrentHistory", initializeLayers],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
     };
@@ -1399,6 +1406,7 @@ define(function (require, exports) {
     resetIndex.action = {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC],
+        modal: true,
         transfers: [initializeLayers, getLayerIDsForDocumentID],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
     };
@@ -1492,7 +1500,7 @@ define(function (require, exports) {
         return this.transfer(reorderLayers, document, layerIDs, "front");
     };
     bringToFront.action = {
-        reads: [],
+        reads: [locks.JS_DOC, locks.JS_APP],
         writes: [],
         transfers: [reorderLayers],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
@@ -1523,7 +1531,7 @@ define(function (require, exports) {
         return this.transfer(reorderLayers, document, layerIDs, "next");
     };
     bringForward.action = {
-        reads: [],
+        reads: [locks.JS_DOC, locks.JS_APP],
         writes: [],
         transfers: [reorderLayers],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
@@ -1554,7 +1562,7 @@ define(function (require, exports) {
         return this.transfer(reorderLayers, document, layerIDs, "previous");
     };
     sendBackward.action = {
-        reads: [],
+        reads: [locks.JS_DOC, locks.JS_APP],
         writes: [],
         transfers: [reorderLayers],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
@@ -1585,7 +1593,7 @@ define(function (require, exports) {
         return this.transfer(reorderLayers, document, layerIDs, "back");
     };
     sendToBack.action = {
-        reads: [],
+        reads: [locks.JS_DOC, locks.JS_APP],
         writes: [],
         transfers: [reorderLayers],
         post: ["verify.layers.verifyLayerIndex", "verify.layers.verifyLayerSelection"]
@@ -1814,7 +1822,7 @@ define(function (require, exports) {
         return this.transfer(resetBounds, document, document.layers.all);
     };
     handleCanvasShift.action = {
-        reads: [locks.JS_DOC],
+        reads: [locks.JS_DOC, locks.JS_APP],
         writes: [],
         transfers: [resetBounds],
         modal: true,
@@ -2014,7 +2022,8 @@ define(function (require, exports) {
     };
     beforeStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -1096,6 +1096,7 @@ define(function (require, exports) {
     selectLibrary.action = {
         reads: [],
         writes: [locks.JS_LIBRARIES],
+        modal: true,
         transfers: [preferencesActions.setPreference]
     };
 
@@ -1118,6 +1119,7 @@ define(function (require, exports) {
     createLibrary.action = {
         reads: [],
         writes: [locks.CC_LIBRARIES, locks.JS_LIBRARIES],
+        modal: true,
         transfers: [preferencesActions.setPreference]
     };
 
@@ -1156,6 +1158,7 @@ define(function (require, exports) {
     removeLibrary.action = {
         reads: [],
         writes: [locks.CC_LIBRARIES, locks.JS_LIBRARIES],
+        modal: true,
         transfers: [preferencesActions.setPreference]
     };
     
@@ -1169,6 +1172,7 @@ define(function (require, exports) {
     };
     syncLibraries.action = {
         reads: [],
+        modal: true,
         writes: [locks.CC_LIBRARIES, locks.JS_LIBRARIES]
     };
 
@@ -1193,6 +1197,7 @@ define(function (require, exports) {
     };
     renameLibrary.action = {
         reads: [],
+        modal: true,
         writes: [locks.CC_LIBRARIES, locks.JS_LIBRARIES]
     };
     
@@ -1234,6 +1239,7 @@ define(function (require, exports) {
     handleLibrariesLoaded.action = {
         reads: [locks.CC_LIBRARIES],
         writes: [locks.JS_LIBRARIES],
+        modal: true,
         transfers: ["search.libraries.registerLibrarySearch"]
     };
     
@@ -1379,6 +1385,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [locks.JS_LIBRARIES, locks.CC_LIBRARIES],
         writes: [],
+        modal: true,
         transfers: [handleLibrariesLoaded]
     };
     

--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -156,7 +156,8 @@ define(function (require, exports) {
     };
     openURL.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**

--- a/src/js/actions/panel.js
+++ b/src/js/actions/panel.js
@@ -94,7 +94,8 @@ define(function (require, exports) {
         return adapter.setPropertyValue(TOOLTIP_TIME_KEY, DEFAULT_TOOLTIP_TIME);
     };
     enableTooltips.action = {
-        writes: [locks.PS_APP]
+        writes: [locks.PS_APP],
+        modal: true
     };
 
     /**
@@ -108,7 +109,8 @@ define(function (require, exports) {
         });
     };
     disableTooltips.action = {
-        writes: [locks.PS_APP]
+        writes: [locks.PS_APP],
+        modal: true
     };
 
     /**
@@ -127,6 +129,7 @@ define(function (require, exports) {
     togglePinnedToolbar.action = {
         reads: [],
         writes: [locks.JS_PREF],
+        modal: true,
         transfers: [preferences.setPreference]
     };
 
@@ -148,6 +151,7 @@ define(function (require, exports) {
     toggleSingleColumnMode.action = {
         reads: [],
         writes: [locks.JS_PREF],
+        modal: true,
         transfers: [preferences.setPreference]
     };
 
@@ -184,6 +188,7 @@ define(function (require, exports) {
     cloak.action = {
         reads: [locks.JS_PANEL],
         writes: [locks.PS_APP],
+        modal: true,
         hideOverlays: true
     };
 
@@ -250,6 +255,7 @@ define(function (require, exports) {
     setOverlayOffsetsForFirstDocument.action = {
         reads: [locks.JS_PREF, locks.JS_APP, locks.JS_PANEL],
         writes: [locks.PS_APP],
+        modal: true,
         transfers: [],
         hideOverlays: true
     };
@@ -287,7 +293,7 @@ define(function (require, exports) {
         var stop = payload.stop,
             psStop = appLib.colorStops[stop],
             setColorStop = appLib.setColorStop(psStop),
-            setColorStopPromise = descriptor.playObject(setColorStop),
+            setColorStopPromise = descriptor.playObject(setColorStop, { canExecuteWhileModal: true }),
             dispatchPromise = this.dispatchAsync(events.panel.COLOR_STOP_CHANGED, {
                 stop: stop
             });
@@ -297,6 +303,7 @@ define(function (require, exports) {
     setColorStop.action = {
         reads: [],
         writes: [locks.PS_APP, locks.JS_PANEL],
+        modal: true,
         transfers: []
     };
 

--- a/src/js/actions/policy.js
+++ b/src/js/actions/policy.js
@@ -382,6 +382,7 @@ define(function (require, exports) {
     beforeStartup.action = {
         reads: [],
         writes: [locks.PS_APP, locks.JS_POLICY],
+        modal: true,
         transfers: ["policy.setMode"]
     };
 

--- a/src/js/actions/search.js
+++ b/src/js/actions/search.js
@@ -56,6 +56,7 @@ define(function (require, exports) {
     toggleSearchBar.action = {
         reads: [locks.JS_DIALOG],
         writes: [],
+        modal: true,
         transfers: [dialog.openDialog, dialog.closeDialog]
     };
 
@@ -70,6 +71,7 @@ define(function (require, exports) {
     beforeStartup.action = {
         reads: [],
         writes: [locks.JS_SEARCH],
+        modal: true,
         transfers: []
     };
 

--- a/src/js/actions/shortcuts.js
+++ b/src/js/actions/shortcuts.js
@@ -275,6 +275,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: ["search.commands.registerGlobalShortcutSearch"]
     };
 

--- a/src/js/actions/superselect.js
+++ b/src/js/actions/superselect.js
@@ -449,6 +449,7 @@ define(function (require, exports) {
     click.action = {
         reads: [locks.PS_DOC, locks.JS_DOC, locks.JS_TOOL, locks.JS_UI],
         writes: [],
+        modal: true,
         transfers: [layerActions.deselectAll, layerActions.select]
     };
 
@@ -529,6 +530,7 @@ define(function (require, exports) {
     doubleClick.action = {
         reads: [locks.JS_UI, locks.JS_DOC, locks.PS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.select, editLayer]
     };
 
@@ -556,6 +558,7 @@ define(function (require, exports) {
     backOut.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.select, layerActions.deselectAll]
     };
 
@@ -575,6 +578,7 @@ define(function (require, exports) {
     nextSibling.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.select]
     };
 
@@ -614,6 +618,7 @@ define(function (require, exports) {
     diveIn.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.select, editLayer]
     };
 
@@ -717,6 +722,7 @@ define(function (require, exports) {
     marqueeSelect.action = {
         reads: [locks.JS_DOC],
         writes: [locks.JS_PANEL],
+        modal: true,
         transfers: [layerActions.deselectAll, layerActions.select]
     };
 

--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -522,6 +522,7 @@ define(function (require, exports) {
     initTool.action = {
         reads: [locks.JS_TOOL],
         writes: [],
+        modal: true,
         transfers: [selectTool]
     };
 
@@ -580,7 +581,7 @@ define(function (require, exports) {
         reads: [],
         writes: [],
         transfers: [policy.suspendAllPolicies, policy.restoreAllPolicies,
-        changeModalState, "panel.cloak"],
+            changeModalState, "panel.cloak"],
         modal: true
     };
 
@@ -909,9 +910,9 @@ define(function (require, exports) {
         return this.transfer(initTool); // Initialize the current tool
     };
     beforeStartup.action = {
-        modal: true,
         reads: [],
         writes: [],
+        modal: true,
         transfers: [initTool]
     };
 
@@ -992,9 +993,9 @@ define(function (require, exports) {
         return this.transfer(shortcuts.addShortcuts, shortcutSpecs);
     };
     afterStartup.action = {
-        modal: true,
         reads: [locks.JS_TOOL],
         writes: [],
+        modal: true,
         transfers: [shortcuts.addShortcuts]
     };
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -779,7 +779,7 @@ define(function (require, exports) {
     };
     flipY.action = {
         reads: [],
-        writes: [locks.JS_DOC, locks.JS_DOC],
+        writes: [locks.JS_DOC, locks.PS_DOC],
         transfers: [historyActions.newHistoryState, layerActions.resetBounds],
         post: ["verify.layers.verifySelectedBounds"]
     };
@@ -1370,7 +1370,7 @@ define(function (require, exports) {
         }
     };
     handleTransformLayer.action = {
-        read: [locks.JS_APP, locks.JS_DOC],
+        reads: [locks.JS_APP, locks.JS_DOC],
         writes: [locks.JS_TOOL],
         transfers: ["layers.addLayers", "ui.updateTransform", "layers.resetLayers", "layers.resetBounds",
             "history.newHistoryStateRogueSafe", "layers.select"],
@@ -1414,7 +1414,8 @@ define(function (require, exports) {
     };
     beforeStartup.action = {
         reads: [],
-        writes: []
+        writes: [],
+        modal: true
     };
 
     /**

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -817,7 +817,7 @@ define(function (require, exports) {
     beforeStartup.action = {
         reads: [],
         writes: [],
-        modal: []
+        modal: true
     };
 
     /**
@@ -833,7 +833,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [],
         writes: [],
-        modal: []
+        modal: true
     };
 
     /**
@@ -850,7 +850,7 @@ define(function (require, exports) {
     onReset.action = {
         reads: [],
         writes: [],
-        modal: []
+        modal: true
     };
 
     exports.setPostScript = setPostScript;

--- a/src/js/actions/typetool.js
+++ b/src/js/actions/typetool.js
@@ -61,9 +61,9 @@ define(function (require, exports) {
         }
     };
     handleDeletedLayer.action = {
-        modal: true,
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.removeLayers, documentActions.updateDocument]
     };
 
@@ -84,9 +84,9 @@ define(function (require, exports) {
         return this.transfer(layerActions.resetLayers, document, document.layers.selected);
     };
     handleTypeModalStateCanceled.action = {
-        modal: true,
         reads: [locks.JS_APP, locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: [layerActions.resetLayers],
         post: ["verify.layers.verifySelectedBounds"]
     };

--- a/src/js/actions/ui.js
+++ b/src/js/actions/ui.js
@@ -101,6 +101,7 @@ define(function (require, exports) {
     updateTransform.action = {
         reads: [locks.PS_APP, locks.JS_APP],
         writes: [locks.JS_UI],
+        modal: true,
         hideOverlays: true
     };
 
@@ -427,6 +428,7 @@ define(function (require, exports) {
     afterStartup.action = {
         reads: [],
         writes: [],
+        modal: true,
         transfers: ["shortcuts.addShortcut", updateTransform]
     };
 


### PR DESCRIPTION
1. Mark most actions that do not write PS doc or app state as modal safe. Playing `get` commands _should_ work even when PS is in a modal state, and the adapter should not require those to be played with the `canExecuteWhileModal` flag. Small consequence: you can now pan the canvas without ending the modal state.
2. Make `setGroupExpansion` and `setColorStop` modal safe even though they do write PS doc state.
3. Instrument the controller so that it fails fast if there are duplicate read/write locks, or unexpected action properties, both of which are indicative of typos. 
4. Fix a few typos which caused both of the aforementioned bug instances, and also add a few other missing locks.