### PR TITLE
Translate instead of setting absolute position when swapping layers

### DIFF
--- a/src/js/actions/transform.js
+++ b/src/js/actions/transform.js
@@ -497,9 +497,9 @@ define(function (require, exports) {
                 }
             },
             layerOneActions = _getMoveLayerActions
-                .call(this, document, layers.get(0), newPositions.get(0), "lt", payload.positions),
+                .call(this, document, layers.get(0), newPositions.get(0), "lt", payload.positions, true),
             layerTwoActions = _getMoveLayerActions
-                .call(this, document, layers.get(1), newPositions.get(1), "lt", payload.positions),
+                .call(this, document, layers.get(1), newPositions.get(1), "lt", payload.positions, true),
             translateActions = layerOneActions.concat(layerTwoActions);
                 
         var dispatchPromise = this.dispatchAsync(events.document.history.REPOSITION_LAYERS, payload);


### PR DESCRIPTION
This is a first-down hail-mary pass trying to address #3804.

I confirmed that photoshop is acting strangely when asked to set an artboard's absolute position by X/Y coords.  But, while troubleshooting, I tried using the alternate method of moving layers that is used when entering X or Y coords in the Position inputs.  This alternate flavor of `_getMoveLayerActions` uses an underlying `move` command instead of `transform`.

It seems to work fine.  But I half-expect someone to remember a situation that I haven't considered which breaks it.

Note: If this alternate approach *is* sufficient, then it seems like one of the code paths in `_getMoveLayerActions` may effectively be dead now.

Bonus Bug: I also found in the existing version that the width of an artboard was sometimes slowly growing after repeated swapping.