### PR TITLE
Bug fix: document `change` event should be emitted before history `timetravel`

### DIFF
--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -448,9 +448,13 @@ define(function (require, exports, module) {
                 nextDocument = nextDocument.overlayVisibility(currentDocument);
 
                 // these will emit their own changes
-                this.flux.store("document").setDocument(nextDocument);
                 this.flux.store("export").setDocumentExports(documentID, nextDocumentExports);
-                this.emit("timetravel");
+                this.flux.store("document").setDocument(nextDocument)
+                    .bind(this)
+                    .then(function () {
+                        // Emit the event after the document store finished dispatching its `change` event.
+                        this.emit("timetravel");
+                    });
             }
         },
 
@@ -480,9 +484,13 @@ define(function (require, exports, module) {
             this._saved = this._saved.set(documentID, this._current.get(documentID));
 
             // these will emit their own changes
-            this.flux.store("document").setDocument(lastHistoryState.document);
             this.flux.store("export").setDocumentExports(lastHistoryState.documentExports);
-            this.emit("timetravel");
+            this.flux.store("document").setDocument(lastHistoryState.document)
+                .bind(this)
+                .then(function () {
+                    // Emit the event after the document store finished dispatching its `change` event.
+                    this.emit("timetravel");
+                });
         },
 
         /**


### PR DESCRIPTION
When `timetravel` event is fired, ColorInput requires its prop to be updated so that it can re-render based on the current props, and the update is triggered by document store's `change` event. Below is the expected working order:

1. Undo command executed
2. document store emits `change` event
3. ColorInput receives updated props, but skip rendering
4. history store emits `timetravel` event
5. ColorInput handles `timetravel` and re-render 

With our recent optimization on browser paint, document store's `change` event is delayed to allow browser starts rendering ASAP, and this hack disrupts the order, and now it becomes: `1 - 4 - 5 - 2 - 3`

This PR use promise to ensure the correct event order.

Fix for #3658

@mcilroyc can you review and let me know if you approve the fix? 

