### PR TITLE
Menu 'open documents' refresh process should not throw error when there's no active document

### DIFF
--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -639,7 +639,7 @@ define(function (require, exports, module) {
      * If First launch is open, no documents will be shown
      *
      * @param {Object.<number, Document>} documents List of open documents
-     * @param {Document} currentDocument 
+     * @param {Document=} currentDocument optional currently active document to be "checked" in the menu
      * @param {boolean} appIsModal true if the app is in a globally modal state
      * @return {MenuBar}
      */
@@ -661,7 +661,7 @@ define(function (require, exports, module) {
                     "label": label,
                     "command": id,
                     "enabled": !appIsModal,
-                    "checked": document.id === currentDocument.id,
+                    "checked": currentDocument && document.id === currentDocument.id,
                     "shortcut": (index < 9) ? new MenuShortcut({
                         "keyChar": (index + 1).toString(),
                         "modifiers": shortcutModifierBits


### PR DESCRIPTION
When updating the open documents menu list, do not *error* if no document is set to active in the app store.

When opening several documents simultaneously via the "Open.." menu, the first `open` event from photoshop is for an *inactive* document.  That event is handled by `allocateDocument` which causes an updateDocument, which in turn emits an event that will cause the menu items to refresh.  At this time, the application store may not be aware of the current document.  Previously, in the menu code, the `updateOpenDocuments` method would throw an error if a current document was not provided.  It seems safe to me to relax that requirement, and tolerate the no-active-document situation here. 

This is a simple fix for #3679