### PR TITLE
Disable the scrubby feature

### DIFF
--- a/src/js/jsx/shared/Label.jsx
+++ b/src/js/jsx/shared/Label.jsx
@@ -27,11 +27,10 @@ define(function (require, exports, module) {
     var React = require("react"),
         classnames = require("classnames"),
         Fluxxor = require("fluxxor"),
-        FluxMixin = Fluxxor.FluxMixin(React),
-        ScrubbyMixin = require("js/jsx/mixin/Scrubby");
+        FluxMixin = Fluxxor.FluxMixin(React);
     
     var Label = React.createClass({
-        mixins: [FluxMixin, ScrubbyMixin],
+        mixins: [FluxMixin],
         
         propTypes: {
             size: React.PropTypes.string


### PR DESCRIPTION
Temporarily disable the scrubby feature to address issue #3591

(I am keeping the scrub handles in the components (`Radius`, `VectorFill`, `Position`, `Rotate`, and `Size`) for future reference.)