### PR TITLE
Console/Timeline improvements

### DIFF
--- a/src/js/actions/debug.js
+++ b/src/js/actions/debug.js
@@ -337,6 +337,24 @@ define(function (require, exports) {
     };
 
     /**
+     * Debug-only method to toggle action logging
+     *
+     * @return {Promise}
+     */
+    var toggleActionLogging = function () {
+        var preferencesStore = this.flux.store("preferences"),
+            preferences = preferencesStore.getState(),
+            enabled = preferences.get("logActions");
+
+        return this.transfer("preferences.setPreference", "logActions", !enabled);
+    };
+    toggleActionLogging.action = {
+        reads: [],
+        writes: [locks.JS_PREF],
+        transfers: ["preferences.setPreference"]
+    };
+
+    /**
      * Debug-only method to toggle action transfer logging
      *
      * @return {Promise}
@@ -554,6 +572,7 @@ define(function (require, exports) {
     exports.resetRecess = resetRecess;
     exports.togglePolicyFrames = togglePolicyFrames;
     exports.togglePostconditions = togglePostconditions;
+    exports.toggleActionLogging = toggleActionLogging;
     exports.toggleActionTransferLogging = toggleActionTransferLogging;
     exports.logDescriptor = logDescriptor;
     exports.logHeadlights = logHeadlights;

--- a/src/js/actions/debug.js
+++ b/src/js/actions/debug.js
@@ -31,6 +31,14 @@ define(function (require, exports) {
         locks = require("js/locks");
 
     /**
+     * Highlight descritor in the console that take longer than the specific time (ms) to complete.
+     * 
+     * @const
+     * @type {number}
+     */
+    var SLOW_DESCRIPTOR = 100;
+
+    /**
      * Temporary helper function to easily open the testrunner. This should
      * eventually replaced with a action that opens the testrunner in a new
      * window.
@@ -393,8 +401,8 @@ define(function (require, exports) {
 
         var blockStyle = "color:gray;",
             groupStyle = "color:blue;font-weight:normal",
-            // Each descriptor log has a unique ID to help mapping between console message and timeline stamp.
-            descritorID = 500;
+            redText = "color:red;font-weight:normal",
+            blueText = "color:blue;font-weight:normal";
 
         descriptor.__getAsync = descriptor.__getAsync || descriptor._getAsync;
         descriptor.__batchPlayAsync = descriptor.__batchPlayAsync || descriptor._batchPlayAsync;
@@ -404,54 +412,114 @@ define(function (require, exports) {
         };
 
         if (enabled) {
+            // Customized version of the `descriptor._getAsync` to capture the descriptor ID.
+            var getAsync = Promise.promisify(function (reference, options, idCallback, callback) {
+                var id = this.get(reference, options, callback);
+                idCallback(id);
+                return id;
+            }, {
+                context: window._spaces.ps.descriptor
+            });
+            
             descriptor._getAsync = function (reference, options) {
-                var id = descritorID++,
-                    start = new Date();
+                var start = new Date(),
+                    descriptorID;
 
-                log.groupCollapsed("%c[Descriptor] Executing get - %d", groupStyle, id);
-                log.trace("Trace");
-                log.debug("Params:\n%c%s", blockStyle, JSON.stringify(reference, null, " "));
-                log.groupEnd();
-                log.timeStamp("[Descriptor] Executing get - " + id);
+                return getAsync(reference, options, function (id) {
+                    descriptorID = id;
 
-                return descriptor.__getAsync(reference, options).then(function (result) {
-                    var end = new Date();
-                    
-                    log.groupCollapsed("%c[Descriptor] Finished get in %dms - %d", groupStyle, end - start, id);
+                    log.groupCollapsed("%c[Descriptor] Executing get - %d", groupStyle, descriptorID);
                     log.trace("Trace");
+                    log.debug("Params:\n%c%s", blockStyle, JSON.stringify(reference, null, " "));
+                    log.groupEnd();
+                    log.timeStamp("[Descriptor] Executing get - " + descriptorID);
+                }).then(function (result) {
+                    var end = new Date();
+
+                    log.groupCollapsed("%c[Descriptor] Finished get in %c%dms%c - %d", groupStyle,
+                        end - start > SLOW_DESCRIPTOR ? redText : blueText,
+                        end - start,
+                        blueText,
+                        descriptorID);
                     log.debug("Result:\n%c%s", blockStyle, JSON.stringify(result, null, " "));
                     log.groupEnd();
-                    log.timeStamp("[Descriptor] Finished get - " + id);
+                    log.timeStamp("[Descriptor] Finished get - " + descriptorID);
                     return result;
                 });
             };
 
-            descriptor._batchPlayAsync = function (commands, options) {
-                var commandNames = commands.map(function (c) { return c.name; }).join(", "),
-                    isHitTest = commandNames === "hitTest",
-                    id = descritorID++,
-                    start = new Date();
+            // Customized version of the `descriptor._batchPlay` to capture the descriptor ID.
+            var batchPlayAsync = Promise.promisify(function (commands, options, idCallback, callback) {
+                var id = this.batchPlay(commands, options, callback);
+                idCallback(id);
+                return id;
+            }, {
+                context: window._spaces.ps.descriptor,
+                multiArgs: true
+            });
 
-                if (!isHitTest) {
-                    var str = "(" + JSON.stringify(commands, null, " ") + ", " +
-                        JSON.stringify(options, null, " ") + ");";
-
-                    log.groupCollapsed("%c[Descriptor] Executing batchPlay: %s - %d", groupStyle, commandNames, id);
-                    log.trace("Trace");
-                    log.debug("Params:\n%c%s", blockStyle, str);
-                    log.groupEnd();
-                    log.timeStamp("[Descriptor] Executing batchPlay - " + id);
+            var summarizeCommands = function (commands) {
+                if (commands.length === 0) {
+                    return "EMPTY";
                 }
-                return descriptor.__batchPlayAsync(commands, options).tap(function (result) {
+
+                commands = commands.map(function (c) { return c.name; });
+
+                var lastCommand = commands[0],
+                    grouppedCommands = [],
+                    results = [];
+
+                commands.forEach(function (command) {
+                    if (lastCommand !== command) {
+                        results.push(grouppedCommands);
+                        lastCommand = command;
+                        grouppedCommands = [];
+                    }
+
+                    grouppedCommands.push(command);
+                });
+
+                results.push(grouppedCommands);
+
+                return results.map(function (grouppedCommands) {
+                    return grouppedCommands.length === 1 ? grouppedCommands[0] :
+                        grouppedCommands[0] + " x " + grouppedCommands.length;
+                }).join(", ");
+            };
+
+            descriptor._batchPlayAsync = function (commands, options) {
+                var commandNames = summarizeCommands(commands),
+                    isHitTest = commandNames === "[hitTest]",
+                    start = new Date(),
+                    descriptorID;
+
+                return batchPlayAsync(commands, options, function (id) {
+                    descriptorID = id;
+
+                    if (!isHitTest) {
+                        var str = "(" + JSON.stringify(commands, null, " ") + ", " +
+                            JSON.stringify(options, null, " ") + ");";
+
+                        log.groupCollapsed("%c[Descriptor] Executing batchPlay: [%s] - %d", groupStyle,
+                            commandNames, descriptorID);
+                        log.trace("Trace");
+                        log.debug("Params:\n%c%s", blockStyle, str);
+                        log.groupEnd();
+                        log.timeStamp("[Descriptor] Executing batchPlay - " + descriptorID);
+                    }
+                }).tap(function (result) {
                     if (!isHitTest) {
                         var end = new Date();
 
-                        log.groupCollapsed("%c[Descriptor] Finished batchPlay: %s in %dms - %d", groupStyle,
-                            commandNames, end - start, id);
-                        log.trace("Trace");
+                        log.groupCollapsed("%c[Descriptor] Finished batchPlay: [%s] in %c%dms%c - %d", groupStyle,
+                            commandNames,
+                            end - start > SLOW_DESCRIPTOR ? redText : blueText,
+                            end - start,
+                            blueText,
+                            descriptorID);
                         log.debug("Result:\n%c%s", blockStyle, JSON.stringify(result, null, " "));
                         log.groupEnd();
-                        log.timeStamp("[Descriptor] Finished batchPlay - " + id);
+                        log.timeStamp("[Descriptor] Finished batchPlay - " + descriptorID);
                     }
                 });
             };

--- a/src/js/actions/debug.js
+++ b/src/js/actions/debug.js
@@ -352,7 +352,7 @@ define(function (require, exports) {
     var toggleActionLogging = function () {
         var preferencesStore = this.flux.store("preferences"),
             preferences = preferencesStore.getState(),
-            enabled = preferences.get("logActions");
+            enabled = preferences.get("logActions", true);
 
         return this.transfer("preferences.setPreference", "logActions", !enabled);
     };
@@ -436,11 +436,10 @@ define(function (require, exports) {
                 }).then(function (result) {
                     var end = new Date();
 
-                    log.groupCollapsed("%c[Descriptor] Finished get in %c%dms%c - %d", groupStyle,
+                    log.groupCollapsed("%c[Descriptor] Finished get - %d in %c%dms", groupStyle,
+                        descriptorID,
                         end - start > SLOW_DESCRIPTOR ? redText : blueText,
-                        end - start,
-                        blueText,
-                        descriptorID);
+                        end - start);
                     log.debug("Result:\n%c%s", blockStyle, JSON.stringify(result, null, " "));
                     log.groupEnd();
                     log.timeStamp("[Descriptor] Finished get - " + descriptorID);
@@ -460,7 +459,7 @@ define(function (require, exports) {
 
             var summarizeCommands = function (commands) {
                 if (commands.length === 0) {
-                    return "EMPTY";
+                    return "";
                 }
 
                 commands = commands.map(function (c) { return c.name; });
@@ -489,7 +488,7 @@ define(function (require, exports) {
 
             descriptor._batchPlayAsync = function (commands, options) {
                 var commandNames = summarizeCommands(commands),
-                    isHitTest = commandNames === "[hitTest]",
+                    isHitTest = commandNames === "hitTest",
                     start = new Date(),
                     descriptorID;
 
@@ -511,12 +510,11 @@ define(function (require, exports) {
                     if (!isHitTest) {
                         var end = new Date();
 
-                        log.groupCollapsed("%c[Descriptor] Finished batchPlay: [%s] in %c%dms%c - %d", groupStyle,
+                        log.groupCollapsed("%c[Descriptor] Finished batchPlay: [%s] - %d in %c%dms", groupStyle,
                             commandNames,
+                            descriptorID,
                             end - start > SLOW_DESCRIPTOR ? redText : blueText,
-                            end - start,
-                            blueText,
-                            descriptorID);
+                            end - start);
                         log.debug("Result:\n%c%s", blockStyle, JSON.stringify(result, null, " "));
                         log.groupEnd();
                         log.timeStamp("[Descriptor] Finished batchPlay - " + descriptorID);

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -781,7 +781,8 @@ define(function (require, exports, module) {
     FluxController.prototype._applyAction = function (action, actionReceiver, params, parentActionName) {
         var flux = this.flux,
             actionObject = action.action,
-            actionName = this._actionNames.get(action);
+            actionName = this._actionNames.get(action),
+            logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions");
 
         if (!actionObject) {
             throw new Error("Action " + actionName + " is not a valid action");
@@ -800,7 +801,7 @@ define(function (require, exports, module) {
             actionTitle = "action " + actionName;
         }
 
-        if (__PG_DEBUG__) {
+        if (logActions) {
             log.timeStamp("Executing " + actionTitle);
         }
 
@@ -860,7 +861,7 @@ define(function (require, exports, module) {
                     this._setAllowFailure(false);
                 }
         
-                if (__PG_DEBUG__) {
+                if (logActions) {
                     log.timeStamp("Finished " + actionTitle);
                 }
 
@@ -915,31 +916,40 @@ define(function (require, exports, module) {
 
         return function () {
             var args = Array.prototype.slice.call(arguments, 0),
-                enqueued = Date.now();
+                logActions = __PG_DEBUG__ && self.flux.store("preferences").getState().get("logActions");
 
             // The receiver of the action, augmented to include a transfer
             // function that allows it to safely transfer control to another action
             var actionReceiver = self._actionReceivers.get(action);
 
-            log.debug("Enqueuing action %s; %d/%d",
-                actionName, actionQueue.active(), actionQueue.pending());
+            if (logActions) {
+                var enqueued = Date.now();
+
+                log.debug("Enqueuing action %s; %d/%d",
+                    actionName, actionQueue.active(), actionQueue.pending());
+            }
 
             var jobPromise = actionQueue.push(function () {
-                var start = Date.now();
+                if (logActions) {
+                    var start = Date.now();
 
-                log.debug("Executing action %s after waiting %dms; %d/%d",
-                    actionName, start - enqueued, actionQueue.active(), actionQueue.pending());
+                    log.debug("Executing action %s after waiting %dms; %d/%d",
+                        actionName, start - enqueued, actionQueue.active(), actionQueue.pending());
+                }
 
                 return this._applyAction(action, actionReceiver, args)
                     .bind(this)
                     .tap(function () {
-                        var finished = Date.now(),
-                            elapsed = finished - start,
-                            total = finished - enqueued,
-                            color = elapsed > SLOW_ACTION ? "color:red" : "";
+                        var finished = Date.now();
 
-                        log.debug("Finished action %s in %c%dms %cwith RTT %dms; %d/%d", actionName, color, elapsed,
-                            "color:blue", total, actionQueue.active(), actionQueue.pending());
+                        if (logActions) {
+                            var elapsed = finished - start,
+                                total = finished - enqueued,
+                                color = elapsed > SLOW_ACTION ? "color:red" : "";
+
+                            log.debug("Finished action %s in %c%dms %cwith RTT %dms; %d/%d", actionName, color, elapsed,
+                                "color:blue", total, actionQueue.active(), actionQueue.pending());
+                        }
 
                         if (__PG_DEBUG__) {
                             performance.recordAction(namespace, name, enqueued, start, finished);
@@ -1069,6 +1079,12 @@ define(function (require, exports, module) {
      * @return {Promise} Resolves once all the applied methods have resolved
      */
     FluxController.prototype._invokeActionMethods = function (methodName, params) {
+        var logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions");
+
+        if (logActions) {
+            log.timeStamp("Executing controller " + methodName);
+        }
+
         var getParam = function (name) {
             if (typeof params === "object") {
                 return params[name];
@@ -1076,8 +1092,6 @@ define(function (require, exports, module) {
                 return params;
             }
         };
-
-        log.timeStamp("Executing controller " + methodName);
 
         var allMethodPromises = Object.keys(actionIndex)
                 .filter(function (moduleName) {
@@ -1099,7 +1113,9 @@ define(function (require, exports, module) {
                 return results;
             }, {})
             .tap(function () {
-                log.timeStamp("Finished controller " + methodName);
+                if (logActions) {
+                    log.timeStamp("Finished controller " + methodName);
+                }
             });
     };
 

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -548,6 +548,7 @@ define(function (require, exports, module) {
                                 actionName, nextActionName,
                                 start - enqueued,
                                 transferQueue.active(), transferQueue.pending());
+                            log.timeStamp("Executing transfer from " + actionName + " to " + nextActionName);
                         }
 
                         return self._applyAction(nextAction, nextReceiver, params, actionName)
@@ -562,6 +563,7 @@ define(function (require, exports, module) {
                                         actionName, nextActionName,
                                         color, elapsed, "color:blue",
                                         total, transferQueue.active(), transferQueue.pending());
+                                    log.timeStamp("Finished transfer from " + actionName + " to " + nextActionName);
                                 }
                             })
                             .catch(function (err) {

--- a/src/js/fluxcontroller.js
+++ b/src/js/fluxcontroller.js
@@ -784,7 +784,7 @@ define(function (require, exports, module) {
         var flux = this.flux,
             actionObject = action.action,
             actionName = this._actionNames.get(action),
-            logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions");
+            logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions", true);
 
         if (!actionObject) {
             throw new Error("Action " + actionName + " is not a valid action");
@@ -918,7 +918,7 @@ define(function (require, exports, module) {
 
         return function () {
             var args = Array.prototype.slice.call(arguments, 0),
-                logActions = __PG_DEBUG__ && self.flux.store("preferences").getState().get("logActions");
+                logActions = __PG_DEBUG__ && self.flux.store("preferences").getState().get("logActions", true);
 
             // The receiver of the action, augmented to include a transfer
             // function that allows it to safely transfer control to another action
@@ -1081,7 +1081,7 @@ define(function (require, exports, module) {
      * @return {Promise} Resolves once all the applied methods have resolved
      */
     FluxController.prototype._invokeActionMethods = function (methodName, params) {
-        var logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions");
+        var logActions = __PG_DEBUG__ && this.flux.store("preferences").getState().get("logActions", true);
 
         if (logActions) {
             log.timeStamp("Executing controller " + methodName);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -127,18 +127,18 @@ define(function (require, exports) {
 
         var startupPromises = _controller.start()
             .then(function () {
-                log.debug("Actions loaded: %dms", Date.now() - startTime);
+                log.debug("Actions loaded at %dms", log.timeElapsed());
             });
 
         var renderPromise = new Promise(function (resolve) {
             ReactDOM.render(new Main(props), window.document.querySelector(".app"), function () {
-                log.debug("Main component mounted: %dms", Date.now() - startTime);
+                log.debug("Main component mounted at %dms", log.timeElapsed());
                 resolve();
             });
         });
 
         Promise.join(renderPromise, startupPromises, function () {
-            log.info("Startup complete: %dms", Date.now() - startTime);
+            log.info("Startup complete at %dms (self %dms)", log.timeElapsed(), Date.now() - startTime);
         });
     };
 

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -530,6 +530,7 @@ define(function (require, exports, module) {
             return updatedMenu.updateSubmenuItems("DEBUG", {
                 "TOGGLE_POLICY_FRAMES": { "checked": preferences.get("policyFramesEnabled", false) },
                 "TOGGLE_POSTCONDITIONS": { "checked": preferences.get("postConditionsEnabled", false) },
+                "TOGGLE_ACTION_LOGGING": { "checked": preferences.get("logActions", false) },
                 "TOGGLE_ACTION_TRANSFER_LOGGING": { "checked": preferences.get("logActionTransfers", false) },
                 "TOGGLE_DESCRIPTOR_LOGGING": { "checked": preferences.get("descriptorLoggingEnabled", false) },
                 "TOGGLE_HEADLIGHTS_LOGGING": { "checked": preferences.get("headlightsLoggingEnabled", false) }

--- a/src/js/models/menubar.js
+++ b/src/js/models/menubar.js
@@ -530,7 +530,7 @@ define(function (require, exports, module) {
             return updatedMenu.updateSubmenuItems("DEBUG", {
                 "TOGGLE_POLICY_FRAMES": { "checked": preferences.get("policyFramesEnabled", false) },
                 "TOGGLE_POSTCONDITIONS": { "checked": preferences.get("postConditionsEnabled", false) },
-                "TOGGLE_ACTION_LOGGING": { "checked": preferences.get("logActions", false) },
+                "TOGGLE_ACTION_LOGGING": { "checked": preferences.get("logActions", true) },
                 "TOGGLE_ACTION_TRANSFER_LOGGING": { "checked": preferences.get("logActionTransfers", false) },
                 "TOGGLE_DESCRIPTOR_LOGGING": { "checked": preferences.get("descriptorLoggingEnabled", false) },
                 "TOGGLE_HEADLIGHTS_LOGGING": { "checked": preferences.get("headlightsLoggingEnabled", false) }

--- a/src/js/util/log.js
+++ b/src/js/util/log.js
@@ -43,6 +43,15 @@ define(function (require, exports, module) {
     if (!loglevel.hasOwnProperty("timeStamp")) {
         loglevel.timeStamp = console.timeStamp.bind(console);
     }
+    
+    /**
+     * Return the time (in ms) elapsed since page load.
+     * 
+     * @return {Number}
+     */
+    loglevel.timeElapsed = function () {
+        return Date.now() - performance.timing.domLoading;
+    };
 
     module.exports = loglevel;
 });

--- a/src/js/util/log.js
+++ b/src/js/util/log.js
@@ -39,10 +39,12 @@ define(function (require, exports, module) {
         // Otherwise, only log information, warnings and errors
         loglevel.setLevel(loglevel.levels.INFO);
     }
-
-    if (!loglevel.hasOwnProperty("timeStamp")) {
-        loglevel.timeStamp = console.timeStamp.bind(console);
-    }
+    
+    ["timeStamp", "group", "groupCollapsed", "groupEnd", "trace"].forEach(function (api) {
+        if (!loglevel.hasOwnProperty(api)) {
+            loglevel[api] = console[api].bind(console);
+        }
+    });
     
     /**
      * Return the time (in ms) elapsed since page load.

--- a/src/nls/en/menu.json
+++ b/src/nls/en/menu.json
@@ -239,6 +239,7 @@
         "LOAD_DEBUGGING_HELPERS": "Load Debugging Helpers",
         "TOGGLE_POLICY_FRAMES": "Show Policy Frames",
         "TOGGLE_POSTCONDITIONS": "Verify Postconditions",
+        "TOGGLE_ACTION_LOGGING": "Log Actions",
         "TOGGLE_ACTION_TRANSFER_LOGGING": "Log Action Transfers",
         "TOGGLE_DESCRIPTOR_LOGGING": "Log Descriptor Events",
         "TOGGLE_HEADLIGHTS_LOGGING": "Log Headlights Events"

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -508,6 +508,10 @@
             "$action": "debug.togglePostconditions",
             "$enable-rule": "always-except-modal"
         },
+        "TOGGLE_ACTION_LOGGING": {
+            "$action": "debug.toggleActionLogging",
+            "$enable-rule": "always-except-modal"
+        },
         "TOGGLE_ACTION_TRANSFER_LOGGING": {
             "$action": "debug.toggleActionTransferLogging",
             "$enable-rule": "always-except-modal"

--- a/src/static/menu-mac.json
+++ b/src/static/menu-mac.json
@@ -788,6 +788,10 @@
                     "debug": true
                 },
                 {
+                    "id": "TOGGLE_ACTION_LOGGING",
+                    "debug": true
+                },
+                {
                     "id": "TOGGLE_ACTION_TRANSFER_LOGGING",
                     "debug": true
                 },

--- a/src/static/menu-win.json
+++ b/src/static/menu-win.json
@@ -762,6 +762,10 @@
                     "debug": true
                 },
                 {
+                    "id": "TOGGLE_ACTION_LOGGING",
+                    "debug": true
+                },
+                {
                     "id": "TOGGLE_ACTION_TRANSFER_LOGGING",
                     "debug": true
                 },


### PR DESCRIPTION
This PR includes the following improvements to the Console and Timeline:

#### Togglable action log
You will be able to disable action log and timestamp completely by turning `Log Actions` and `Log Action Transfers` off. This is useful when you need a clean console or Timeline.

<img width="270" alt="screen shot 2016-02-18 at 3 48 50 pm" src="https://cloud.githubusercontent.com/assets/118264/13162169/d2318084-d657-11e5-9c30-bd05f45fe94d.png">

#### Better descriptor log
- Descriptor log now shows the params/result in a collapsed group, which avoids overcrowding the console.
- Has stack trace
- Show completion time. This helps target slow descriptors.
- Show timestamp in the Timeline.
- Descriptor calls have unique ID to help mapping the `executing/finished` message in the console, and mapping between the console and timeline.

<img width="433" alt="screen shot 2016-02-18 at 3 49 23 pm" src="https://cloud.githubusercontent.com/assets/118264/13162275/93c9a9ba-d658-11e5-9d16-689f8fdf7105.png">


#### Startup timestamp
<img width="689" alt="screen shot 2016-02-18 at 3 48 29 pm" src="https://cloud.githubusercontent.com/assets/118264/13162255/76a8bfec-d658-11e5-8592-0ec057215992.png">
