### PR TITLE
Fix panel bounds measurement

### DIFF
--- a/src/js/jsx/IconBar.jsx
+++ b/src/js/jsx/IconBar.jsx
@@ -25,13 +25,9 @@ define(function (require, exports, module) {
     "use strict";
 
     var React = require("react"),
-        ReactDOM = require("react-dom"),
         Fluxxor = require("fluxxor"),
         FluxMixin = Fluxxor.FluxMixin(React),
-        classnames = require("classnames"),
-        _ = require("lodash");
-
-    var os = require("adapter").os;
+        classnames = require("classnames");
 
     var Button = require("js/jsx/shared/Button"),
         SVGIcon = require("js/jsx/shared/SVGIcon"),
@@ -40,52 +36,6 @@ define(function (require, exports, module) {
 
     var PanelSet = React.createClass({
         mixins: [FluxMixin],
-        
-        /**
-         * Update the sizes of the panels.
-         *
-         * @private
-         * @param {boolean=} unmounting
-         * @return {Promise}
-         */
-        _updatePanelSizes: function (unmounting) {
-            var iconBarWidth;
-            if (unmounting) {
-                iconBarWidth = 0;
-            } else {
-                var node = ReactDOM.findDOMNode(this);
-                if (node) {
-                    iconBarWidth = node.getBoundingClientRect().width;
-                } else {
-                    iconBarWidth = 0;
-                }
-            }
-
-            return this.getFlux().actions.panel.updatePanelSizes({
-                iconBarWidth: iconBarWidth
-            });
-        },
-
-        /**
-         * Debounced version of _updatePanelSizes
-         *
-         * @private
-         */
-        _updatePanelSizesDebounced: null,
-
-        componentDidMount: function () {
-            this._updatePanelSizesDebounced = _.debounce(function () {
-                return this._updatePanelSizes();
-            }.bind(this), 500);
-
-            os.addListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
-            this._updatePanelSizes();
-        },
-
-        componentWillUnmount: function () {
-            os.removeListener("displayConfigurationChanged", this._updatePanelSizesDebounced);
-            this._updatePanelSizes(true);
-        },
 
         render: function () {
             var panelTabBarClassNames = classnames({

--- a/src/js/jsx/PanelSet.jsx
+++ b/src/js/jsx/PanelSet.jsx
@@ -96,11 +96,21 @@ define(function (require, exports, module) {
          * @return {Promise}
          */
         _updatePanelSizes: function () {
-            var node = ReactDOM.findDOMNode(this.refs.panelSet),
+            var iconBarNode = ReactDOM.findDOMNode(this.refs.iconBar),
+                iconBarWidth;
+
+            if (iconBarNode) {
+                iconBarWidth = iconBarNode.getBoundingClientRect().width;
+            } else {
+                iconBarWidth = 0;
+            }
+
+            var panelNode = ReactDOM.findDOMNode(this.refs.panelSet),
                 panelWidth;
 
-            if (node) {
-                panelWidth = node.getBoundingClientRect().width;
+            if (panelNode) {
+                // The panel width includes the iconBar width.
+                panelWidth = panelNode.getBoundingClientRect().width - iconBarWidth;
             } else {
                 panelWidth = 0;
             }
@@ -122,6 +132,7 @@ define(function (require, exports, module) {
 
             return this.getFlux().actions.panel.updatePanelSizes({
                 panelWidth: panelWidth,
+                iconBarWidth: iconBarWidth,
                 columnCount: columnCount
             });
         },
@@ -447,7 +458,7 @@ define(function (require, exports, module) {
                             {documentPanels.layerPanels}
                             {documentPanels.librariesPanel}
                         </PanelColumn>
-                        <IconBar>
+                        <IconBar ref="iconBar">
                             <Button className={propertiesButtonClassNames}
                                 title={propertiesColumnTitle}
                                 disabled={false}
@@ -482,14 +493,14 @@ define(function (require, exports, module) {
                             <RecentFiles recentFiles={this.state.recentFiles} />
                             <ArtboardPresets />
                         </PanelColumn>
-                        <IconBar />
+                        <IconBar ref="iconBar" />
                     </div>
                 );
             } else {
                 noDocPanelSet = (
                     <div className={noDocPanelSetClassName}>
                         <PanelColumn visible="true" />
-                        <IconBar />
+                        <IconBar ref="iconBar" />
                     </div>
                 );
             }


### PR DESCRIPTION
The structure of the `PanelSet` recently changed to include the `IconBar`, but the bounds arithmetic did not change along with it. This resolves the discrepancy by putting the `PanelSet` in charge of reporting both `panelBounds` and `iconBounds`. As a nice side effect, there is one fewer component calling `updatePanelSizes` all the time.

Addresses #3703.