### PR TITLE
Update keyOriginType for layers on handleLayerTransform

### DIFF
--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -1210,7 +1210,11 @@ define(function (require, exports, module) {
                 descriptor.artboardEnabled = layer.isArtboard;
 
                 var nextBounds = layer.bounds.resetFromDescriptor(descriptor),
-                    nextLayer = layer.set("bounds", nextBounds);
+                    nextRadii = Radii.fromLayerDescriptor(descriptor),
+                    nextLayer = layer.merge({
+                        "bounds": nextBounds,
+                        "radii": nextRadii
+                    });
 
                 layers.set(layerID, nextLayer);
             }, this);

--- a/src/js/models/radii.js
+++ b/src/js/models/radii.js
@@ -82,6 +82,18 @@ define(function (require, exports, module) {
     }));
 
     /**
+     * Updates the radii object with new properties
+     *
+     * @param {object} descriptor Photoshop layer descriptor
+     * @return {Radii}
+     */
+    Radii.prototype.resetFromDescriptor = function (descriptor) {
+        var newRadiiObject = Radii.fromLayerDescriptor(descriptor);
+
+        return this.merge(newRadiiObject);
+    };
+
+    /**
      * Construct a Radii object from the given Photoshop layer descriptor.
      *
      * @param {object} descriptor


### PR DESCRIPTION
This PR does few things:

 - Changes `_boundsPropertyForLayer` function to `_boundsPropertiesForLayer`, allowing for multiple property keys to be attached to a layer bound. This allows us to get `keyOriginType` as well for vector layers on `resetBounds` calls.
 - When a vector layer is rotated, it's keyOriginType changes as well, which tells us the layer can no longer set corner radii. So on `resetBounds` call, we update both of those properties, also in `verifySelectedLayerBounds`

Addresses #3444