### PR TITLE
Disable the export button on the export modal panel if nothing to export

### DIFF
--- a/src/js/jsx/sections/export/ExportAllPanel.jsx
+++ b/src/js/jsx/sections/export/ExportAllPanel.jsx
@@ -257,7 +257,9 @@ define(function (require, exports, module) {
             var allArtboardsExportComponents = artboardsSorted.map(layerExportComponent),
                 allNonABLayerExportComponents = nonABLayersFiltered.reverse().map(layerExportComponent),
                 allArtboardsExportEnabled = collection.pluck(artboardsSorted, "exportEnabled"),
-                allNonABLayersExportEnabled = collection.pluck(nonABLayersFiltered, "exportEnabled");
+                allNonABLayersExportEnabled = collection.pluck(nonABLayersFiltered, "exportEnabled"),
+                atLeastOneExportEnabled = allArtboardsExportEnabled.some(_.identity) ||
+                    allNonABLayersExportEnabled.some(_.identity);
 
             var panelClassnames = classnames("exports-panel__container");
 
@@ -313,7 +315,7 @@ define(function (require, exports, module) {
                         <div className="exports-panel__button-group">
                             <Button
                                 className="loader-animation"
-                                disabled={this.state.exportDisabled || serviceBusy}
+                                disabled={!atLeastOneExportEnabled || this.state.exportDisabled || serviceBusy}
                                 onClick={this._exportAllAssets.bind(this, prefixMap)}>
                                 {exportButton}
                             </Button>


### PR DESCRIPTION
This is a narrow fix for the problem reported in #3710.  I made this fix awhile ago but sat on it while continuing to research the "make it just work" proposal/discussion from that issue.  But, I think it makes sense to just squash this bug, and backlog the fancy proposal.

If there is nothing to export, disable the button (in the modal export dialog)