### PR TITLE
Guard against null documents in documents.close

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -670,6 +670,10 @@ define(function (require, exports) {
             document = this.flux.store("application").getCurrentDocument();
         }
 
+        if (!document) {
+            return Promise.resolve();
+        }
+
         var closeObj = documentLib.close(document.id),
             playOptions = {
                 interactionMode: descriptor.interactionMode.DISPLAY


### PR DESCRIPTION
This PR adds a guard against null document model references in `document.close`. This is necessary because the menu system can't guarantee that this action will only be played when a valid document model exists because the menu system's rebuilds are debounced. See discussion in #3678. We should be on the lookout for other instances of this unsound assumption.

Addresses #3678. 