### PR TITLE
Reset bounds of layers that moved during swap, as canvas shift can happen

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -564,7 +564,10 @@ define(function (require, exports) {
                 return descriptor.endTransaction(transaction);
             })
             .then(function () {
-                return this.transfer(layerActions.resetIndex, document);
+                var boundsPromise = this.transfer(layerActions.resetBounds, document, document.layers.allSelected),
+                    indexPromise = this.transfer(layerActions.resetIndex, document);
+
+                return Promise.join(boundsPromise, indexPromise);
             });
 
         return Promise.join(dispatchPromise, swapPromise);
@@ -572,7 +575,7 @@ define(function (require, exports) {
     swapLayers.action = {
         reads: [],
         writes: [locks.PS_DOC, locks.JS_DOC],
-        transfers: [layerActions.resetIndex],
+        transfers: [layerActions.resetIndex, layerActions.resetBounds],
         post: ["verify.layers.verifySelectedBounds"]
     };
 


### PR DESCRIPTION
Addresses #3505 

We set autoExpandDisabled during our action play, but as soon as we finish and re-set it, PS handles canvas shift, and sends us the event, which we debounce. Because we debounce it, if we were to call swap again, we would be trying to swap layers at a wrong location, and cause the bug. So now as part of swap, we call resetBounds on all selected layers. This doesn't add that much to action time, so didn't seem like a bad performance hit.
