### PR TITLE
User interaction batchPlay option

### DIFF
--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -67,7 +67,8 @@ define(function (require, exports) {
                 target: documentLib.referenceBy.id(document.id),
                 coalesce: !!options.coalesce,
                 suppressHistoryStateNotification: !!options.coalesce
-            }
+            },
+            isUserInteractionCommand: !!options.coalesce
         });
     };
 

--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -1136,7 +1136,8 @@ define(function (require, exports) {
                 target: documentLib.referenceBy.id(document.id),
                 coalesce: !!options.coalesce,
                 suppressHistoryStateNotification: !!options.coalesce
-            }
+            },
+            isUserInteractionCommand: !!options.coalesce
         });
 
         var radiusDescriptor = contentLib.setRadius(radius),

--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -71,7 +71,8 @@ define(function (require, exports) {
                 quality: "draft"
             },
             canExecuteWhileModal: true,
-            ignoreTargetWhenModal: true
+            ignoreTargetWhenModal: true,
+            isUserInteractionCommand: !!coalesce
         };
 
         if (!modal) {

--- a/src/js/stores/menu.js
+++ b/src/js/stores/menu.js
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
             if (!Immutable.is(oldMenu, this._applicationMenu)) {
                 this.emit("change");
             }
-        }, 200),
+        }, 400),
 
         /**
          * This is our main listener for most of the events in the app


### PR DESCRIPTION
1. Set the `isUserInteractionCommand` batchPlay option when coalescing `transform.setRadius`, `shapes.setFill*`, `shapes.setStroke*` and `type.setType*` actions. (I think this only affects the color picker and the radius slider, at the moment, since the other actions that could be affected by this change aren't ever coalesced.) I can't actually measure any performance difference with this change, but @jsbache wants it and I want him to be happy! 
2. Also, just because, double the menu-update debounce timeout from 200ms to 400ms to make it less likely to trigger during user interactions. 200ms seems a little optimistic for a lot of computers... 