### PR TITLE
Bug fix: check existence of layer before scrolling into it

### DIFF
--- a/src/js/jsx/sections/layers/LayerGroup.jsx
+++ b/src/js/jsx/sections/layers/LayerGroup.jsx
@@ -157,8 +157,8 @@ define(function (require, exports, module) {
          */
         _scrollIntoFirstSelectedLayer: function () {
             var firstSelectedLayer = this.props.document.layers.selected.first(),
-                layerNode = ReactDOM.findDOMNode(this.refs[firstSelectedLayer.key]);
-                
+                layerNode = firstSelectedLayer ? ReactDOM.findDOMNode(this.refs[firstSelectedLayer.key]) : null;
+            
             if (layerNode) {
                 layerNode.scrollIntoViewIfNeeded();
             }


### PR DESCRIPTION
This PR checks if the current document has selected layers before scrolling into it at initial display. This will fix for issue #3764 

