### PR TITLE
Delay adding new layer for 'drag' event.

### DIFF
--- a/src/js/actions/documents.js
+++ b/src/js/actions/documents.js
@@ -1134,7 +1134,10 @@ define(function (require, exports) {
                 return;
             }
 
-            this.flux.actions.layers.addLayers(currentDocument, event.layerID);
+            // Delay adding the new layer in case the new layer is not ready for read.
+            window.setTimeout(function () {
+                this.flux.actions.layers.addLayers(currentDocument, event.layerID);
+            }.bind(this), 100);
         }.bind(this);
         descriptor.addListener("drag", _dragHandler);
 


### PR DESCRIPTION
Fix for issue #3635 by applying the similar workaround that we have for the `make` handler (https://github.com/adobe-photoshop/spaces-design/blob/master/src/js/actions/layers.js#L1905)