### PR TITLE
Changes to search bar: edits the tool names, direct selection vector option conditional

### DIFF
--- a/src/js/actions/search/commands.js
+++ b/src/js/actions/search/commands.js
@@ -72,7 +72,7 @@ define(function (require, exports) {
     };
     
     /**
-     * Get a shortcut as a string for themen menu entry shortcut object
+     * Get a shortcut as a string for menu entry shortcut object
      *
      * @private
      * @param {object} fullShortcut
@@ -114,7 +114,7 @@ define(function (require, exports) {
     };
     
     /**
-     * Make list of recent documents info so search store can create search options
+     * Make list of shortcut commands info so search store can create search options
      * 
      * @private
      * @return {Immutable.List.<object>}
@@ -258,7 +258,7 @@ define(function (require, exports) {
     };
     
     /**
-     * Register recent document info for search
+     * Register menu commands and associated shortcuts for search
      */
     var registerMenuCommandSearch = function () {
         var menuCommandPayload = {

--- a/src/js/jsx/ToolbarIcon.jsx
+++ b/src/js/jsx/ToolbarIcon.jsx
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
                     id={this.props.id}
                     style={this.props.style}>
                     <Button
-                        title={nls.localize("strings.TOOLS." + toolID)}
+                        title={nls.localize("strings.TOOLTIPS.TOOLS." + toolID)}
                         className={buttonClassName}
                         onClick={!this.props.disabled && this.props.onClick}
                         disabled={this.props.disabled}>

--- a/src/js/models/tools/ellipse.js
+++ b/src/js/models/tools/ellipse.js
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
-        shortcuts = require("js/util/shortcuts");
+        shortcuts = require("js/util/shortcuts"),
+        nls = require("js/util/nls");
 
     /**
      * @implements {Tool}
@@ -47,7 +48,7 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.PROPAGATE_TO_BROWSER,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE);
         
-        Tool.call(this, "ellipse", "Ellipse", "ellipseTool", "tool.ellipse.select");
+        Tool.call(this, "ellipse", nls.localize("strings.TOOLS.NAMES.ELLIPSE"), "ellipseTool", "tool.ellipse.select");
 
         this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy, escapeKeyPolicy];
         this.activationKey = shortcuts.GLOBAL.TOOLS.ELLIPSE;

--- a/src/js/models/tools/pen.js
+++ b/src/js/models/tools/pen.js
@@ -31,14 +31,15 @@ define(function (require, exports, module) {
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
-        shortcutUtil = require("js/util/shortcuts");
+        shortcutUtil = require("js/util/shortcuts"),
+        nls = require("js/util/nls");
 
     /**
      * @implements {Tool}
      * @constructor
      */
     var PenTool = function () {
-        Tool.call(this, "pen", "Pen", "penTool");
+        Tool.call(this, "pen", nls.localize("strings.TOOLS.NAMES.PEN"), "penTool");
 
         var backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.PROPAGATE_TO_BROWSER,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE),

--- a/src/js/models/tools/rectangle.js
+++ b/src/js/models/tools/rectangle.js
@@ -32,7 +32,8 @@ define(function (require, exports, module) {
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
-        utilShortcuts = require("js/util/shortcuts");
+        utilShortcuts = require("js/util/shortcuts"),
+        nls = require("js/util/nls");
 
     /**
      * @implements {Tool}
@@ -48,7 +49,8 @@ define(function (require, exports, module) {
             backspaceKeyPolicy = new KeyboardEventPolicy(UI.policyAction.PROPAGATE_TO_BROWSER,
                 OS.eventKind.KEY_DOWN, null, OS.eventKeyCode.BACKSPACE);
 
-        Tool.call(this, "rectangle", "Rectangle", "rectangleTool", "tool.rectangle.select");
+        Tool.call(this, "rectangle", nls.localize("strings.TOOLS.NAMES.RECTANGLE"),
+            "rectangleTool", "tool.rectangle.select");
        
         this.keyboardPolicyList = [shiftUKeyPolicy, deleteKeyPolicy, backspaceKeyPolicy, escapeKeyPolicy];
         this.activationKey = utilShortcuts.GLOBAL.TOOLS.RECTANGLE;

--- a/src/js/models/tools/sampler.js
+++ b/src/js/models/tools/sampler.js
@@ -32,14 +32,15 @@ define(function (require, exports, module) {
         EventPolicy = require("js/models/eventpolicy"),
         PointerEventPolicy = EventPolicy.PointerEventPolicy,
         SamplerOverlay = require("js/jsx/tools/SamplerOverlay"),
-        shortcuts = require("js/util/shortcuts");
+        shortcuts = require("js/util/shortcuts"),
+        nls = require("js/util/nls");
 
     /**
      * @implements {Tool}
      * @constructor
      */
     var SamplerTool = function () {
-        Tool.call(this, "sampler", "Sampler", "eyedropperTool");
+        Tool.call(this, "sampler", nls.localize("strings.TOOLS.NAMES.EYEDROPPER"), "eyedropperTool");
 
         this.icon = "eyedropper";
         this.activationKey = shortcuts.GLOBAL.TOOLS.SAMPLER;

--- a/src/js/models/tools/superselect.js
+++ b/src/js/models/tools/superselect.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
         TypeTool = require("./superselect/type"),
         system = require("js/util/system"),
         shortcuts = require("js/util/shortcuts"),
+        nls = require("js/util/nls"),
         SuperselectOverlay = require("js/jsx/tools/SuperselectOverlay"),
         ArtboardAdderOverlay = require("js/jsx/tools/ArtboardAdderOverlay"),
         EventPolicy = require("js/models/eventpolicy"),
@@ -101,7 +102,7 @@ define(function (require, exports, module) {
     var SuperSelectTool = function () {
         this.id = "newSelect";
         this.icon = "newSelect";
-        this.name = "Super Select";
+        this.name = nls.localize("strings.TOOLS.NAMES.SELECT");
         this.nativeToolName = _nativeToolName;
         this.dragging = false;
         this.dragEvent = null;

--- a/src/js/models/tools/superselect/type.js
+++ b/src/js/models/tools/superselect/type.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         
     var Tool = require("js/models/tool"),
         EventPolicy = require("js/models/eventpolicy"),
+        nls = require("js/util/nls"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy;
 
     /**
@@ -37,7 +38,8 @@ define(function (require, exports, module) {
      * @constructor
      */
     var SuperSelectTypeTool = function () {
-        Tool.call(this, "superselectType", "Superselect-Type", "typeCreateOrEditTool");
+        Tool.call(this, "superselectType", nls.localize("strings.TOOLS.NAMES.SUPER_SELECT_TYPE"),
+            "typeCreateOrEditTool");
         this.icon = "typeCreateOrEdit";
 
         var escapeKeyPolicy = new KeyboardEventPolicy(UI.policyAction.PROPAGATE_TO_BROWSER,

--- a/src/js/models/tools/superselect/vector.js
+++ b/src/js/models/tools/superselect/vector.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         
     var Tool = require("js/models/tool"),
         system = require("js/util/system"),
+        nls = require("js/util/nls"),
         EventPolicy = require("js/models/eventpolicy"),
         SuperselectVectorMaskOverlay = require("js/jsx/tools/SuperselectVectorMaskOverlay"),
         KeyboardEventPolicy = EventPolicy.KeyboardEventPolicy,
@@ -40,7 +41,8 @@ define(function (require, exports, module) {
      * @constructor
      */
     var SuperSelectVectorTool = function () {
-        Tool.call(this, "superselectVector", "Superselect - Direct Select", "directSelectTool");
+        Tool.call(this, "superselectVector", nls.localize("strings.TOOLS.NAMES.DIRECT_SELECTION_TOOL"),
+            "directSelectTool");
         this.icon = "directSelect";
         this.isMainTool = false;
         this.handleVectorMaskMode = true;

--- a/src/js/models/tools/type.js
+++ b/src/js/models/tools/type.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     var util = require("adapter").util;
 
     var Tool = require("js/models/tool"),
+        nls = require("js/util/nls"),
         shortcuts = require("js/util/shortcuts");
 
     /**
@@ -34,7 +35,8 @@ define(function (require, exports, module) {
      * @constructor
      */
     var TypeTool = function () {
-        Tool.call(this, "typeCreateOrEdit", "Type", "typeCreateOrEditTool", "tool.type.select", "tool.type.deselect");
+        Tool.call(this, "typeCreateOrEdit", nls.localize("strings.TOOLS.NAMES.TYPE"), "typeCreateOrEditTool",
+            "tool.type.select", "tool.type.deselect");
 
         this.activationKey = shortcuts.GLOBAL.TOOLS.TYPE;
     };

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -150,13 +150,17 @@
     },
     "TITLE_TRANSFORM": "Transform",
     "TOOLS": {
-        "superselectVector": "A - Select Vector Tool",
-        "newSelect": "V - Select Tool",
-        "rectangle": "R - Rectangle Tool",
-        "ellipse": "E - Ellipse Tool",
-        "pen": "P - Pen Tool",
-        "typeCreateOrEdit": "T - Type Tool",
-        "sampler": "I - Sampler Tool"
+        "NAMES" : {
+            "DIRECT_SELECTION_TOOL": "Direct Selection Tool",
+            "VECTOR_MASK_MODE": "Vector Mask Mode",
+            "ELLIPSE": "Ellipse Tool",
+            "PEN": "Pen Tool",
+            "SUPER_SELECT_TYPE": "Superselect-Type",
+            "RECTANGLE": "Rectangle Tool",
+            "EYEDROPPER": "Sampler Tool",
+            "SELECT": "Select Tool",
+            "TYPE": "Type Tool"
+        }
     },
     "TOOLTIPS": {
         "SELECT_NEXT_DOCUMENT": "Select Next Document",
@@ -274,7 +278,16 @@
         "EXPORT_DIALOG": "Export",
         "REFERENCE_POINT_TOOL": "Set reference point",
         "VECTOR_MASK_MODE": "Mask mode",
-        "SEARCH": "Search"
+        "SEARCH": "Search",
+        "TOOLS": {
+            "superselectVector": "A - Select Vector Tool",
+            "newSelect": "V - Select Tool",
+            "rectangle": "R - Rectangle Tool",
+            "ellipse": "E - Ellipse Tool",
+            "pen": "P - Pen Tool",
+            "typeCreateOrEdit": "T - Type Tool",
+            "sampler": "I - Sampler Tool"
+        }
     },
     "LAYER_KIND": {
         "ANY": "Any Layer",


### PR DESCRIPTION
References issue #3737 

- All tools have "Tool" succeeding their individual names 
- "Super Select" --> "Select Tool"
- "Vector Mask" --> "Vector Mask Mode"
- "Super Select Vector" --> "Direct Selection Tool"
- "Direct Selection Tool" is not an option in Search > Global Shortcuts if we are not in Vector Mode 

![](https://www.dropbox.com/s/q3mkrf5fjhsvn2l/Untitled-1%401x.jpg?raw=1)
