### PR TITLE
Two shouldComponentUpdate fixes

### DIFF
--- a/src/js/jsx/sections/style/VectorFill.jsx
+++ b/src/js/jsx/sections/style/VectorFill.jsx
@@ -44,6 +44,17 @@ define(function (require, exports, module) {
         classnames = require("classnames");
 
     /**
+     * Immutable object that summarizes downsampled fills.
+     *
+     * @constructor
+     */
+    var FillRecord = Immutable.Record({
+        colors: null,
+        opacityPercentages: null,
+        enabledFlags: null
+    });
+
+    /**
      * VectorFill Component displays information of fills for non-type only sets of layers
      */
     var VectorFill = React.createClass({
@@ -105,16 +116,16 @@ define(function (require, exports, module) {
                     }
                 }),
                 opacityPercentages = collection.pluck(fills, "color")
-                .map(function (color) {
-                    return color && color.opacity;
-                }),
+                    .map(function (color) {
+                        return color && color.opacity;
+                    }),
                 enabledFlags = collection.pluck(fills, "enabled", false);
 
-            return {
+            return new FillRecord({
                 colors: colors,
                 opacityPercentages: opacityPercentages,
                 enabledFlags: enabledFlags
-            };
+            });
         },
 
         /**

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -59,6 +59,17 @@ define(function (require, exports, module) {
          */
         _target: null,
 
+        /**
+         * Dialogs currently need two passes to fully render, which rules out a
+         * naive implementation of shouldComponentUpdate. This flag makes a more
+         * complex implementation possible by tracking the render pass in progress.
+         * The flag is set when the component is between passes.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _changing: false,
+
         propTypes: {
             id: React.PropTypes.string.isRequired,
             onOpen: React.PropTypes.func,
@@ -105,6 +116,18 @@ define(function (require, exports, module) {
             return {
                 open: openDialogs.has(this.props.id)
             };
+        },
+
+        shouldComponentUpdate: function (nextProps, nextState) {
+            if (this.state.open !== nextState.open) {
+                this._changing = true;
+                return true;
+            } else if (this._changing) {
+                this._changing = false;
+                return true;
+            } else {
+                return false;
+            }
         },
 
         componentWillMount: function () {


### PR DESCRIPTION
1. Implement `shouldComponentUpdate` in `Dialog`. This is not as easy as it should be because `Dialog` components render in two passes. To make this possible, I've added a flag to each instance of which makes it possible to track the progress of these two-pass renders.
2. Fix the `shouldComponentUpdate` implementations in Fill.jsx. We were passing in a plain objects as the `fill` prop to the components defined in `Fill.jsx`, but testing for equality with `Immutable.is`. (It would be nice if this threw an error?) I worked around the problem by just creating a custom struct to hold the properties in that previously mutable object.

Both of these components were being rendered unnecessarily when calling `initializeBackgroundLayers`. The former was also causing _all_ dialogs to re-render whenever one dialog was opened.

Addresses: concerns.