### PR TITLE
Consider vector masks of groups in their bounds

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -64,6 +64,7 @@ define(function (require, exports) {
         "layerLocking",
         "itemIndex",
         "background",
+        "bounds",
         "boundsNoMask",
         "boundsNoEffects",
         "mode"
@@ -269,6 +270,8 @@ define(function (require, exports) {
             property = ["pathBounds", "keyOriginType"];
         } else if (layer.isText) {
             property = ["boundingBox"];
+        } else if (layer.isGroup && layer.vectorMaskEnabled) {
+            property = ["bounds", "vectorMaskEnabled"];
         } else {
             property = ["boundsNoMask"];
         }
@@ -524,7 +527,7 @@ define(function (require, exports) {
                 .filterNot(function (layer) {
                     // We don't track bounds of non-artboard groups or adjustment layers
                     return layer.isGroupEnd ||
-                        (layer.isGroup && !layer.isArtboard) ||
+                        (layer.isGroup && !(layer.isArtboard || layer.vectorMaskEnabled)) ||
                         layer.isAdjustment;
                 });
 

--- a/src/js/models/bounds.js
+++ b/src/js/models/bounds.js
@@ -164,6 +164,12 @@ define(function (require, exports, module) {
             switch (layerKind) {
                 // Photoshop's group / adjustment bounds are not useful, so ignore them.
             case Layer.KINDS.GROUP:
+                if (descriptor.vectorMaskEnabled) {
+                    boundsObject = descriptor.bounds;
+                } else {
+                    return null;
+                }
+                break;
             case Layer.KINDS.GROUPEND:
             case Layer.KINDS.ADJUSTMENT:
                 return null;

--- a/src/js/models/layerstructure.js
+++ b/src/js/models/layerstructure.js
@@ -961,6 +961,10 @@ define(function (require, exports, module) {
                         return bounds && bounds.area > 0;
                     });
 
+            if (layer.vectorMaskEnabled) {
+                childBounds = childBounds.push(layer.bounds);
+            }
+
             return Bounds.union(childBounds);
         case Layer.KINDS.GROUPEND:
             return null;


### PR DESCRIPTION
In a situation where a vector mask was created for a group, we would still be calculating it's bounds using the child bounds. But the transform controls show for the union of child bounds and the mask bounds.

This PR makes sure we get the required properties for the group bounds, and use them in bounds calculations.

Addresses #3704 and potentially other mask related group bounds issues