### PR TITLE
Fast history initialization for fresh documents

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -250,9 +250,10 @@ define(function (require, exports) {
     /**
      * Initialize document and layer state, emitting DOCUMENT_UPDATED.
      *
+     * @param {boolean=} noCurrentHistory
      * @return {Promise.<{activeDocumentID: number, openDocumentIDs: Array.<number>}=>}
      */
-    var initActiveDocument = function () {
+    var initActiveDocument = function (noCurrentHistory) {
         var appRef = appLib.referenceBy.current,
             rangeOpts = {
                 range: "document",
@@ -274,14 +275,17 @@ define(function (require, exports) {
 
                 var currentRef = documentLib.referenceBy.current,
                     documentPromise = _getDocumentByRef(currentRef),
-                    deselectPromise = descriptor.playObject(selectionLib.deselectAll());
+                    deselectPromise = noCurrentHistory ?
+                        Promise.resolve() :
+                        descriptor.playObject(selectionLib.deselectAll());
 
                 return documentPromise
                     .bind(this)
                     .then(function (currentDoc) {
                         var currentDocLayersPromise = _getLayersForDocument(currentDoc),
-                            historyPromise = this.transfer(historyActions.queryCurrentHistory,
-                                currentDoc.documentID, true),
+                            historyPromise = noCurrentHistory ?
+                                this.transfer("history.initNewHistory", currentDoc.documentID, true) :
+                                this.transfer("history.queryCurrentHistory", currentDoc.documentID, true),
                             // Load guides lazily if they're not currently visible
                             guidesVisible = currentDoc.guidesVisibility,
                             guidesPromise = guidesVisible ? _getGuidesForDocument(currentDoc) : Promise.resolve(),
@@ -323,7 +327,8 @@ define(function (require, exports) {
         reads: [locks.PS_DOC],
         writes: [locks.JS_DOC, locks.JS_APP],
         modal: true,
-        transfers: [historyActions.queryCurrentHistory, "layers.deselectAll", "application.updateRecentFiles"],
+        transfers: ["history.queryCurrentHistory", "history.initNewHistory",
+            "layers.deselectAll", "application.updateRecentFiles"],
         hideOverlays: true
     };
 
@@ -504,7 +509,7 @@ define(function (require, exports) {
                     this.dispatch(events.document.SELECT_DOCUMENT, payload);
 
                     return Promise.join(
-                        this.transfer(historyActions.queryCurrentHistory, documentID, false),
+                        this.transfer(historyActions.initNewHistory, documentID, false),
                         this.transfer(ui.updateTransform));
                 }
             });
@@ -513,7 +518,7 @@ define(function (require, exports) {
         reads: [locks.PS_APP],
         writes: [locks.JS_APP],
         modal: true,
-        transfers: [updateDocument, historyActions.queryCurrentHistory, ui.updateTransform],
+        transfers: [updateDocument, historyActions.initNewHistory, ui.updateTransform],
         lockUI: true,
         hideOverlays: true
     };
@@ -613,7 +618,7 @@ define(function (require, exports) {
      */
     var open = function (filePath, settings) {
         settings = settings || {};
-        
+
         return this.transfer("panel.setOverlayOffsetsForFirstDocument")
             .bind(this)
             .then(function () {
@@ -633,14 +638,14 @@ define(function (require, exports) {
                 return descriptor.playObject(documentLib.open(documentRef, settings))
                     .bind(this)
                     .then(function () {
-                        var initPromise = this.transfer(initActiveDocument),
+                        var initPromise = this.transfer(initActiveDocument, true),
                             uiPromise = this.transfer(ui.updateTransform);
 
                         return Promise.join(initPromise, uiPromise);
                     }, function () {
                         // If file doesn't exist anymore, user will get an Open dialog
                         // If user cancels out of open dialog, PS will throw, so catch it here
-                        this.transfer(menu.native, { commandID: _OPEN_DOCUMENT, waitForCompletion: true });
+                        return this.transfer(menu.native, { commandID: _OPEN_DOCUMENT, waitForCompletion: true });
                     })
                     .then(function () {
                         return this.transfer(toolActions.changeVectorMaskMode, false);

--- a/src/js/actions/history.js
+++ b/src/js/actions/history.js
@@ -77,6 +77,33 @@ define(function (require, exports) {
     };
 
     /**
+     * Initialize a document's history state assuming it is both new and clean.
+     *
+     * @param {number} documentID document for which to query history
+     * @param {boolean=} quiet If true, this will not dispatch a history event
+     * @return {Promise}
+     */
+    var initNewHistory = function (documentID, quiet) {
+        var payload = {
+            source: "init",
+            documentID: documentID,
+            totalStates: 1,
+            currentState: 0
+        };
+
+        if (!quiet) {
+            this.dispatch(events.history.PS_HISTORY_EVENT, payload);
+        }
+
+        return Promise.resolve(payload);
+    };
+    initNewHistory.action = {
+        reads: [],
+        writes: [locks.JS_HISTORY],
+        modal: true
+    };
+
+    /**
      * Helper function to load a state from history store based on a count offset
      * and then to fix it up with the latest selection state, visibility state, and
      * then reset border policies.  Selected layers are also initialized in case the current
@@ -481,6 +508,7 @@ define(function (require, exports) {
     };
 
     exports.queryCurrentHistory = queryCurrentHistory;
+    exports.initNewHistory = initNewHistory;
     exports.incrementHistory = incrementHistory;
     exports.decrementHistory = decrementHistory;
     exports.newHistoryState = newHistoryState;

--- a/src/js/stores/history.js
+++ b/src/js/stores/history.js
@@ -125,8 +125,8 @@ define(function (require, exports, module) {
          * @return {boolean}
          */
         hasNextState: function (documentID) {
-            var history = this._history.get(documentID) || [],
-                current = this._current.get(documentID) || -1;
+            var history = this._history.get(documentID, Immutable.List()),
+                current = this._current.get(documentID, -1);
             return (history.size > current + 1);
         },
 
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
          * @return {boolean}
          */
         hasPreviousState: function (documentID) {
-            var current = this._current.get(documentID) || -1;
+            var current = this._current.get(documentID, -1);
             return current > 1;
         },
 
@@ -656,8 +656,8 @@ define(function (require, exports, module) {
                     throw new Error("Could not amend history state, document not found: " + documentID);
                 }
 
-                var history = this._history.get(documentID) || Immutable.List(),
-                    current = this._current.get(documentID) || -1,
+                var history = this._history.get(documentID, Immutable.List()),
+                    current = this._current.get(documentID, -1),
                     currentState = history.get(current),
                     nextState;
 
@@ -707,8 +707,8 @@ define(function (require, exports, module) {
         _pushHistoryState: function (state, coalesce, allowRogue) {
             var document = state.document,
                 documentID = document.id,
-                history = this._history.get(documentID) || Immutable.List(),
-                current = this._current.get(documentID) || -1;
+                history = this._history.get(documentID, Immutable.List()),
+                current = this._current.get(documentID, -1);
 
             // trim the stale future state
             if (current > -1 && history.size > current + 1) {


### PR DESCRIPTION
When creating a new document or opening a fresh document (i.e., the document was not previously open at application-load time), there is no need to query Photoshop for history state information because we already know that the the answer will be trivial: there is one state, and we're at that state. Since querying history can also be very slow (see #3706), we should skip it when we can. That's what this PR does, with an alternative to `queryCurrentHistory` called `initNewHistory`, which initializes the history store without first consulting Photoshop.

This PR is currently review-only because, mysteriously, this does not seem to result in a measurable speedup when `document.open`ing a large document. I can't figure out why, and I suspect a quirk of the adapter or Photoshop. I'm posting this in case either a) it is obvious to someone else, from looking at the diff, why this is not faster, or b) so that I can point to this when @shaoshing and I meet with @jsbache and @jfitz-adobe next week for a JS-native profiling exercise. 