### PR TITLE
Show document panels earlier by promoting the fade-in animation.

### DIFF
--- a/src/style/main.less
+++ b/src/style/main.less
@@ -137,8 +137,11 @@ input {
 /* -- MASTER CONTAINER -- */
 
 .fade-in-mixin {
+    // For panels in no-doc state
     &.main__ready .section-container,
-    &.main__ready .section-container__no-collapse {
+    // For document panels when there are active documents.
+    .panel-set__ready .section-container,
+    .panel-set__ready .section-container__no-collapse {
         opacity: 1;
         transition: all 200ms ease;
         

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -227,6 +227,10 @@
     opacity: 0;
 }
 
+.artboard-presets, .recent-files {
+    flex-grow: 1;
+}
+
 .artboard-presets .section-container,
 .recent-files .section-container {
     padding: 0;


### PR DESCRIPTION
This PR promote the panel's fade-in animation so that they are displayed faster during startup. Before, the animation starts when the `FluxController` emits `ready` event. In general, the event is emitted 150ms - 300ms later after the `PanelSet` completes rendering for the active document, as the event has to wait until all `beforeStartpu` callbacks are completed. So, instead of waiting for the `ready` event, the `PanelSet` now starts the animation when its active document's content are flushed to the DOM.

![screen shot 2016-02-18 at 8 51 43 am](https://cloud.githubusercontent.com/assets/118264/13151110/8c5a09bc-d61d-11e5-9052-9e9296fa744c.png)
1) the panel content are flushed to the DOM. 2) `Main` component receives the `ready` event.

#### Improvements

| panel fade-in starts | Before | After | Diff |
| --- | --- | --- | --- |
| empty document | 1690ms | 1530ms | -160ms |
| vermilion | 2630ms | 2410ms | -220ms |

