### PR TITLE
Re-add marquee rectangles

### DIFF
--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -300,6 +300,20 @@ define(function (require, exports, module) {
                 var offset = system.isMac ? 0 : scale;
 
                 if (layer.isArtboard) {
+                    // We don't want to draw the artboard bounds if it's the selected artboard     
+                    if (!layer.selected) {
+                        this._scrimGroup
+                            .append("rect")
+                            .attr("x", bounds.left + offset)
+                            .attr("y", bounds.top + offset)
+                            .attr("width", bounds.width)
+                            .attr("height", bounds.height)
+                            .attr("layer-id", layer.id)
+                            .attr("id", "layer-" + layer.id)
+                            .classed("layer-bounds", false)
+                            .classed("layer-artboard-bounds", true);
+                    }
+
                     var nameBounds = uiUtil.getNameBadgeBounds(bounds, scale),
                         namePointCoords = [
                             { x: nameBounds.left, y: nameBounds.top },
@@ -321,6 +335,19 @@ define(function (require, exports, module) {
                         .attr("height", nameBounds.height)
                         .classed("artboard-name-rect", true)
                         .classed("layer-artboard-bounds", true);
+                } else {
+                    this._scrimGroup
+                        .append("rect")
+                        .attr("x", bounds.left + offset)
+                        .attr("y", bounds.top + offset)
+                        .attr("width", bounds.width)
+                        .attr("height", bounds.height)
+                        .attr("layer-id", layer.id)
+                        .attr("layer-selected", layer.selected)
+                        .attr("id", "layer-" + layer.id)
+                        .classed("layer-bounds", true)
+                        .classed("layer-artboard-bounds", false)
+                        .classed("marqueeable", true);
                 }
             }, this);
 


### PR DESCRIPTION
Looks like we got a little over zealous with the lint cleanup in #3640 and removed the marquee rectangles from the overlay, breaking marquee select.

This re-adds them, addressing #3653