### PR TITLE
Update menu for Windows

### DIFF
--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -764,6 +764,14 @@
                 {
                     "id": "TOGGLE_ACTION_TRANSFER_LOGGING",
                     "debug": true
+                },
+                {
+                    "id": "TOGGLE_DESCRIPTOR_LOGGING",
+                    "debug": true
+                },
+                {
+                    "id": "TOGGLE_HEADLIGHTS_LOGGING",
+                    "debug": true
                 }
             ]
         },


### PR DESCRIPTION
This PR updates the windows menu config to include the two new debugging items. 

Tested with Windows dev build 1065.