### PR TITLE
Coalesce type face and weight changes

### DIFF
--- a/src/js/actions/type.js
+++ b/src/js/actions/type.js
@@ -144,15 +144,16 @@ define(function (require, exports) {
      * @param {string} postscript Post script name of the described typeface
      * @param {string} family The type face family name, e.g., "Helvetica Neue"
      * @param {string} style The type face style name, e.g., "Oblique"
+     * @param {boolean=} coalesce
      * @return {Promise}
      */
-    var setPostScript = function (document, layers, postscript, family, style) {
+    var setPostScript = function (document, layers, postscript, family, style, coalesce) {
         var layerIDs = collection.pluck(layers, "id"),
             layerRefs = layerIDs.map(textLayerLib.referenceBy.id).toArray(),
             modal = this.flux.store("tool").getModalToolState();
 
         var setFacePlayObject = textLayerLib.setPostScript(layerRefs, postscript),
-            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_FACE"), modal),
+            typeOptions = _getTypeOptions(document.id, nls.localize("strings.ACTIONS.SET_TYPE_FACE"), modal, coalesce),
             setFacePromise = locking.playWithLockOverride(document, layers, setFacePlayObject, typeOptions),
             updatePromise = this.transfer(updatePostScript, document, layers, postscript, family, style);
 

--- a/src/js/jsx/sections/style/Type.jsx
+++ b/src/js/jsx/sections/style/Type.jsx
@@ -47,7 +47,8 @@ define(function (require, exports, module) {
         Color = require("js/models/color"),
         collection = require("js/util/collection"),
         unit = require("js/util/unit"),
-        mathUtil = require("js/util/math");
+        mathUtil = require("js/util/math"),
+        Coalesce = require("js/jsx/mixin/Coalesce");
 
     /**
      * Minimum and maximum values for font size, leading and tracking.
@@ -63,7 +64,7 @@ define(function (require, exports, module) {
         MAX_TRACKING = 10000;
 
     var Type = React.createClass({
-        mixins: [FluxMixin, StoreWatchMixin("font", "tool")],
+        mixins: [FluxMixin, StoreWatchMixin("font", "tool"), Coalesce],
 
         shouldComponentUpdate: function (nextProps, nextState) {
             var getProperties = function (document) {
@@ -183,9 +184,10 @@ define(function (require, exports, module) {
                 }),
                 family = this._getPostScriptFontFamily(postScriptName),
                 style = this._getPostScriptFontStyle(postScriptName),
-                flux = this.getFlux();
+                flux = this.getFlux(),
+                coalesce = this.shouldCoalesce();
 
-            flux.actions.type.setPostScriptThrottled(document, layers, postScriptName, family, style);
+            flux.actions.type.setPostScriptThrottled(document, layers, postScriptName, family, style, coalesce);
         },
 
         /**
@@ -657,6 +659,8 @@ define(function (require, exports, module) {
                             placeholderText={placeholderText}
                             options={this.state.typefaces}
                             size="column-full"
+                            onOpen={this.startCoalescing}
+                            onClose={this.stopCoalescing}
                             onHighlightedChange={this._handleTypefaceChange}/>
                     </div>
                     <div className="formline formline__space-between">
@@ -681,6 +685,8 @@ define(function (require, exports, module) {
                                 selected={postScriptFamilyName}
                                 options={familyFontOptions}
                                 size="column-22"
+                                onOpen={this.startCoalescing}
+                                onClose={this.stopCoalescing}
                                 onHighlightedChange={this._handleTypeWeightChange}/>
                         </div>
                     </div>

--- a/src/js/jsx/shared/Datalist.jsx
+++ b/src/js/jsx/shared/Datalist.jsx
@@ -119,7 +119,14 @@ define(function (require, exports, module) {
              * @param {string} lastHighlightedID - the last highlighted ID. This is equal to initialSelectedID 
              *                                     if the selection is confirmed (with onChange event fired).
              */
-            onClose: React.PropTypes.func
+            onClose: React.PropTypes.func,
+
+            /**
+             * Callback to handle dropdown list open
+             *
+             * @callback Datalist~onOpen
+             */
+            onOpen: React.PropTypes.func
         },
 
         /**
@@ -449,6 +456,10 @@ define(function (require, exports, module) {
          */
         _handleDialogOpen: function () {
             this._initialSelectedID = this.props.selected;
+
+            if (this.props.onOpen) {
+                this.props.onOpen();
+            }
         },
 
         /**


### PR DESCRIPTION
This makes the type face and weight `Datalist` instances coalescable, by mixing the `Coalesce` mixin into the `Type` component. This means that when you open one of those datalists and browse through the entries, you'll only create one history state and don't have to undo a thousand times to get back to your original font.

I'm embarrassed that we shipped with this last time. It turned out to be a lot easier to fix than I thought... 

Addresses #3667.