### PR TITLE
Only update overlays when pointer is inside canvas bounds

### DIFF
--- a/src/js/jsx/tools/GuidesOverlay.jsx
+++ b/src/js/jsx/tools/GuidesOverlay.jsx
@@ -87,7 +87,8 @@ define(function (require, exports, module) {
                 document: currentDocument,
                 tool: currentTool,
                 modalState: modalState || appIsModal,
-                overlaysEnabled: panelState.overlaysEnabled
+                overlaysEnabled: panelState.overlaysEnabled,
+                canvasBounds: panelStore.getCloakRect()
             };
         },
 
@@ -289,6 +290,14 @@ define(function (require, exports, module) {
                 self = this;
 
             if (self._currentMouseDown) {
+                return;
+            }
+
+            var canvasBounds = this.state.canvasBounds;
+            if (!canvasBounds ||
+                mouseX < canvasBounds.left || mouseX > canvasBounds.right ||
+                mouseY < canvasBounds.top || mouseY > canvasBounds.bottom) {
+                self._debouncedHighlight.cancel();
                 return;
             }
             

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     var DEBOUNCE_DELAY = 200;
 
     var SamplerOverlay = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("tool", "document", "application", "ui", "style")],
+        mixins: [FluxMixin, StoreWatchMixin("tool", "document", "application", "ui", "panel", "style")],
 
         /**
          * Keeps track of current mouse position so we can rerender the overlaid layers correctly
@@ -92,6 +92,7 @@ define(function (require, exports, module) {
                 applicationStore = flux.store("application"),
                 toolStore = flux.store("tool"),
                 styleStore = flux.store("style"),
+                panelStore = flux.store("panel"),
                 modalState = toolStore.getModalToolState(),
                 currentTool = toolStore.getCurrentTool(),
                 currentDocument = applicationStore.getCurrentDocument(),
@@ -103,7 +104,8 @@ define(function (require, exports, module) {
                 tool: currentTool,
                 modalState: modalState,
                 sampleTypes: sampleTypes,
-                samplePoint: samplePoint
+                samplePoint: samplePoint,
+                canvasBounds: panelStore.getCloakRect()
             };
         },
 
@@ -527,11 +529,19 @@ define(function (require, exports, module) {
                 return;
             }
 
+            var canvasBounds = this.state.canvasBounds,
+                mouseX = this._currentMouseX,
+                mouseY = this._currentMouseY;
+
+            if (!canvasBounds ||
+                mouseX < canvasBounds.left || mouseX > canvasBounds.right ||
+                mouseY < canvasBounds.top || mouseY > canvasBounds.bottom) {
+                return;
+            }
+
             var scale = this._scale,
                 layerTree = this.state.document.layers,
                 uiStore = this.getFlux().store("ui"),
-                mouseX = this._currentMouseX,
-                mouseY = this._currentMouseY,
                 canvasMouse = uiStore.transformWindowToCanvas(mouseX, mouseY),
                 highlightFound = false;
 

--- a/src/js/jsx/tools/SuperselectOverlay.jsx
+++ b/src/js/jsx/tools/SuperselectOverlay.jsx
@@ -123,7 +123,8 @@ define(function (require, exports, module) {
                 marqueeStart: panelState.marqueeStart,
                 modalState: modalState,
                 leafBounds: leafModifier,
-                vectorMaskMode: vectorMaskMode
+                vectorMaskMode: vectorMaskMode,
+                canvasBounds: panelStore.getCloakRect()
             };
         },
 
@@ -479,16 +480,24 @@ define(function (require, exports, module) {
                 return;
             }
 
+            var canvasBounds = this.state.canvasBounds,
+                mouseX = this._currentMouseX,
+                mouseY = this._currentMouseY;
+
+            if (!canvasBounds ||
+                mouseX < canvasBounds.left || mouseX > canvasBounds.right ||
+                mouseY < canvasBounds.top || mouseY > canvasBounds.bottom) {
+                return;
+            }
+
             var marquee = this.state.marqueeEnabled,
                 layerTree = this.state.document.layers,
                 scale = this._scale,
                 uiStore = this.getFlux().store("ui"),
-                mouseX = this._currentMouseX,
-                mouseY = this._currentMouseY,
                 canvasMouse = uiStore.transformWindowToCanvas(mouseX, mouseY),
                 highlightFound = false,
                 underPolicy = this._positionUnderAlwaysPropagatePolicy(mouseX, mouseY);
-            
+
             // Yuck, we gotta traverse backwards, and D3 doesn't offer reverse iteration
             _.forEachRight(d3.selectAll(".artboard-name-rect")[0], function (element) {
                 var layer = d3.select(element),


### PR DESCRIPTION
What it says! This cuts down on some pointless, wasteful calls to `hitTest`.

Addresses #3732.