### PR TITLE
Number localization with os-specified decimal separator

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -27,9 +27,11 @@ define(function (require) {
     var Promise = require("bluebird");
 
     var ui = require("./util/ui"),
+        nls = require("./util/nls"),
         main = require("./main");
 
     var stylesReady = ui.getPSColorStop(),
+        localeReady = nls.initLocaleInfo(),
         windowReady = new Promise(function (resolve) {
             if (window.document.readyState === "complete") {
                 resolve();
@@ -38,7 +40,7 @@ define(function (require) {
             }
         });
 
-    Promise.join(stylesReady, windowReady, function (stop) {
+    Promise.join(stylesReady, localeReady, windowReady, function (stop) {
         main.startup(stop);
         window.addEventListener("beforeunload", main.shutdown.bind(main));
     });

--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
                 var stable = asset.status === ExportAsset.STATUS.STABLE,
                     requested = asset.status === ExportAsset.STATUS.REQUESTED,
                     errored = asset.status === ExportAsset.STATUS.ERROR,
-                    assetTitle = asset.scale.toLocaleString() + "x";
+                    assetTitle = nls.formatDecimal(asset.scale) + "x";
 
                 var assetClasses = classnames({
                     "exports-panel__layer-asset": true,

--- a/src/js/jsx/sections/export/ExportList.jsx
+++ b/src/js/jsx/sections/export/ExportList.jsx
@@ -42,20 +42,6 @@ define(function (require, exports, module) {
         nls = require("js/util/nls");
 
     /**
-     * The options for the scale datalist
-     * @private
-     * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
-     */
-    var _scaleOptions = Immutable.OrderedMap(ExportAsset.SCALES
-        .map(function (scale) {
-            var obj = {
-                id: scale.toString(),
-                title: scale.toLocaleString()
-            };
-            return [scale.toString(), obj];
-        }));
-
-    /**
      * The options for the format datalist
      * @private
      * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
@@ -158,8 +144,9 @@ define(function (require, exports, module) {
             }
 
             var scale = exportAsset.scale,
-                scaleOption = _scaleOptions.has(scale.toString()) ?
-                    _scaleOptions.get(scale.toString()) : _scaleOptions.get("1"),
+                scaleOptions = this.props.scaleOptions,
+                scaleOption = scaleOptions.has(scale.toString()) ?
+                    scaleOptions.get(scale.toString()) : scaleOptions.get("1"),
                 formatOptionId = exportAsset.formatOptionIndex.toString(),
                 formatOption = _formatOptions.get(formatOptionId) || { title: "-" },
                 keySuffix = this.props.faceKey,
@@ -172,7 +159,7 @@ define(function (require, exports, module) {
                         <Datalist
                             list={scaleListID}
                             className="dialog-export-scale"
-                            options={_scaleOptions.toList()}
+                            options={scaleOptions.toList()}
                             value={scaleOption.title}
                             selected={scaleOption.id}
                             onChange={this._handleUpdateScale}
@@ -215,6 +202,26 @@ define(function (require, exports, module) {
             layers: React.PropTypes.instanceOf(Immutable.Iterable) // undefined => doc-level export
         },
 
+        getInitialState: function () {
+            /**
+             * The options for the scale datalist
+             *
+             * @type {Immutable.OrderedMap.<string, {id: string, title: string}>}
+             */
+            var scaleOptions = Immutable.OrderedMap(ExportAsset.SCALES
+                .map(function (scale) {
+                    var obj = {
+                        id: scale.toString(),
+                        title: nls.formatDecimal(scale)
+                    };
+                    return [scale.toString(), obj];
+                }));
+
+            return {
+                scaleOptions: scaleOptions
+            };
+        },
+
         render: function () {
             var document = this.props.document,
                 layers = this.props.layers,
@@ -238,7 +245,8 @@ define(function (require, exports, module) {
                         index={k}
                         key={key}
                         faceKey={key}
-                        exportAssets={i} />
+                        exportAssets={i}
+                        scaleOptions={this.state.scaleOptions} />
                 );
             }, this);
 

--- a/src/js/jsx/shared/NumberInput.jsx
+++ b/src/js/jsx/shared/NumberInput.jsx
@@ -152,16 +152,11 @@ define(function (require, exports, module) {
 
             var value;
             try {
-                var trimValue = _.trimRight(rawValue, this.props.suffix);
+                var trimValue = _.trimRight(rawValue, this.props.suffix),
+                    normalizedValue = nls.normalizeDecimalExpr(trimValue);
 
-                if (nls.commaDecimalSeparator) {
-                    // Replace decimal separator , with . and replace argument separator ; with ,
-                    trimValue.replace(new RegExp("\\,|\\;", "g"), function (match) {
-                        return match === "," ? "." : ",";
-                    });
-                }
                 /*jslint evil: true */
-                value = mathjs.eval(trimValue);
+                value = mathjs.eval(normalizedValue);
                 /*jslint evil: false */
 
                 // Run it through our simple parser to get rid of complex and big numbers
@@ -201,7 +196,7 @@ define(function (require, exports, module) {
             case "number":
                 if (_.isFinite(value)) {
                     var roundedValue = mathjs.round(value, this.props.precision),
-                        localeValue = roundedValue.toLocaleString();
+                        localeValue = nls.formatDecimal(roundedValue);
 
                     formattedValue = String(localeValue) + this.props.suffix;
                 } else {

--- a/src/js/models/exportasset.js
+++ b/src/js/models/exportasset.js
@@ -27,7 +27,8 @@ define(function (require, exports, module) {
     var Immutable = require("immutable"),
         _ = require("lodash");
 
-    var objUtil = require("js/util/object");
+    var objUtil = require("js/util/object"),
+        nls = require("js/util/nls");
 
     /**
      * Possible statuses of exports asset in the state machine
@@ -162,7 +163,7 @@ define(function (require, exports, module) {
          */
         derivedSuffix: function () {
             var qualitySuffix = (this.quality === 32 || this.quality === 100) ? "" : "-" + this.quality.toString(),
-                scaleSuffix = "@" + this.scale.toLocaleString() + "x";
+                scaleSuffix = "@" + nls.formatDecimal(this.scale) + "x";
 
             return scaleSuffix + qualitySuffix;
         },


### PR DESCRIPTION
This PR improves our number localization so that the operating system-specified decimal separator is used, and not just the locale default. This is done by fetch `localeInfo` from Photoshop before starting the application, and using that to provide util-level information about the correct decimal separator and a decimal-formatting function. I did it this way because a) this setting can't change without restarting Photoshop, and b) it turned out to be extremely challenging to put this into our usual Flux data flow (i.e., it would have required major refactorings, and it just didn't seem to be worth the effort).

To test, manually change your locale's decimal separator this like:
![image](https://cloud.githubusercontent.com/assets/1075154/12926525/b88bc1a8-cf18-11e5-83df-8a81d87ccc72.png)
And then restart Photoshop .

Addresses #3136.