### PR TITLE
Avoid selecting text during scrub

### DIFF
--- a/src/js/jsx/mixin/Scrubby.js
+++ b/src/js/jsx/mixin/Scrubby.js
@@ -181,6 +181,7 @@ define(function (require, exports, module) {
         _handleScrubMove: function (e) {
             if (this.state.scrubbing) {
                 e.stopPropagation();
+                e.preventDefault();
 
                 var coords = this._getScrubPosition(e),
                     deltaX = coords.x - this._initialScrubX,


### PR DESCRIPTION
Prevent the default browser behavior during scrubby mousemove events to avoid selecting text within input elements. This seems to work for me, but please test! CC @chadrolfs 

Addresses #3266.