### PR TITLE
Updated shrinkwrap with new spaces-adapter version (including semver dep)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -196,14 +196,19 @@
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.8.tgz"
     },
     "spaces-adapter": {
-      "version": "1.2.1",
-      "from": "git+https://github.com/adobe-photoshop/spaces-adapter.git#v1.2.1",
-      "resolved": "git+https://github.com/adobe-photoshop/spaces-adapter.git#e08f1c6731278e607259877f245c5591fef81157",
+      "version": "1.2.2",
+      "from": "adobe-photoshop/spaces-adapter#v1.2.2",
+      "resolved": "git://github.com/adobe-photoshop/spaces-adapter.git#9ea589715a6ff750a988a29a411dccfa5dc6d1fb",
       "dependencies": {
         "qunitjs": {
           "version": "1.20.0",
           "from": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.20.0.tgz",
           "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.20.0.tgz"
+        },
+        "semver": {
+          "version": "5.1.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-addons-pure-render-mixin": "^0.14.6",
     "react-dom": "^0.14.6",
     "scriptjs": "^2.5.8",
-    "spaces-adapter": "adobe-photoshop/spaces-adapter#v1.2.1",
+    "spaces-adapter": "adobe-photoshop/spaces-adapter#v1.2.2",
     "tinycolor2": "^1.1.2",
     "wolfy87-eventemitter": "^4.3.0"
   }


### PR DESCRIPTION
what it says.  ~~Anyone concerned with the esprima-fb bit?~~
update: I nuked node_modules and started over... and the esprima-fb dep went away.