### PR TITLE
Added class label to opacity for Japanese styling

### DIFF
--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -628,7 +628,7 @@ define(function (require, exports, module) {
                         <div className="control-group__vertical">
                             <Label
                                 size="column-4"
-                                className={"label__medium__left-aligned"}
+                                className={"label__medium__left-aligned opacity-label"}
                                 title={nls.localize("strings.TOOLTIPS.SET_OPACITY")}>
                                 {nls.localize("strings.STYLE.OPACITY")}
                             </Label>


### PR DESCRIPTION
References issue #3701 

Before: 
![](https://www.dropbox.com/s/jzosi4xabn3yfl4/Screenshot%202016-02-24%2014.42.23.png?raw=1)

After: 
![](https://www.dropbox.com/s/iv5iib55d4nm1kl/Screenshot%202016-02-24%2014.41.46.png?raw=1)
