### PR TITLE
Compare top selected ancestors for border policy reset

### DIFF
--- a/src/js/actions/tools.js
+++ b/src/js/actions/tools.js
@@ -869,6 +869,7 @@ define(function (require, exports) {
             toolStore = this.flux.store("tool"),
             panelStore = this.flux.store("panel"),
             documentLayerBounds,
+            topSelectedLayers,
             activeTool,
             canvasRectangle,
             uiTransformMatrix;
@@ -884,15 +885,18 @@ define(function (require, exports) {
 
             if (currentDocument) {
                 var nextDocumentLayerBounds = currentDocument.layers.selectedChildBounds,
+                    nextTopSelectedLayers = currentDocument.layers.selectedTopAncestors,
                     newxUiTransformMatrix = uiStore.getCurrentTransformMatrix(),
                     newCanvasRectangle = panelStore.getCloakRect(),
                     newTool = toolStore.getCurrentTool();
                     
                 if (!Immutable.is(documentLayerBounds, nextDocumentLayerBounds) ||
+                        !Immutable.is(topSelectedLayers, nextTopSelectedLayers) ||
                         !_.isEqual(uiTransformMatrix, newxUiTransformMatrix) ||
                         !_.isEqual(canvasRectangle, newCanvasRectangle) ||
                         activeTool !== newTool) {
                     documentLayerBounds = nextDocumentLayerBounds;
+                    topSelectedLayers = nextTopSelectedLayers,
                     uiTransformMatrix = newxUiTransformMatrix;
                     activeTool = newTool;
                     canvasRectangle = newCanvasRectangle;


### PR DESCRIPTION
Beautiful edge case, create artboard guide, deselect all layers, then select a layer with no bounds.

We would only check for bounds, and a layer with no bounds would be equal to no layers selected. So now we also check to see if top selected ancestors differ, since they drive which artboard guides show.

Adresses #3736