### PR TITLE
Add acquireFocusOnMouseDown prop to Focusable, set to false in LayerFace

### DIFF
--- a/src/js/jsx/mixin/Focusable.js
+++ b/src/js/jsx/mixin/Focusable.js
@@ -24,13 +24,24 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var ReactDOM = require("react-dom");
+    var ReactDOM = require("react-dom"),
+        React = require("react");
 
     var OS = require("adapter").os;
 
     var log = require("js/util/log");
 
     module.exports = {
+        propTypes: {
+            acquireFocusOnMouseDown: React.PropTypes.bool
+        },
+
+        getDefaultProps: function () {
+            return {
+                acquireFocusOnMouseDown: true // If false, will not install mousedown listeners
+            };
+        },
+        
         /** @ignore */
         acquireFocus: function () {
             return OS.acquireKeyboardFocus()
@@ -51,10 +62,14 @@ define(function (require, exports, module) {
                 });
         },
         componentDidMount: function () {
-            ReactDOM.findDOMNode(this).addEventListener("mousedown", this.acquireFocus);
+            if (this.props.acquireFocusOnMouseDown) {
+                ReactDOM.findDOMNode(this).addEventListener("mousedown", this.acquireFocus);
+            }
         },
         componentWillUnmount: function () {
-            ReactDOM.findDOMNode(this).removeEventListener("mousedown", this.acquireFocus);
+            if (this.props.acquireFocusOnMouseDown) {
+                ReactDOM.findDOMNode(this).removeEventListener("mousedown", this.acquireFocus);
+            }
         }
     };
 });

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -692,6 +692,7 @@ define(function (require, exports, module) {
                                         className="face__name"
                                         ref="layerName"
                                         doubleClickToEdit={true}
+                                        acquireFocusOnMouseDown={false}
                                         value={layer.name}
                                         disabled={this.props.disabled || !nameEditable}
                                         onFocus={this._handleInputFocusChange.bind(this, true)}


### PR DESCRIPTION
When the name of the layer in a LayerFace was clicked on, we would immediately call `OS.acquireKeyboardFocus` due to the `mousedown` listener in Focusable mixin (which is the mixin of TextInput showing layer name). But we would never call `OS.releaseKeyboardFocus` because those were only called on commit/cancel/finish methods.

For TextInputs like layer name, we don't want to acquire focus unless the user double clicks to start editing. We instead acquire focus on `_beginEdit` function which is what happens when user double clicks.

Addresses #3581 
