### PR TITLE
Use actions.layereffects with correct casing

### DIFF
--- a/src/js/jsx/sections/style/ColorOverlayList.jsx
+++ b/src/js/jsx/sections/style/ColorOverlayList.jsx
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _colorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     LayerEffect.COLOR_OVERLAY, this.props.index, color, coalesce, false);
         },
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _opaqueColorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     LayerEffect.COLOR_OVERLAY, this.props.index, color, coalesce, true);
         },
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _alphaChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setAlphaThrottled(this.props.document, this.props.layers,
                     LayerEffect.COLOR_OVERLAY, this.props.index, color.a, coalesce);
         },
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
          * @param {string} blendMode new blend mode
          */
         _blendModeChanged: function (blendMode) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setBlendModeThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -126,7 +126,7 @@ define(function (require, exports, module) {
          * @param {boolean} enabled new enabled state
          */
         _enabledChanged: function (event, enabled) {
-            this.getFlux().actions.layerEffects.setEffectEnabled(
+            this.getFlux().actions.layereffects.setEffectEnabled(
                 this.props.document, this.props.layers, this.props.index, enabled, LayerEffect.COLOR_OVERLAY);
         },
 
@@ -136,7 +136,7 @@ define(function (require, exports, module) {
          * @private
          */
         _handleDelete: function () {
-            this.getFlux().actions.layerEffects.deleteEffect(
+            this.getFlux().actions.layereffects.deleteEffect(
                 this.props.document, this.props.layers, this.props.index, LayerEffect.COLOR_OVERLAY);
             headlights.logEvent("effect", "delete", "color-overlay");
         },

--- a/src/js/jsx/sections/style/EffectsPanel.jsx
+++ b/src/js/jsx/sections/style/EffectsPanel.jsx
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
 
             dialog.toggle(event);
             this._forceVisible();
-            this.getFlux().actions.layerEffects.addEffect(this.props.document, layers, effectType);
+            this.getFlux().actions.layereffects.addEffect(this.props.document, layers, effectType);
 
             headlights.logEvent("effect", "create", _.kebabCase(effectType));
         },

--- a/src/js/jsx/sections/style/ShadowList.jsx
+++ b/src/js/jsx/sections/style/ShadowList.jsx
@@ -81,7 +81,7 @@ define(function (require, exports) {
          * @param {boolean} coalesce
          */
         _colorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     this.props.type, this.props.index, color, coalesce, false);
         },
@@ -94,7 +94,7 @@ define(function (require, exports) {
          * @param {boolean} coalesce
          */
         _opaqueColorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     this.props.type, this.props.index, color, coalesce, true);
         },
@@ -107,7 +107,7 @@ define(function (require, exports) {
          * @param {boolean} coalesce
          */
         _alphaChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setAlphaThrottled(this.props.document, this.props.layers,
                     this.props.type, this.props.index, color.a, coalesce);
         },
@@ -139,7 +139,7 @@ define(function (require, exports) {
             });
 
             if (xChanged) {
-                this.getFlux().actions.layerEffects
+                this.getFlux().actions.layereffects
                     .setShadowXThrottled(this.props.document, this.props.layers,
                         this.props.index, minValidX, this.props.type);
             } else {
@@ -174,7 +174,7 @@ define(function (require, exports) {
             });
 
             if (yChanged) {
-                this.getFlux().actions.layerEffects
+                this.getFlux().actions.layereffects
                     .setShadowYThrottled(this.props.document, this.props.layers,
                         this.props.index, minValidY, this.props.type);
             } else {
@@ -190,7 +190,7 @@ define(function (require, exports) {
          * @param {blur} blur new shadow blur value in pixels
          */
         _blurChanged: function (event, blur) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setShadowBlurThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -206,7 +206,7 @@ define(function (require, exports) {
          * @param {spread} spread new shadow spread value in pixels
          */
         _spreadChanged: function (event, spread) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setShadowSpreadThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -221,7 +221,7 @@ define(function (require, exports) {
          * @param {string} blendMode new blend mode
          */
         _blendModeChanged: function (blendMode) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setBlendModeThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -239,7 +239,7 @@ define(function (require, exports) {
          * @param {boolean} enabled new enabled state
          */
         _enabledChanged: function (event, enabled) {
-            this.getFlux().actions.layerEffects.setEffectEnabled(
+            this.getFlux().actions.layereffects.setEffectEnabled(
                 this.props.document, this.props.layers, this.props.index, enabled, this.props.type);
         },
 
@@ -249,7 +249,7 @@ define(function (require, exports) {
          * @private
          */
         _handleDelete: function () {
-            this.getFlux().actions.layerEffects.deleteEffect(
+            this.getFlux().actions.layereffects.deleteEffect(
                 this.props.document, this.props.layers, this.props.index, this.props.type);
             
             headlights.logEvent("effect", "delete", "shadow");

--- a/src/js/jsx/sections/style/StrokeList.jsx
+++ b/src/js/jsx/sections/style/StrokeList.jsx
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _colorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     LayerEffect.STROKE, this.props.index, color, coalesce, false);
         },
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _opaqueColorChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setColorThrottled(this.props.document, this.props.layers,
                     LayerEffect.STROKE, this.props.index, color, coalesce, true);
         },
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
          * @param {boolean} coalesce
          */
         _alphaChanged: function (color, coalesce) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setAlphaThrottled(this.props.document, this.props.layers,
                     LayerEffect.STROKE, this.props.index, color.a, coalesce);
         },
@@ -121,7 +121,7 @@ define(function (require, exports, module) {
          * @param {string} blendMode new blend mode
          */
         _blendModeChanged: function (blendMode) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setBlendModeThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
          * @param  {number} size
          */
         _sizeChanged: function (event, size) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setStrokeSizeThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
          * @param  {string} style
          */
         _styleChanged: function (style) {
-            this.getFlux().actions.layerEffects
+            this.getFlux().actions.layereffects
                 .setStrokeStyleThrottled(this.props.document,
                     this.props.layers,
                     this.props.index,
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
          * @param {boolean} enabled new enabled state
          */
         _enabledChanged: function (event, enabled) {
-            this.getFlux().actions.layerEffects.setEffectEnabled(
+            this.getFlux().actions.layereffects.setEffectEnabled(
                 this.props.document, this.props.layers, this.props.index, enabled, LayerEffect.STROKE);
         },
 
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
          * @private
          */
         _handleDelete: function () {
-            this.getFlux().actions.layerEffects.deleteEffect(
+            this.getFlux().actions.layereffects.deleteEffect(
                 this.props.document, this.props.layers, this.props.index, LayerEffect.STROKE);
             headlights.logEvent("effect", "delete", "stroke");
         },

--- a/src/js/jsx/sections/style/UnsupportedEffectList.jsx
+++ b/src/js/jsx/sections/style/UnsupportedEffectList.jsx
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
          * @param  {number} effectIndex
          */
         _handleDelete: function (effectType, effectIndex) {
-            this.getFlux().actions.layerEffects.deleteEffect(
+            this.getFlux().actions.layereffects.deleteEffect(
                 this.props.document, this.props.layers, effectIndex, effectType);
             headlights.logEvent("effect", "delete", "unsupported");
         },
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
          * @param {boolean} enabled new enabled state
          */
         _enabledChangedHandler: function (effectType, effectIndex, event, enabled) {
-            this.getFlux().actions.layerEffects.setEffectEnabled(
+            this.getFlux().actions.layereffects.setEffectEnabled(
                 this.props.document, this.props.layers, effectIndex, enabled, effectType);
         },
 

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -458,7 +458,7 @@ define(function (require, exports, module) {
                         .on("click", applyTypeStyleFunc);
                 } else if (sample.type === "layerEffects") {
                     var duplicateLayerEffectsFunc = function () {
-                        fluxActions.layerEffects.duplicateLayerEffects(this.state.document, targetLayers, sample.value);
+                        fluxActions.layereffects.duplicateLayerEffects(this.state.document, targetLayers, sample.value);
                         d3.event.stopPropagation();
                         headlights.logEvent("tools", "sampler-hud", sample.type);
                     }.bind(this);


### PR DESCRIPTION
Addresses #3650, we were using `actions.layerEffects`, but file name is `layereffects` so casing had to be changed.