### PR TITLE
Unify mask commands to all have the same result

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -40,6 +40,7 @@ define(function (require, exports) {
     var events = require("../events"),
         guides = require("./guides"),
         layers = require("./layers"),
+        mask = require("./mask"),
         locks = require("js/locks"),
         policy = require("./policy"),
         shortcuts = require("./shortcuts"),
@@ -619,6 +620,12 @@ define(function (require, exports) {
         var currentLayers = currentDocument.layers.selected,
             currentLayer = currentLayers.first();
 
+        if (currentLayers.size > 2) {
+            return Promise.resolve();
+        } else if (currentLayers.size === 2) {
+            return this.transfer(mask.createVectorMaskFromShape);
+        }
+
         // vector mask mode requires an active layer
         if (!currentLayer) {
             if (vectorMaskMode) {
@@ -814,7 +821,7 @@ define(function (require, exports) {
         writes: [locks.JS_TOOL, locks.PS_DOC],
         modal: true,
         transfers: [selectTool, policy.addPointerPolicies, policy.removePointerPolicies,
-            installShapeDefaults, "layers.resetLayers"]
+            installShapeDefaults, "layers.resetLayers", mask.createVectorMaskFromShape]
     };
 
     /**

--- a/src/js/jsx/DocumentHeader.jsx
+++ b/src/js/jsx/DocumentHeader.jsx
@@ -249,7 +249,8 @@ define(function (require, exports, module) {
                     document.layers.selected.isEmpty();
 
             if (!maskDisabled) {
-                maskDisabled = !document.layers.selectedLayersCanHaveVectorMask;
+                maskDisabled = !(document.layers.selectedLayersCanHaveVectorMask ||
+                    document.layers.selectedLayersCanMakeVectorMaskFromShape);
             }
 
             if (!maskDisabled) {

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -581,11 +581,30 @@ define(function (require, exports, module) {
         "selectedLayersCanHaveVectorMask": function () {
             var layers = this.selected,
                 curLayer = layers.first();
-            return !layers.isEmpty() &&
+            return layers.size === 1 &&
                 !curLayer.isGroupEnd &&
                 !curLayer.isVector &&
                 !curLayer.isBackground &&
                 !curLayer.locked;
+        },
+
+        /**
+         * Determine whether a vector mask can be created from a shape on the current layer selection
+         *
+         * @return {boolean} if the layer selection can handle a vector mask
+         */
+        "selectedLayersCanMakeVectorMaskFromShape": function () {
+            var layers = this.selected;
+            return layers.size === 2 &&
+                layers.some(function (curLayer) {
+                    return curLayer.isVector;
+                }) &&
+                layers.some(function (curLayer) {
+                    return !curLayer.isGroupEnd &&
+                    !curLayer.isVector &&
+                    !curLayer.isBackground &&
+                    !curLayer.locked;
+                });
         },
 
         /**

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -274,14 +274,18 @@ define(function (require, exports, module) {
                 (document !== null) &&
                 !document.unsupported &&
                 (document.layers !== null) &&
-                (document.layers.selectedNormalized.size === 2) &&
+                (((document.layers.selectedNormalized.size === 2) &&
                 (document.layers.selected.some(function (layer) {
                     return layer.isVector;
                 })) &&
                 (document.layers.selected.some(function (layer) {
                     return document.layers.canSupportVectorMask(layer) &&
                         !layer.vectorMaskEnabled;
-                }))
+                }))) ||
+                ((document.layers.selectedNormalized.size === 1) &&
+                (document.layers.selected.some(function (layer) {
+                    return document.layers.canSupportVectorMask(layer);
+                }))))
         };
     };
 


### PR DESCRIPTION
Adding code to the two paths into vector masks so that they have the same results depending upon the layer selection