### PR TITLE
Stop listening to moveToArtboard events, and look for it in move events

### DIFF
--- a/src/js/jsx/sections/transform/TransformPanel.jsx
+++ b/src/js/jsx/sections/transform/TransformPanel.jsx
@@ -55,6 +55,8 @@ define(function (require, exports, module) {
             return this.state.referencePoint !== nextState.referencePoint ||
                 this.props.disabled !== nextProps.disabled ||
                 !Immutable.is(this.props.document.layers.selected, nextProps.document.layers.selected) ||
+                !Immutable.is(this.props.document.layers.selectedRelativeChildBounds,
+                    nextProps.document.layers.selectedRelativeChildBounds) ||
                 !Immutable.is(this.props.document.bounds, nextProps.document.bounds);
         },
 


### PR DESCRIPTION
Starting with pg-dev-mac#1104, we will get an array named `moveToArtboard` inside the `move` and `duplicateNewSheets` commands that will tell us all the layers that changed artboards with structure: `[ { layer: #, artboard: # }, ...]`

Whoever is reviewing, please do a quick testing as well (I've done some but it's nice to have extra eyes)

Also addresses #3748 