### PR TITLE
document load time: CC Libraries optimization

### DIFF
--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -55,13 +55,6 @@ define(function (require, exports) {
         historyActions = require("./history"),
         preferencesActions = require("./preferences"),
         LibrarySyncStatus = require("js/models/library_sync_status");
-
-    /**
-     * The external CC Libraries API is loaded here asynchronously, used in beforeStartup
-     *
-     * @type {Promise}
-     */
-    var apiLoadPromise = Promise.promisify($S)("file://shared/libs/cc-libraries-api.min.js");
         
     /**
      * For image elements, their extensions signify their representation type
@@ -1273,14 +1266,35 @@ define(function (require, exports) {
         _toolModalStateChangedHandler = function (event) {
             var isPlacingGraphic = this.flux.store("library").getState().isPlacingGraphic,
                 modalStateEnded = event.state && event.state._value === "exit";
-
+        
             if (isPlacingGraphic && modalStateEnded) {
                 this.flux.actions.libraries.handleCompletePlacingGraphic();
             }
         }.bind(this);
         descriptor.addListener("toolModalStateChanged", _toolModalStateChangedHandler);
 
-        return apiLoadPromise
+        return Promise.resolve();
+    };
+    beforeStartup.action = {
+        reads: [locks.JS_PREF],
+        writes: [locks.JS_LIBRARIES, locks.CC_LIBRARIES]
+    };
+
+    /**
+     * Libraries loadedCollections event handlers.
+     *
+     * @private
+     * @type {function}
+     */
+    var _handleLibrariesLoadedHelper;
+
+    /**
+     * After startup, load the libraries
+     *
+     * @return {Promise}
+     */
+    var afterStartup = function () {
+        return Promise.promisify($S)("file://shared/libs/cc-libraries-api.min.js")
             .timeout(3000, "CC Libraries API load timeout, please don't restart and notify the chatroom!")
             .bind(this)
             .then(function () {
@@ -1288,14 +1302,14 @@ define(function (require, exports) {
                 // There is now a ccLibraries object in this scope
                 // So we emit that to the store
                 this.dispatch(events.libraries.LIBRARIES_API_LOADED, ccLibraries);
-
+        
                 var dependencies = {
                     // Photoshop on startup will grab the port of the CC Library process and expose it to us
                     vulcanCall: function (requestType, requestPayload, responseType, callback) {
                         descriptor.getProperty("application", "designSpaceLibrariesInfo")
                             .then(function (imsInfo) {
                                 var port = imsInfo.port;
-
+        
                                 callback(JSON.stringify({ port: port }));
                             });
                     },
@@ -1331,7 +1345,7 @@ define(function (require, exports) {
                         }
                     }
                 };
-
+        
                 // SHARED_LOCAL_STORAGE flag forces websocket use
                 ccLibraries.configure(dependencies, {
                     SHARED_LOCAL_STORAGE: true,
@@ -1344,49 +1358,31 @@ define(function (require, exports) {
                         ELEMENT_COLORTHEME_TYPE
                     ]
                 });
+
+                if (_handleLibrariesLoadedHelper) {
+                    ccLibraries.removeLoadedCollectionsListener(_handleLibrariesLoadedHelper);
+                }
+
+                // Listen to the load event of CC Libraries. The event has two scenarios:
+                //     loaded: Libraries data is ready for use. Fired after user sign in creative cloud.
+                //     unloaded: Libraries data is cleared. Fired after user sign out creative cloud.
+                _handleLibrariesLoadedHelper = function () {
+                    return this.flux.actions.libraries.handleLibrariesLoaded();
+                }.bind(this);
+                ccLibraries.addLoadedCollectionsListener(_handleLibrariesLoadedHelper);
+                
+                // ccLibraries will not notify if users is logged out before, call the callback manually instead.
+                setTimeout(function () {
+                    if (ccLibraries.getLoadedCollections.length === 0) {
+                        _handleLibrariesLoadedHelper();
+                    }
+                }, 1000);
             });
-    };
-    beforeStartup.action = {
-        reads: [locks.JS_PREF],
-        writes: [locks.JS_LIBRARIES, locks.CC_LIBRARIES]
-    };
-
-    /**
-     * Libraries loadedCollections event handlers.
-     *
-     * @private
-     * @type {function}
-     */
-    var _handleLibrariesLoadedHelper;
-
-    /**
-     * After startup, load the libraries
-     *
-     * @return {Promise}
-     */
-    var afterStartup = function () {
-        var ccLibraries = this.flux.store("library").getLibrariesAPI();
-
-        if (_handleLibrariesLoadedHelper) {
-            ccLibraries.removeLoadedCollectionsListener(_handleLibrariesLoadedHelper);
-        }
-
-        // Listen to the load event of CC Libraries. The event has two scenarios:
-        //     loaded: Libraries data is ready for use. Fired after user sign in creative cloud.
-        //     unloaded: Libraries data is cleared. Fired after user sign out creative cloud.
-        _handleLibrariesLoadedHelper = function () {
-            return this.flux.actions.libraries.handleLibrariesLoaded();
-        }.bind(this);
-        ccLibraries.addLoadedCollectionsListener(_handleLibrariesLoadedHelper);
-        
-        // Trigger the load event callback manually for initial start up.
-        return this.transfer(handleLibrariesLoaded);
     };
     afterStartup.action = {
         reads: [locks.JS_LIBRARIES, locks.CC_LIBRARIES],
         writes: [],
-        modal: true,
-        transfers: [handleLibrariesLoaded]
+        modal: true
     };
     
     /**

--- a/src/js/actions/libraries.js
+++ b/src/js/actions/libraries.js
@@ -1372,11 +1372,11 @@ define(function (require, exports) {
                 }.bind(this);
                 ccLibraries.addLoadedCollectionsListener(_handleLibrariesLoadedHelper);
                 
-                // `ccLibraries` will not emit the `LoadedCollections` (will empty collection) event 
-                // when the user log out Creative Cloud before it starts, so we have to manually call
-                // the event handler to notify the `Unload` event.
+                // `ccLibraries` will not emit the `LoadedCollections` event when the user sign out Creative Cloud
+                // before it is loaded. We have to check the size of libraries once, and call the event handler
+                // when it is empty.
                 setTimeout(function () {
-                    if (ccLibraries.getLoadedCollections.length === 0) {
+                    if (ccLibraries.getLoadedCollections().length === 0) {
                         _handleLibrariesLoadedHelper();
                     }
                 }, 1000);

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -257,164 +257,173 @@ define(function (require, exports, module) {
 
         render: function () {
             var documentIDs = this.state.documentIDs,
-                activeDocument = this.state.activeDocument;
+                activeDocument = this.state.activeDocument,
+                hasActiveDocument = activeDocument && this.state.activeDocumentInitialized && documentIDs.size > 0;
 
-            if (activeDocument && this.state.activeDocumentInitialized && documentIDs.size > 0) {
-                var panelStore = this.getFlux().store("panel"),
-                    components = panelStore.components,
-                    documentProperties = {
-                        transformPanels: [],
-                        appearancePanels: [],
-                        effectPanels: [],
-                        exportPanels: [],
-                        layerPanels: []
+            var panelStore = this.getFlux().store("panel"),
+                components = panelStore.components,
+                documentPanels = {
+                    transformPanels: [],
+                    appearancePanels: [],
+                    effectPanels: [],
+                    exportPanels: [],
+                    layerPanels: [],
+                    librariesPanel: null
+                };
+                
+            this.state.mountedDocuments.forEach(function (document) {
+                var documentID = document.id,
+                    current = documentID === activeDocument.id,
+                    disabled = document && document.unsupported,
+                    panelProps = {
+                        key: documentID,
+                        disabled: disabled,
+                        document: document,
+                        active: current,
+                        shouldPanelGrow: !this.state[components.LAYERS_PANEL] &&
+                            !this.state[components.LIBRARIES_PANEL]
                     };
                     
-                this.state.mountedDocuments.forEach(function (document) {
-                    var documentID = document.id,
-                        current = documentID === activeDocument.id,
-                        disabled = document && document.unsupported,
-                        panelProps = {
-                            key: documentID,
-                            disabled: disabled,
-                            document: document,
-                            active: current,
-                            shouldPanelGrow: !this.state[components.LAYERS_PANEL] &&
-                                !this.state[components.LIBRARIES_PANEL]
-                        };
-                        
-                    documentProperties.transformPanels.push(
-                        <TransformPanel {...panelProps} />
-                    );
-                    
-                    documentProperties.appearancePanels.push(
-                        <AppearancePanel
-                            {...panelProps}
-                            ref={current && components.APPEARANCE_PANEL}
-                            visible={!disabled && this.state[components.APPEARANCE_PANEL]}
-                            onVisibilityToggle=
-                                {this._handlePanelVisibilityToggle
-                                    .bind(this, components.APPEARANCE_PANEL)} />
-                    );
-                    
-                    documentProperties.effectPanels.push(
-                        <EffectsPanel
-                            {...panelProps}
-                            ref={current && components.EFFECTS_PANEL}
-                            visible={!disabled && this.state[components.EFFECTS_PANEL]}
-                            onVisibilityToggle=
-                                {this._handlePanelVisibilityToggle.bind(this, components.EFFECTS_PANEL)} />
-                    );
-                    
-                    documentProperties.exportPanels.push(
-                        <ExportPanel
-                            {...panelProps}
-                            ref={current && components.EXPORT_PANEL}
-                            visible={!disabled && this.state[components.EXPORT_PANEL]}
-                            onVisibilityToggle=
-                                {this._handlePanelVisibilityToggle.bind(this, components.EXPORT_PANEL)} />
-                    );
-                    
-                    documentProperties.layerPanels.push(
-                        <LayersPanel
-                            {...panelProps}
-                            visible={this.state[components.LAYERS_PANEL]}
-                            ref={current && components.LAYERS_PANEL}
-                            onVisibilityToggle=
-                                {this._handlePanelVisibilityToggle.bind(this, components.LAYERS_PANEL)} />
-                    );
-                }, this);
-
-                var propertiesButtonClassNames = classnames({
-                        "toolbar-button": true,
-                        "tool-selected": this.state[components.PROPERTIES_COL]
-                    }),
-                    layersButtonClassNames = classnames({
-                        "toolbar-button": true,
-                        "tool-selected": this.state[components.LAYERS_LIBRARY_COL]
-                    }),
-                    panelCollapse = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_COLLAPSE"),
-                    panelExpand = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_EXPAND"),
-                    layerColumnTitle = nls.localize("strings.TOOLTIPS.LAYERS_LIBRARIES") +
-                        (this.state[components.LAYERS_LIBRARY_COL] ? panelCollapse : panelExpand),
-                    propertiesColumnTitle = nls.localize("strings.TOOLTIPS.PROPERTIES") +
-                        (this.state[components.PROPERTIES_COL] ? panelCollapse : panelExpand),
-                    handlePropertiesColumnVisibilityToggle =
-                        this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL),
-                    handleLayersLibraryColumnVisibilityToggle =
-                        this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL);
-
-                var librariesPanel = (
-                    <LibrariesPanel
-                        key="libraries-panel"
-                        className="section__active"
-                        ref={components.LIBRARIES_PANEL}
-                        disabled={activeDocument && activeDocument.unsupported}
-                        document={activeDocument}
-                        visible={this.state[components.LIBRARIES_PANEL]}
-                        onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
-                        components.LIBRARIES_PANEL)} />
+                documentPanels.transformPanels.push(
+                    <TransformPanel {...panelProps} />
                 );
+                
+                documentPanels.appearancePanels.push(
+                    <AppearancePanel
+                        {...panelProps}
+                        ref={current && components.APPEARANCE_PANEL}
+                        visible={!disabled && this.state[components.APPEARANCE_PANEL]}
+                        onVisibilityToggle=
+                            {this._handlePanelVisibilityToggle
+                                .bind(this, components.APPEARANCE_PANEL)} />
+                );
+                
+                documentPanels.effectPanels.push(
+                    <EffectsPanel
+                        {...panelProps}
+                        ref={current && components.EFFECTS_PANEL}
+                        visible={!disabled && this.state[components.EFFECTS_PANEL]}
+                        onVisibilityToggle=
+                            {this._handlePanelVisibilityToggle.bind(this, components.EFFECTS_PANEL)} />
+                );
+                
+                documentPanels.exportPanels.push(
+                    <ExportPanel
+                        {...panelProps}
+                        ref={current && components.EXPORT_PANEL}
+                        visible={!disabled && this.state[components.EXPORT_PANEL]}
+                        onVisibilityToggle=
+                            {this._handlePanelVisibilityToggle.bind(this, components.EXPORT_PANEL)} />
+                );
+                
+                documentPanels.layerPanels.push(
+                    <LayersPanel
+                        {...panelProps}
+                        visible={this.state[components.LAYERS_PANEL]}
+                        ref={current && components.LAYERS_PANEL}
+                        onVisibilityToggle=
+                            {this._handlePanelVisibilityToggle.bind(this, components.LAYERS_PANEL)} />
+                );
+            }, this);
+            
+            documentPanels.librariesPanel = (
+                <LibrariesPanel
+                    key="libraries-panel"
+                    className="section__active"
+                    ref={components.LIBRARIES_PANEL}
+                    disabled={activeDocument && activeDocument.unsupported}
+                    document={activeDocument}
+                    visible={this.state[components.LIBRARIES_PANEL]}
+                    onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
+                    components.LIBRARIES_PANEL)} />
+            );
 
-                if (this.props.singleColumnModeEnabled) {
-                    return (
-                        <div className="panel-set__container panel-set__container__small-screen">
-                            <div ref="panelSet"
-                                 className="panel-set">
-                                <PanelColumn visible={true}>
-                                    {documentProperties.transformPanels}
-                                    {documentProperties.appearancePanels}
-                                    {documentProperties.effectPanels}
-                                    {documentProperties.exportPanels}
-                                    {documentProperties.layerPanels}
-                                    {librariesPanel}
-                                </PanelColumn>
-                            </div>
-                        </div>
-                    );
-                } else {
-                    return (
-                        <div className="panel-set__container">
-                            <div ref="panelSet"
-                                 className="panel-set">
-                                <PanelColumn visible={this.state[components.PROPERTIES_COL]}
-                                             onVisibilityToggle={handlePropertiesColumnVisibilityToggle}>
-                                    {documentProperties.transformPanels}
-                                    {documentProperties.appearancePanels}
-                                    {documentProperties.effectPanels}
-                                    {documentProperties.exportPanels}
-                                </PanelColumn>
-                                <PanelColumn visible={this.state[components.LAYERS_LIBRARY_COL]}
-                                             onVisibilityToggle= {handleLayersLibraryColumnVisibilityToggle}>
-                                    {documentProperties.layerPanels}
-                                    {librariesPanel}
-                                </PanelColumn>
-                            </div>
-                            <IconBar>
-                                <Button className={propertiesButtonClassNames}
-                                    title={propertiesColumnTitle}
-                                    disabled={false}
-                                    onClick=
-                                    {this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL)}>
-                                    <SVGIcon
-                                        CSSID="properties" />
-                                </Button>
-                                <Button className={layersButtonClassNames}
-                                    title={layerColumnTitle}
-                                    disabled={false}
-                                    onClick=
-                                    {this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL)}>
-                                    <SVGIcon
-                                        CSSID="layers" />
-                                </Button>
-                            </IconBar>
-                        </div>
-                    );
-                }
-            } else if (this.state.recentFilesInitialized) {
-                return (
-                    <div className="panel-set panel-set__active null-state">
-                        <PanelColumn ref="panelSet" visible="true">
+            var propertiesButtonClassNames = classnames({
+                    "toolbar-button": true,
+                    "tool-selected": this.state[components.PROPERTIES_COL]
+                }),
+                layersButtonClassNames = classnames({
+                    "toolbar-button": true,
+                    "tool-selected": this.state[components.LAYERS_LIBRARY_COL]
+                }),
+                panelCollapse = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_COLLAPSE"),
+                panelExpand = nls.localize("strings.TOOLTIPS.PANEL_COLUMN_EXPAND"),
+                layerColumnTitle = nls.localize("strings.TOOLTIPS.LAYERS_LIBRARIES") +
+                    (this.state[components.LAYERS_LIBRARY_COL] ? panelCollapse : panelExpand),
+                propertiesColumnTitle = nls.localize("strings.TOOLTIPS.PROPERTIES") +
+                    (this.state[components.PROPERTIES_COL] ? panelCollapse : panelExpand),
+                handlePropertiesColumnVisibilityToggle =
+                    this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL),
+                handleLayersLibraryColumnVisibilityToggle =
+                    this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL);
+            
+            var documentPanelSet,
+                documentPanelSetClassName = classnames({
+                    "panel-set": true,
+                    "panel-set__small-screen": this.props.singleColumnModeEnabled,
+                    "panel-set__not-visible": !hasActiveDocument
+                });
+
+            if (this.props.singleColumnModeEnabled) {
+                documentPanelSet = (
+                    <div className={documentPanelSetClassName}>
+                        <PanelColumn visible={hasActiveDocument}>
+                            {documentPanels.transformPanels}
+                            {documentPanels.appearancePanels}
+                            {documentPanels.effectPanels}
+                            {documentPanels.exportPanels}
+                            {documentPanels.layerPanels}
+                            {documentPanels.librariesPanel}
+                        </PanelColumn>
+                    </div>
+                );
+            } else {
+                documentPanelSet = (
+                    <div className={documentPanelSetClassName}>
+                        <PanelColumn visible={hasActiveDocument && this.state[components.PROPERTIES_COL]}
+                                     onVisibilityToggle={handlePropertiesColumnVisibilityToggle}>
+                            {documentPanels.transformPanels}
+                            {documentPanels.appearancePanels}
+                            {documentPanels.effectPanels}
+                            {documentPanels.exportPanels}
+                        </PanelColumn>
+                        <PanelColumn visible={hasActiveDocument && this.state[components.LAYERS_LIBRARY_COL]}
+                                     onVisibilityToggle= {handleLayersLibraryColumnVisibilityToggle}>
+                            {documentPanels.layerPanels}
+                            {documentPanels.librariesPanel}
+                        </PanelColumn>
+                        <IconBar>
+                            <Button className={propertiesButtonClassNames}
+                                title={propertiesColumnTitle}
+                                disabled={false}
+                                onClick=
+                                {this._handleColumnVisibilityToggle.bind(this, components.PROPERTIES_COL)}>
+                                <SVGIcon
+                                    CSSID="properties" />
+                            </Button>
+                            <Button className={layersButtonClassNames}
+                                title={layerColumnTitle}
+                                disabled={false}
+                                onClick=
+                                {this._handleColumnVisibilityToggle.bind(this, components.LAYERS_LIBRARY_COL)}>
+                                <SVGIcon
+                                    CSSID="layers" />
+                            </Button>
+                        </IconBar>
+                    </div>
+                );
+            }
+
+            var noDocPanelSet,
+                noDocPanelSetClassName = classnames({
+                    "panel-set": true,
+                    "panel-set__not-visible": hasActiveDocument
+                });
+            
+            if (this.state.recentFilesInitialized) {
+                noDocPanelSet = (
+                    <div className={noDocPanelSetClassName}>
+                        <PanelColumn visible="true">
                             <RecentFiles recentFiles={this.state.recentFiles} />
                             <ArtboardPresets />
                         </PanelColumn>
@@ -422,16 +431,20 @@ define(function (require, exports, module) {
                     </div>
                 );
             } else {
-                return (
-                    <div className="panel-set__container">
-                        <div ref="panelSet"
-                             className="panel-set">
-                            <PanelColumn visible={true} />
-                        </div>
+                noDocPanelSet = (
+                    <div className={noDocPanelSetClassName}>
+                        <PanelColumn visible="true" />
                         <IconBar />
                     </div>
                 );
             }
+            
+            return (
+                <div className="panel-set__container" ref="panelSet">
+                    {documentPanelSet}
+                    {noDocPanelSet}
+                </div>
+            );
         }
     });
 

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -185,10 +185,16 @@ define(function (require, exports, module) {
             }
 
             var libraryState = this.getFlux().store("library").getState(),
-                isInitialized = libraryState.isInitialized;
+                isInitialized = libraryState.isInitialized,
+                containerClasses = classnames({
+                    "section-container": true,
+                    "section-container__collapsed": !this.props.visible,
+                    "libraries__container": true,
+                    "libraries__ready": isInitialized
+                });
 
             if (!isInitialized) {
-                return null;
+                return (<div className={containerClasses}/>);
             }
 
             var isConnected = libraryState.isConnected,
@@ -214,12 +220,6 @@ define(function (require, exports, module) {
                     </div>
                 );
             }
-
-            var containerClasses = classnames({
-                "section-container": true,
-                "section-container__collapsed": !this.props.visible,
-                "libraries__container": true
-            });
 
             return (
                 <div className={containerClasses}>

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -185,12 +185,18 @@ define(function (require, exports, module) {
             }
 
             var libraryState = this.getFlux().store("library").getState(),
-                connected = libraryState.isConnected,
+                isInitialized = libraryState.isInitialized;
+
+            if (!isInitialized) {
+                return null;
+            }
+
+            var isConnected = libraryState.isConnected,
                 libraries = this.state.libraries,
                 currentLibrary = this.state.selectedLibrary,
                 containerContents;
 
-            if (connected) {
+            if (isConnected) {
                 containerContents = (
                 <Library
                     className={this.state.isCreatingLibrary && "libraries__content__hidden"}
@@ -222,7 +228,7 @@ define(function (require, exports, module) {
                         selected={currentLibrary}
                         onLibraryChange={this._handleLibraryChange}
                         onCreateLibrary={this._handleCreateLibrary}
-                        disabled={!connected} />
+                        disabled={!isConnected} />
                     {containerContents}
                     <LibraryBar
                         className="libraries__bar__bottom"

--- a/src/js/jsx/sections/libraries/LibraryBar.jsx
+++ b/src/js/jsx/sections/libraries/LibraryBar.jsx
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         mixins: [FluxMixin],
 
         propTypes: {
-            document: React.PropTypes.instanceOf(Document).isRequired,
+            document: React.PropTypes.instanceOf(Document),
             disabled: React.PropTypes.bool
         },
 
@@ -191,6 +191,10 @@ define(function (require, exports, module) {
         },
 
         render: function () {
+            if (!this.props.document) {
+                return null;
+            }
+
             var addFillButton = this._createColorButton(function (layer) {
                 return !layer.fill ? null :
                     { color: layer.fill.color, title: nls.localize("strings.TOOLTIPS.ADD_FILL_COLOR") };

--- a/src/js/stores/library.js
+++ b/src/js/stores/library.js
@@ -65,6 +65,14 @@ define(function (require, exports, module) {
          * @type {string}
          */
         _selectedLibraryID: null,
+        
+        /**
+         * Whether the CC Libraries is fully initialized and its state (e.g. 
+         * `_libraryCollection`,`_serviceConnected`) are properly assigned.
+         * 
+         * @type {boolean}
+         */
+        _isInitialized: false,
 
         /**
          * @type {boolean}
@@ -158,6 +166,7 @@ define(function (require, exports, module) {
                 currentLibraryID: this._selectedLibraryID,
                 currentLibrary: this.getLibraryByID(this._selectedLibraryID),
                 editStatus: this._editStatusByDocumentID,
+                isInitialized: this._isInitialized,
                 isConnected: this._serviceConnected,
                 isSyncing: this._isSyncing,
                 isPlacingGraphic: this._isPlacingGraphic,
@@ -185,6 +194,7 @@ define(function (require, exports, module) {
 
         /** @ignore */
         _handleLibrariesUnloaded: function () {
+            this._isInitialized = true;
             this._handleReset();
 
             this.emit("change");
@@ -212,6 +222,7 @@ define(function (require, exports, module) {
          */
         _handleLibrariesLoaded: function (payload) {
             this._serviceConnected = true;
+            this._isInitialized = true;
             this._libraryCollection = payload.collection;
             this._updateLibraries(payload.lastSelectedLibraryID);
             

--- a/src/js/stores/panel.js
+++ b/src/js/stores/panel.js
@@ -248,7 +248,7 @@ define(function (require, exports, module) {
             var centerOffsets = this.getCenterOffsets(),
                 windowWidth = window.document.body.clientWidth,
                 windowHeight = window.document.body.clientHeight;
-            
+
             return {
                 left: centerOffsets.left,
                 top: centerOffsets.top,

--- a/src/style/main.less
+++ b/src/style/main.less
@@ -141,6 +141,14 @@ input {
     &.main__ready .section-container__no-collapse {
         opacity: 1;
         transition: all 200ms ease;
+        
+        &.libraries__container {
+            opacity: 0;
+        }
+        
+        &.libraries__container.libraries__ready {
+            opacity: 1;
+        }
     }
 }
 

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -40,6 +40,14 @@
     display: flex;
 }
 
+.panel-set__not-visible {
+    display: none;
+}
+
+.panel__tab-bar__visible {
+    display: block;
+}
+
 .panel__tab-bar {
     background-color: @bg-panel;
     width: @toolbar-button-size + 0.2rem;
@@ -409,7 +417,7 @@
     }
 }
 
-.panel-set__container__small-screen {
+.panel-set__small-screen {
     .panel {
         border-right: @hairline solid @bg-border;
     }

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -210,7 +210,7 @@ svg use {
 }
 
 .layer__not-visible
-.layer__not-invisible + .layer-group {
+.layer__not-visible + .layer-group {
     .face:hover .button-toggle,
     .face .button-toggle {
         svg {

--- a/src/style/shared/link-list.less
+++ b/src/style/shared/link-list.less
@@ -20,12 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-.null-state{
-    .panel:hover .panel__hide{
-        display: none;
-    }
-}
-
 .link-list__list {
 	width: 100%;
 }

--- a/src/style/shared/loader.less
+++ b/src/style/shared/loader.less
@@ -21,7 +21,7 @@
  *
  */
 
-.loader-animation svg use{    
+.loader-animation svg g{
     animation: loader-spin;
     animation-duration: 0.66s; 
     animation-timing-function: steps(6,end);     

--- a/src/style/shared/title-header.less
+++ b/src/style/shared/title-header.less
@@ -94,7 +94,7 @@
     line-height: 2rem;
 }
 
-.panel-set__container__small-screen {
+.panel-set__small-screen {
     .appearance,
     .effects,
     .export,


### PR DESCRIPTION
This PR includes the following optimizations on CC Libraries to improve performance.

* Defer CC Libraries loading/rendering process to improve startup performance. Before, CC Libraries is loaded in the `beforeStartup` callback, which slows down the startup process and triggers libraries panel rendering, which slow down the startup further. This process can be deferred as the chance of using the librarise panel right after startup is small. 
* Prevent the Libraries panel DOM from removing when closing the last document. Otherwise, we have to waste time in rendering the panel again when creating a new document.
* Pre-render the Libraries panel in no-doc state. While in no-doc state, the libraries panel can be pre-rendered (by React) when the data is ready. 

Below is the result of the before/after test in various scenarios:

|  | Before | After | Diff |
| --- | --- | --- | --- |
| no-doc startup | 869ms | **758ms** | -111ms |
| empty doc startup | 1741ms | **828ms** | -903ms |
| vermillion startup | 2562ms | **1640ms** | -922ms |
| no-doc -> empty doc (scripting) | 691ms | **252ms** | -439ms |
| no-doc -> empty doc (rendering) | 71ms | **54ms** | -17ms |
| empty doc -> no-doc (scripting) | 208ms | 208ms | 0 |
| empty doc -> no-doc (rendering) | **5ms**  | 9ms | 4ms |
(selected library: `Samples Collection April 23 2015`)
