### PR TITLE
Require at least node version 4.2.3 when running npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "Ian Wehrman <wehrman@adobe.com>"
   ],
   "description": "Adobe Photoshop Design Space",
+  "enginesStrict": true,
+  "engines": {
+      "node": ">= 4.2.3"
+  },
   "scripts": {
     "test": "grunt test",
     "build": "grunt compile"


### PR DESCRIPTION
@jsbache found today that node 0.10.x is insufficient for `grunt compile`. This simple change should cause `npm install` to fail with a clear error message when when using a node version below 4.2.3. (I arbitrarily picked that version because it was LTS for a while, and there doesn't seem to be a good reason to force developers to upgrade to anything newer at this point.)

Addresses #3780. 

More info: http://www.marcusoft.net/2015/03/packagejson-and-engines-and-enginestrict.html