### PR TITLE
Add a Mac-only ad for Adobe Xd in the first-launch dialog

### DIFF
--- a/src/js/jsx/help/FirstLaunch.jsx
+++ b/src/js/jsx/help/FirstLaunch.jsx
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
 
     var Carousel = require("js/jsx/shared/Carousel"),
         nls = require("js/util/nls"),
+        system = require("js/util/system"),
         SVGIcon = require("js/jsx/shared/SVGIcon");
  
     var FirstLaunch = React.createClass({
@@ -77,6 +78,36 @@ define(function (require, exports, module) {
             });
         },
 
+        /**
+         * On Mac only, render an advertisement for Adobe Experience Design CC.
+         *
+         * @return {?ReactElement}
+         */
+        _renderAdvertisement: function () {
+            if (!system.isMac) {
+                return null;
+            }
+
+            var onClick = this._handleClick.bind(this, "http://www.adobe.com/go/experience-design", "xdAd"),
+                rawParts = nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_ADVERTISEMENT_1").split("{ADOBE_XD}"),
+                formattedParts = [
+                    rawParts[0],
+                    <em>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.ADOBE_XD")}</em>,
+                    rawParts[1] + " ",
+                    (<a href="#" onClick={onClick}>
+                        {nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_ADVERTISEMENT_2")}
+                    </a>)
+                ];
+
+            return (
+                <div className="advertisement">
+                    <h3>
+                        {formattedParts}
+                    </h3>
+                </div>
+            );
+        },
+
         render: function () {
             var psDesignTwitterURL = "https://www.adobe.com/go/designspace-twitter",
                 psForumURL = "https://www.adobe.com/go/designspace-forum",
@@ -117,36 +148,37 @@ define(function (require, exports, module) {
                 (<div className="carousel__slide">
                     <div className="carousel__slide__body">
                         <h1>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.HEADLINE")}</h1>
-                            <ul className="carousel__slide__three__list">
-                                <li>
-                                    <div
-                                        onClick={this._handleClick.bind(this, psDesignTwitterURL, "twitter")}>
-                                        <SVGIcon
-                                            CSSID="bird"/>
-                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_FIRST")}</h2>
-                                    </div>
-                                </li>
-                            </ul>
-                            <ul className="carousel__slide__three__list">
-                                <li>
-                                    <div
-                                        onClick={this._handleClick.bind(this, githubURL, "github")}>
-                                        <SVGIcon
-                                            CSSID="github"/>
-                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_SECOND")}</h2>
-                                    </div>
-                                </li>
-                            </ul>
-                            <ul className="carousel__slide__three__list">
-                                <li>
-                                    <div
-                                        onClick={this._handleClick.bind(this, psForumURL, "forum")}>
-                                        <SVGIcon
-                                            CSSID="workspace"/>
-                                        <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_THIRD")}</h2>
-                                    </div>
-                                </li>
-                            </ul>
+                        <ul className="carousel__slide__three__list">
+                            <li>
+                                <div
+                                    onClick={this._handleClick.bind(this, psDesignTwitterURL, "twitter")}>
+                                    <SVGIcon
+                                        CSSID="bird"/>
+                                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_FIRST")}</h2>
+                                </div>
+                            </li>
+                        </ul>
+                        <ul className="carousel__slide__three__list">
+                            <li>
+                                <div
+                                    onClick={this._handleClick.bind(this, githubURL, "github")}>
+                                    <SVGIcon
+                                        CSSID="github"/>
+                                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_SECOND")}</h2>
+                                </div>
+                            </li>
+                        </ul>
+                        <ul className="carousel__slide__three__list">
+                            <li>
+                                <div
+                                    onClick={this._handleClick.bind(this, psForumURL, "forum")}>
+                                    <SVGIcon
+                                        CSSID="workspace"/>
+                                    <h2>{nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_THIRD")}</h2>
+                                </div>
+                            </li>
+                        </ul>
+                        {this._renderAdvertisement()}
                     </div>
                 </div>)
                 ];

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -94,7 +94,10 @@
                 "HEADLINE": "Design Space",
                 "BODY_FIRST": "Twitter",
                 "BODY_SECOND": "GitHub",
-                "BODY_THIRD": "Forum"
+                "BODY_THIRD": "Forum",
+                "BODY_ADVERTISEMENT_1": "You seem like the type who likes to check out betas. We've been hard at work building a new end-to-end solution for UX designers, including great integration with Photoshop. We're happy to share that {ADOBE_XD} is now in public beta.",
+                "BODY_ADVERTISEMENT_2": "Go download a build and try it out!",
+                "ADOBE_XD": "Adobe Experience Design CC"
             }
         ]
     },

--- a/src/style/help/first-launch.less
+++ b/src/style/help/first-launch.less
@@ -441,6 +441,25 @@
     height: 3.5rem;
 }
 
+.carousel__slide .advertisement {
+    margin-top: 12em;
+
+    h3 {
+        font-size: 1.8rem;
+        line-height: 3.2rem;
+        font-weight: lighter;
+    }
+
+    em {
+        font-weight: 400;
+        white-space: nowrap;
+    }
+
+    a {
+        color: @first-launch-focus-highlight;
+    }
+}
+
 // LANGUAGE SPECIFIC STYLES //
 
 /**** FRENCH *****/


### PR DESCRIPTION
This adds a Mac-only advertisement paragraph to the last screen in the first-launch dialog for Adobe Experience Design CC. On Windows it will still look like this:
![image](https://cloud.githubusercontent.com/assets/1075154/14648053/461ce8a2-0615-11e6-8d93-6ed4c5378b59.png)

But on Mac it will now look like this:
![image](https://cloud.githubusercontent.com/assets/1075154/14648057/4c592532-0615-11e6-9503-39324ab6abee.png)
