### PR TITLE
TextInput and Datalist event handling fixes

### DIFF
--- a/src/js/jsx/search/SearchBar.jsx
+++ b/src/js/jsx/search/SearchBar.jsx
@@ -416,7 +416,7 @@ define(function (require, exports, module) {
          * Perform action based on ID
          *
          * @private
-         * @type {Datalist~onInputChange}
+         * @type {Datalist~onChange}
          */
         _handleChange: function (id) {
             if (id === null) {
@@ -455,9 +455,10 @@ define(function (require, exports, module) {
          * Handle input change. 
          *
          * @private
-         * @type {Datalist~onInputChange}
+         * @param {SyntheticEvent} event
+         * @param {Datalist~onInput} value
          */
-        _handleInputChange: function (value) {
+        _handleInput: function (event, value) {
             var nextHasInputValue = value.length !== 0;
             
             if (nextHasInputValue !== this.state.hasInputValue) {
@@ -570,7 +571,7 @@ define(function (require, exports, module) {
                         neverSelectAllInput={true}
                         changeOnBlur={false}
                         onChange={this._handleChange}
-                        onInputChange={this._handleInputChange}
+                        onInput={this._handleInput}
                         onKeyDown={this._handleKeyDown} />
                     {clearInputBtn}
                 </div>

--- a/src/js/jsx/sections/layers/LayerFace.jsx
+++ b/src/js/jsx/sections/layers/LayerFace.jsx
@@ -199,18 +199,6 @@ define(function (require, exports, module) {
         },
 
         /**
-         * Not implemented yet, but will call the handler being passed from PagesPanel
-         * to skip to the next layer and make it editable
-         * 
-         * @private
-         * @param {SyntheticEvent} event
-         */
-        _skipToNextLayerName: function (event) {
-            // TODO: Skip to next layer on the tree
-            event.stopPropagation();
-        },
-
-        /**
          * Grabs the correct modifier by processing event modifier keys
          * and calls the select action with correct modifier.
          * 
@@ -694,7 +682,6 @@ define(function (require, exports, module) {
                                         disabled={this.props.disabled || !nameEditable}
                                         onFocus={this._handleInputFocusChange.bind(this, true)}
                                         onBlur={this._handleInputFocusChange.bind(this, false)}
-                                        onKeyDown={this._skipToNextLayerName}
                                         onChange={this._handleLayerNameChange}
                                         allowEmpty={false}>
                                     </TextInput>

--- a/src/js/jsx/sections/libraries/LibraryList.jsx
+++ b/src/js/jsx/sections/libraries/LibraryList.jsx
@@ -192,10 +192,14 @@ define(function (require, exports, module) {
          * @param {SyntheticEvent} event
          */
         _handleLibraryNameInputKeydown: function (event) {
-            if (event.key === "Return" || event.key === "Enter") {
+            switch (event.key) {
+            case "Return":
+            case "Enter":
                 this._handleConfirmCommand();
-            } else if (event.key === "Escape") {
+                break;
+            case "Escape":
                 this._handleCancelCommand();
+                break;
             }
         },
         

--- a/src/js/jsx/shared/ColorPicker.jsx
+++ b/src/js/jsx/shared/ColorPicker.jsx
@@ -581,9 +581,7 @@ define(function (require, exports, module) {
          * @param {KeyboardEvent} event
          */
         _handleKeyDown: function (event) {
-            var key = event.key;
-
-            switch (key) {
+            switch (event.key) {
             case "Tab":
                 if (event.shiftKey) {
                     this.props.onShiftTabPress();

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -76,12 +76,12 @@ define(function (require, exports, module) {
             onChange: React.PropTypes.func,
 
             /**
-             * Callback to handle input change
+             * Callback to handle change of the component's text input
              * 
-             * @callback Datalist~onChange
+             * @callback Datalist~onInput
              * @param {string} value - the current value of the input
              */
-            onInputChange: React.PropTypes.func,
+            onInput: React.PropTypes.func,
             
             /**
              * Callback to handle input keydown
@@ -159,6 +159,7 @@ define(function (require, exports, module) {
                 filterIcon: null,
                 changeOnBlur: true,
                 onChange: _.noop,
+                onInput: _.noop,
                 onHighlightedChange: _.noop,
                 onListOpen: _.noop,
                 onClose: _.noop,
@@ -434,37 +435,28 @@ define(function (require, exports, module) {
         },
 
         /**
-         * When the input changes, update the filter value.
+         * When the input changes, update the filter value. Open the select menu if closed.
          *
          * @private
          * @param {SyntheticEvent} event
          * @param {string} value
          */
-        _handleInputChange: function (event, value) {
+        _handleInput: function (event, value) {
             this.setState({
                 filter: value
             });
+
+            var select = this.refs.select;
+            if (!select) {
+                this._handleInputClick(event);
+            }
 
             if (this.state.filter !== value) {
                 this._updateAutofill(value);
             }
             
-            if (this.props.onInputChange) {
-                this.props.onInputChange(value);
-            }
-        },
-
-        /**
-         * If the select menu is closed, open it if the underlying input receives
-         * any "change" event.
-         *
-         * @private
-         * @param {Event} event
-         */
-        _handleInputDOMChange: function (event) {
-            var select = this.refs.select;
-            if (!select) {
-                this._handleInputClick(event);
+            if (this.props.onInput) {
+                this.props.onInput(event, value);
             }
         },
 
@@ -755,8 +747,7 @@ define(function (require, exports, module) {
                         onFocus={this._handleInputFocus}
                         onBlur={this._handleInputBlur}
                         onKeyDown={this._handleInputKeyDown}
-                        onInputChange={this._handleInputChange}
-                        onDOMChange={this._handleInputDOMChange}
+                        onInput={this._handleInput}
                         onClick={this._handleInputClick} />
                     {autocomplete}
                     {dialog}

--- a/src/js/jsx/shared/Dialog.jsx
+++ b/src/js/jsx/shared/Dialog.jsx
@@ -126,7 +126,7 @@ define(function (require, exports, module) {
                 this._changing = false;
                 return true;
             } else {
-                return false;
+                return this.state.open;
             }
         },
 

--- a/src/js/jsx/shared/TextInput.jsx
+++ b/src/js/jsx/shared/TextInput.jsx
@@ -49,13 +49,11 @@ define(function (require, exports, module) {
         propTypes: {
             // Value for the input
             value: React.PropTypes.string.isRequired,
-            // Event handler for changed value of the input. This is called whenever the input value is changed.
-            onInputChange: React.PropTypes.func,
             // Event handler for committed value of the input. This is called when user hit Return/Enter or when 
             // the input loses focus. (also look at the allowEmpty option for different behavior)
             onChange: React.PropTypes.func,
-            // Event handler for changed value of input, called regardless of continuous being true or not
-            onDOMChange: React.PropTypes.func,
+            // Event handler for input event, which is triggered when the contents of the input change
+            onInput: React.PropTypes.func,
             // Event handler for when input receives focus
             onFocus: React.PropTypes.func,
             // Event handler for when input loses focus
@@ -79,8 +77,7 @@ define(function (require, exports, module) {
             return {
                 value: "",
                 onChange: _.identity,
-                onInputChange: _.identity,
-                onDOMChange: _.identity,
+                onInput: _.identity,
                 onFocus: _.identity,
                 disabled: false,
                 doubleClickToEdit: false,
@@ -176,10 +173,7 @@ define(function (require, exports, module) {
                 selectDisabled: true
             });
 
-            this.props.onInputChange(event, nextValue);
-
-            // Only used by Datalist
-            this.props.onDOMChange(event);
+            this.props.onInput(event, nextValue);
         },
 
         /**


### PR DESCRIPTION
This PR makes the following changes to the event-handling interfaces of `TextInput` and `Datalist`:

1. `TextInput` now has a single `onInput` prop in place of the previous `onInputChange` and `onDOMChange` props. Those props were only ever being called one after another as a result of a `change` event on the `input` element, so this simplifies the interface and changes the name to be more meaningful and correct.
2. `Datalist` now has an `onInput` prop that replaces the previous `onInputChange` prop. The latter was a confusing name in relation to the semantics of that prop, which was and is that it is triggered as a result of the child `TextInput`'s `onInput` event. 

Besides updating the usage of these components and fixing up some stale comments, this also makes a change to the `shouldComponentUpdate` method of `Dialog`. On master, it never re-renders while the dialog is open, which means that the contents of the dialog don't ever re-render as a result of a parent re-render. Consequently, the `Select` component of `Datalist` was not correctly filtering during input. This changes the `shouldComponentUpdate` method to always re-render when the `Dialog` is open. 

Addresses #3713.