### PR TITLE
Reduce cost of updating panel sizes

### DIFF
--- a/src/js/stores/panel.js
+++ b/src/js/stores/panel.js
@@ -169,11 +169,11 @@ define(function (require, exports, module) {
             this._enableOverlaysDebounced = _.debounce(this._setOverlays.bind(this), 100);
 
             // HACK: Do not reset panel sizes because they should remain constant.
-            this._panelWidth = 0;
-            this._columnCount = 0;
-            this._iconBarWidth = 0;
-            this._headerHeight = 0;
-            this._toolbarWidth = 0;
+            this._panelWidth = -1;
+            this._columnCount = -1;
+            this._iconBarWidth = -1;
+            this._headerHeight = -1;
+            this._toolbarWidth = -1;
 
             this._handleReset();
         },
@@ -195,12 +195,19 @@ define(function (require, exports, module) {
         
         /** @ignore */
         getState: function () {
+            var panelsInitialized = this._panelWidth >= 0 &&
+                this._columnCount >= 0 &&
+                this._iconBarWidth >= 0 &&
+                this._headerHeight >= 0 &&
+                this._toolbarWidth >= 0;
+
             return {
                 centerOffsets: this.getCenterOffsets(),
                 overlaysEnabled: this._overlaysEnabled,
                 marqueeEnabled: this._marqueeEnabled,
                 marqueeStart: this._marqueeStart,
-                referencePoint: this._referencePoint
+                referencePoint: this._referencePoint,
+                panelsInitialized: panelsInitialized
             };
         },
         


### PR DESCRIPTION
This PR makes three changes to avoid unnecessary action calls to update the cloaking rectangle in the adapter:

1. Factor `commitPanelSizes` out of `updatePanelSizes`. The former commits changes to the adapter, while the latter only updates the bounds in the panel store. 
2. Do not call `commitPanelSizes` until all panels have been initialized. This should make the calls that happen before `beforeStartup` less costly.
3. Once all panels are initialized, use a debounced version of `commitPanelSizes` to avoid committing unnecessarily. This should avoid repeatedly committing stale panel size values when, e.g., dragging a window from one display to another.

@shaoshing: I haven't convinced myself that this leads to any concrete improvements. Can you take a look and make a judgement call about whether this extra complexity is warranted? I'm not sure myself yet.