### PR TITLE
Improve performance of switching initialized documents

### DIFF
--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -279,67 +279,118 @@ define(function (require, exports, module) {
                 var documentID = document.id,
                     current = documentID === activeDocument.id,
                     disabled = document && document.unsupported,
+                    sectionClassnames = classnames({
+                        "panel-section": true,
+                        "panel-section__no-selected-layer": document.layers.selected.isEmpty(),
+                        "panel-section__not-visible": !current
+                    }),
                     panelProps = {
-                        key: documentID,
                         disabled: disabled,
                         document: document,
-                        active: current,
                         shouldPanelGrow: !this.state[components.LAYERS_PANEL] &&
                             !this.state[components.LIBRARIES_PANEL]
                     };
-                    
-                documentPanels.transformPanels.push(
-                    <TransformPanel {...panelProps} />
-                );
                 
+                var appearancePanelVisible = !disabled && this.state[components.APPEARANCE_PANEL],
+                    effectsPanelVisible = !disabled && this.state[components.EFFECTS_PANEL],
+                    exportPanelVisible = !disabled && this.state[components.EXPORT_PANEL],
+                    layersPanelVisible = this.state[components.LAYERS_PANEL],
+                    transformClassnames = classnames(sectionClassnames, {
+                        "panel-transform-section": true
+                    }),
+                    appearanceClassnames = classnames(sectionClassnames, {
+                        "panel-appearance-section": true,
+                        "panel-section__collapsed": !appearancePanelVisible
+                    }),
+                    effectsClassnames = classnames(sectionClassnames, {
+                        "panel-effects-section": true,
+                        "panel-section__collapsed": !effectsPanelVisible
+                    }),
+                    exportClassnames = classnames(sectionClassnames, {
+                        "panel-export-section": true,
+                        "panel-section__collapsed": !exportPanelVisible
+                    }),
+                    layersClassnames = classnames(sectionClassnames, {
+                        "panel-layers-section": true,
+                        "panel-section__collapsed": !layersPanelVisible
+                    });
+
+                documentPanels.transformPanels.push(
+                    <div className={transformClassnames} key={documentID}>
+                        <TransformPanel
+                            {...panelProps}
+                            key="transform" />
+                    </div>
+                );
+
                 documentPanels.appearancePanels.push(
-                    <AppearancePanel
-                        {...panelProps}
-                        ref={current && components.APPEARANCE_PANEL}
-                        visible={!disabled && this.state[components.APPEARANCE_PANEL]}
-                        onVisibilityToggle=
-                            {this._handlePanelVisibilityToggle
-                                .bind(this, components.APPEARANCE_PANEL)} />
+                    <div className={appearanceClassnames} key={documentID}>
+                        <AppearancePanel
+                            {...panelProps}
+                            key="appearance"
+                            ref={current && components.APPEARANCE_PANEL}
+                            visible={appearancePanelVisible}
+                            onVisibilityToggle=
+                                {this._handlePanelVisibilityToggle
+                                    .bind(this, components.APPEARANCE_PANEL)} />
+                    </div>
                 );
                 
                 documentPanels.effectPanels.push(
-                    <EffectsPanel
-                        {...panelProps}
-                        ref={current && components.EFFECTS_PANEL}
-                        visible={!disabled && this.state[components.EFFECTS_PANEL]}
-                        onVisibilityToggle=
-                            {this._handlePanelVisibilityToggle.bind(this, components.EFFECTS_PANEL)} />
+                    <div className={effectsClassnames} key={documentID}>
+                        <EffectsPanel
+                            {...panelProps}
+                            key="effect"
+                            ref={current && components.EFFECTS_PANEL}
+                            visible={effectsPanelVisible}
+                            onVisibilityToggle=
+                                {this._handlePanelVisibilityToggle.bind(this, components.EFFECTS_PANEL)} />
+                    </div>
                 );
                 
                 documentPanels.exportPanels.push(
-                    <ExportPanel
-                        {...panelProps}
-                        ref={current && components.EXPORT_PANEL}
-                        visible={!disabled && this.state[components.EXPORT_PANEL]}
-                        onVisibilityToggle=
-                            {this._handlePanelVisibilityToggle.bind(this, components.EXPORT_PANEL)} />
+                    <div className={exportClassnames} key={documentID}>
+                        <ExportPanel
+                            {...panelProps}
+                            key="export"
+                            ref={current && components.EXPORT_PANEL}
+                            visible={exportPanelVisible}
+                            onVisibilityToggle=
+                                {this._handlePanelVisibilityToggle.bind(this, components.EXPORT_PANEL)} />
+                    </div>
                 );
                 
                 documentPanels.layerPanels.push(
-                    <LayersPanel
-                        {...panelProps}
-                        visible={this.state[components.LAYERS_PANEL]}
-                        ref={current && components.LAYERS_PANEL}
-                        onVisibilityToggle=
-                            {this._handlePanelVisibilityToggle.bind(this, components.LAYERS_PANEL)} />
+                    <div className={layersClassnames} key={documentID}>
+                        <LayersPanel
+                            {...panelProps}
+                            key="layers"
+                            visible={layersPanelVisible}
+                            ref={current && components.LAYERS_PANEL}
+                            onVisibilityToggle=
+                                {this._handlePanelVisibilityToggle.bind(this, components.LAYERS_PANEL)} />
+                    </div>
                 );
             }, this);
             
+            var librariesPanelVisible = this.state[components.LIBRARIES_PANEL],
+                librariesClassnames = classnames({
+                    "panel-section": true,
+                    "panel-section__collapsed": !librariesPanelVisible,
+                    "panel-libraries-section": true
+                });
+            
             documentPanels.librariesPanel = (
-                <LibrariesPanel
-                    key="libraries-panel"
-                    className="section__active"
-                    ref={components.LIBRARIES_PANEL}
-                    disabled={activeDocument && activeDocument.unsupported}
-                    document={activeDocument}
-                    visible={this.state[components.LIBRARIES_PANEL]}
-                    onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
-                    components.LIBRARIES_PANEL)} />
+                <div className={librariesClassnames}>
+                    <LibrariesPanel
+                        key="libraries-panel"
+                        ref={components.LIBRARIES_PANEL}
+                        disabled={activeDocument && activeDocument.unsupported}
+                        document={activeDocument}
+                        visible={librariesPanelVisible}
+                        onVisibilityToggle={this._handlePanelVisibilityToggle.bind(this,
+                            components.LIBRARIES_PANEL)} />
+                </div>
             );
 
             var propertiesButtonClassNames = classnames({

--- a/src/js/jsx/sections/layers/LayersPanel.jsx
+++ b/src/js/jsx/sections/layers/LayersPanel.jsx
@@ -90,16 +90,13 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps) {
-            if (this.props.disabled !== nextProps.disabled ||
-                this.props.active !== nextProps.active) {
-                return true;
+            // If the panel is remaining invisible, no need to re-render.
+            if (!nextProps.visible && !this.props.visible) {
+                return false;
             }
 
-            if (this.props.visible !== nextProps.visible) {
-                return true;
-            }
-
-            return this.props.active !== nextProps.active ||
+            return this.props.disabled !== nextProps.disabled ||
+                this.props.visible !== nextProps.visible ||
                 !Immutable.is(_getFaces(this.props), _getFaces(nextProps)) ||
                 !Immutable.is(_getDepths(this.props), _getDepths(nextProps));
         },
@@ -132,7 +129,6 @@ define(function (require, exports, module) {
                 sectionClasses = classnames({
                     "layers": true,
                     "section": true,
-                    "section__active": this.props.active,
                     "section__collapsed": !this.props.visible
                 });
 

--- a/src/js/jsx/sections/libraries/LibrariesPanel.jsx
+++ b/src/js/jsx/sections/libraries/LibrariesPanel.jsx
@@ -64,12 +64,13 @@ define(function (require, exports, module) {
         _setTooltipThrottled: null,
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            if (this.props.disabled !== nextProps.disabled) {
-                return true;
-            }
-
+            // If the panel is remaining invisible, no need to re-render.
             if (!nextProps.visible && !this.props.visible) {
                 return false;
+            }
+
+            if (this.props.disabled !== nextProps.disabled) {
+                return true;
             }
 
             if (this.state.isDropTarget && nextState.isDropTarget) {

--- a/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
+++ b/src/js/jsx/sections/nodoc/ArtboardPresets.jsx
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
             }, this);
 
             return (
-                <section className="artboard-presets section section__active">
+                <section className="artboard-presets section">
                     <TitleHeader title={nls.localize("strings.NO_DOC.ARTBOARD_PRESETS_TITLE")} />
                     <div className="section-container artboard-launcher__body">
                         <ul className="link-list__list">

--- a/src/js/jsx/sections/nodoc/RecentFiles.jsx
+++ b/src/js/jsx/sections/nodoc/RecentFiles.jsx
@@ -75,13 +75,13 @@ define(function (require, exports, module) {
 
             if (recentFilesLimited.isEmpty()) {
                 return (
-                    <section className="recent-files section section__active">
+                    <section className="recent-files section">
                         <TitleHeader title={nls.localize("strings.NO_DOC.RECENT_FILES_TITLE")} />
                     </section>
                );
             } else {
                 return (
-                    <section className="recent-files section section__active">
+                    <section className="recent-files section">
                         <TitleHeader title={nls.localize("strings.NO_DOC.RECENT_FILES_TITLE")} />
                         <div className="section-container">
                             <ul className="link-list__list">

--- a/src/js/jsx/sections/transform/Position.jsx
+++ b/src/js/jsx/sections/transform/Position.jsx
@@ -53,8 +53,7 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            return this.props.active !== nextProps.active ||
-                this.state.disabled !== nextState.disabled ||
+            return this.state.disabled !== nextState.disabled ||
                 this.props.referencePoint !== nextProps.referencePoint ||
                 !Immutable.is(this.state.xValues, nextState.xValues) ||
                 !Immutable.is(this.state.yValues, nextState.yValues) ||

--- a/src/js/jsx/sections/transform/Size.jsx
+++ b/src/js/jsx/sections/transform/Size.jsx
@@ -47,8 +47,7 @@ define(function (require, exports, module) {
         shouldComponentUpdate: function (nextProps, nextState) {
             // Calculations that are usually done here are done in
             // componentWillReceiveProps
-            return this.props.active !== nextProps.active ||
-                this.props.referencePoint !== nextProps.referencePoint ||
+            return this.props.referencePoint !== nextProps.referencePoint ||
                 this.state.disabled !== nextState.disabled ||
                 this.state.proportional !== nextState.proportional ||
                 !Immutable.is(this.state.layers, nextState.layers) ||

--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -53,9 +53,9 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps, nextState) {
             return this.state.referencePoint !== nextState.referencePoint ||
-                this.props.active !== nextProps.active ||
                 this.props.disabled !== nextProps.disabled ||
-                !Immutable.is(this.props.document, nextProps.document);
+                !Immutable.is(this.props.document.layers.selected, nextProps.document.layers.selected) ||
+                !Immutable.is(this.props.document.bounds, nextProps.document.bounds);
         },
 
         /**
@@ -71,8 +71,7 @@ define(function (require, exports, module) {
         render: function () {
             var sectionClasses = classnames({
                 "transform": true,
-                "section": true,
-                "section__active": this.props.active
+                "section": true
             });
             
             var positionRotateClasses = classnames("formline",
@@ -99,7 +98,6 @@ define(function (require, exports, module) {
                         <div className="formline formline__padded-first-child formline__space-between">
                             <div className="control-group">
                                 <Size
-                                    active={this.props.active}
                                     document={this.props.document}
                                     referencePoint={this.state.referencePoint}/>
                             </div>
@@ -181,7 +179,6 @@ define(function (require, exports, module) {
                         <div className={positionRotateClasses}>
                             <div className="control-group">
                                 <Position
-                                    active={this.props.active}
                                     document={this.props.document}
                                     referencePoint={this.state.referencePoint} />
                             </div>

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -34,6 +34,47 @@
     box-shadow: inset @panel-border-width 0 0 @bg-border-for-canvas;
 }
 
+.panel-section {
+    display: flex;
+    flex-shrink: 1;
+    flex-grow: 1;
+}
+
+.panel-transform-section, .panel-appearance-section {
+    flex-shrink: 0;
+    flex-grow: 0;
+}
+
+.panel-effects-section{
+    min-height: 24rem;
+}
+
+.panel-export-section{
+    min-height: 18rem;
+}
+
+.panel-layers-section, .panel-libraries-section {
+    min-height: 50%;
+}
+
+.panel-section__collapsed {
+    min-height: 4.6rem;
+    height: 4.6rem;
+    flex-grow: 0;
+}
+
+.panel-appearance-section, .panel-effects-section {
+    &.panel-section__no-selected-layer {
+        flex-grow: 0;
+        height: auto;
+        min-height: 0;
+    }
+}
+
+.panel-section__not-visible {
+    display: none;
+}
+
 .panel-set__container {
     height: 100%;
     max-height: 100%;
@@ -60,26 +101,7 @@
     display: block;
 }
 
-.panel__hide{
-    display: none;
-    position: absolute;
-    right: 0;
-    top: 0.5rem;
-    width: 1.5rem;
-    height: 2.5rem;
-    z-index: 10;
-    line-height: 2.5rem;
-    text-align: center;
-    background-color: @bg-panel;
-    border-top-left-radius: 0.2rem;
-    border-bottom-left-radius: 0.2rem;
-}
-
-.panel:hover .panel__hide{
-    display: block;
-}
-
-.panel__tab-bar .button-simple{
+.panel__tab-bar .button-simple {
     width: @toolbar-button-size;
     height: @toolbar-button-size;
 }
@@ -97,22 +119,12 @@
     flex-direction: column;
 }
 
-.panel__visible + .panel:nth-child(2){
+.panel__visible + .panel:nth-child(2) {
     border-right: @panel-border-width solid @bg-border;
 }
 
-.panel__visible{
+.panel__visible {
     display: flex;
-}
-
-.panel__element {
-    height: 100%;
-    display: none;
-}
-
-.panel__element__active {
-    display: flex;
-    flex-direction: column;
 }
 
 .properties {
@@ -161,22 +173,15 @@
 }
 
 .section {
-    display: none;
+    display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
     flex-shrink: 1;
     border-bottom: @panel-border-width solid @bg-border;
-    &:last-child {
-        border-bottom: none;
+    
+    &.export {
+        border-bottom: 0;
     }
-}
-
-.section__hidden {
-    display: none;
-}
-
-.section__active {
-    display: flex;
 }
 
 .section.section__collapsed {
@@ -230,14 +235,6 @@
 .recent-files .section-container {
     padding-bottom: 1rem;
     flex-shrink: 1;
-}
-
-.effects.section__active {
-    min-height: 24rem;
-}
-
-.export.section__active {
-    min-height: 18rem;
 }
 
 .effects.section__collapsed,
@@ -301,14 +298,7 @@
 .layers {
     flex-grow: 1;
     flex-shrink: 1;
-}
-
-.layers, .libraries {
-    min-height: 50%;
-
-    &.section__collapsed {
-        min-height: 0;
-    }
+    width: 100%;
 }
 
 .generate-columns(@panel-column-width);
@@ -421,6 +411,10 @@
     .panel {
         border-right: @hairline solid @bg-border;
     }
+    
+    .export {
+        border-bottom: @panel-border-width solid @bg-border;
+    }
 
     .section.section__collapsed {
         flex-grow: 0;
@@ -429,13 +423,13 @@
         border-bottom: @panel-border-width solid @bg-border;
     }
 
-    .libraries, .layers {
+    .panel-libraries-section, .panel-layers-section {
         flex-grow: 1;
         flex-basis: 20rem;
     }
 
-    .export, .effects {
-        height: 15%;
+    .panel-export-section, .panel-effects-section {
+        max-height: 15%;
         flex-grow: 0;
         min-height: 0;
         
@@ -443,21 +437,43 @@
             height: auto;
         }
     }
-
-    .layers, .libraries {
-        min-height: 7rem;
+    
+    .panel-libraries-section, .panel-layers-section {
+        min-height: 0;
     }
 
     .layers, .libraries, .export, .effects {
+        min-height: 0;
+        
         &.section__collapsed {
             min-height: 3.2rem;
+            flex-grow: 1;
             flex-basis: 0;
         }
+    }
+    
+    .libraries, .layers {
+        min-height: 10rem;
     }
 
     .appearance, .type {
         height: 18rem;
         flex-grow: 0;
+    }
+    
+    .panel-section__collapsed {
+        flex-grow: 0;
+        flex-basis: auto;
+        min-height: 3.2rem;
+        height: 3.2rem;
+    }
+    
+    .panel-appearance-section, .panel-effects-section {
+        &.panel-section__no-selected-layer {
+            flex-grow: 0;
+            height: auto;
+            min-height: 0;
+        }
     }
 }
 

--- a/src/style/sections/libraries/libraries-section.less
+++ b/src/style/sections/libraries/libraries-section.less
@@ -30,6 +30,7 @@
     position: relative;
     flex-grow: 1;
     flex-shrink: 0;
+    width: 100%;
 
     .section-container {
         padding: 0;

--- a/src/style/sections/style/style-section.less
+++ b/src/style/sections/style/style-section.less
@@ -25,7 +25,11 @@
 
 .effects,
 .appearance {
-    min-height: 3rem;
+    width: 100%;
+}
+
+.export {
+    width: 100%;
 }
 
 .effects {

--- a/src/style/shared/icons.less
+++ b/src/style/shared/icons.less
@@ -66,11 +66,6 @@ svg use {
     }
 }
 
-.panel__hide svg {
-    fill: @icon-active;
-    height: 0.8rem;
-}
-
 .button-generator {
     background: url("img/ico-generator-white.svg") no-repeat;
     background-size: 2rem;


### PR DESCRIPTION
This PR improves the performance of switching initialized documents by optimizing the rendering process. When switching documents, we toggle the CSS class "section__active" to show panels of active document and hide the rest of the panels. Before, to just toggle one class, we have to re-render all the panels (`Transform, Appearance, Effects, Export, Layers`), which adds extra time to the switching. To improve this, this PR wraps the panel components with a `div`, and toggle the panels by change the class of the `div`. In this way, the panels can remain unchanged.

##### Improvements

| | Before | After | Diff |
| --- | --- | --- | --- |
| switch from an empty doc to vermilion | 364ms | **256ms** | -108ms |
| switch from vermilion to an empty doc | 199ms | **89ms** | -110ms |
(both documents are already initialized)
