### PR TITLE
More reliable click modifier tracking

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -193,14 +193,18 @@ define(function (require, exports, module) {
                 !Immutable.is(this.state.activeDocument, nextState.activeDocument);
         },
 
-        /** @ignore */
-        _handleColumnVisibilityToggle: function (columnName) {
+        /**
+         * Handle icon clicks, toggling visibility of one or both columns.
+         *
+         * @private
+         * @param {string} columnName
+         * @param {SyntheticEvent} event
+         */
+        _handleColumnVisibilityToggle: function (columnName, event) {
             var flux = this.getFlux(),
                 panelStore = flux.store("panel"),
-                modifierStore = flux.store("modifier"),
                 components = panelStore.components,
-                modifierState = modifierStore.getState(),
-                swapModifier = system.isMac ? modifierState.command : modifierState.control,
+                swapModifier = system.isMac ? event.metaKey : event.ctrlKey,
                 currentlyVisible,
                 nextState = {};
                 

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -162,10 +162,7 @@ define(function (require, exports, module) {
             event.stopPropagation();
 
             // Presence of option/alt modifier determines whether all descendants are toggled
-            var flux = this.getFlux(),
-                modifierStore = flux.store("modifier"),
-                modifierState = modifierStore.getState(),
-                descendants = modifierState.alt,
+            var descendants = event.altKey,
                 nextExpandedState = !this.state.expanded;
 
             // The clicked layer may an have out-of-date document models due to


### PR DESCRIPTION
With this PR, properties on click events are used to infer modifier state instead of using the modifier store, which is less reliable. It's less reliable because it relies on receiving `adapterFlagsChanged` events, which can't be dispatched when the application is not active. So, e.g., if another window is activate, and then some modifiers are held, and then the Design Space window is activated, the modifier store's state will be incorrect. In some cases, like `SuperSelectOverlay`, we actually do want to use the functionality provided by the modifier store because we want to re-render views when modifier state changes in absence of other mouse events. But, in the case of the `LayerFace` and `IconBar` click handlers below, it's both simpler and more reliable to use the modifier properties from the click event.