### PR TITLE
When in modal text edit state, allow color change and disable opacity input

### DIFF
--- a/src/js/actions/layers.js
+++ b/src/js/actions/layers.js
@@ -1894,6 +1894,7 @@ define(function (require, exports) {
     changeColors.action = {
         reads: [locks.JS_DOC],
         writes: [],
+        modal: true,
         transfers: ["shapes.setFillColor", "type.setColor"]
     };
 

--- a/src/js/actions/shapes.js
+++ b/src/js/actions/shapes.js
@@ -574,7 +574,8 @@ define(function (require, exports) {
     };
     setFillColor.action = {
         reads: [locks.PS_DOC, locks.JS_DOC],
-        writes: [locks.PS_DOC, locks.JS_DOC]
+        writes: [locks.PS_DOC, locks.JS_DOC],
+        modal: true
     };
 
     /**

--- a/src/js/jsx/sections/style/AppearanceProperties.jsx
+++ b/src/js/jsx/sections/style/AppearanceProperties.jsx
@@ -50,6 +50,7 @@ define(function (require, exports, module) {
 
         shouldComponentUpdate: function (nextProps) {
             return this.props.disabled !== nextProps.disabled ||
+                this.props.opaque !== nextProps.opaque ||
                 !Immutable.is(this.props.document, nextProps.document) ||
                 !Immutable.is(this.props.fill, nextProps.fill);
         },
@@ -272,7 +273,7 @@ define(function (require, exports, module) {
                             </Label>
                             <Opacity
                                 document={this.props.document}
-                                disabled={this.props.disabled}
+                                disabled={this.props.disabled || this.props.opaque}
                                 onFocus={this.props.onFocus}
                                 selectedLayers={this.props.selectedLayers} />
                         </div>

--- a/src/js/jsx/sections/style/Opacity.jsx
+++ b/src/js/jsx/sections/style/Opacity.jsx
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
                 return collection.pluckAll(props.selectedLayers, ["id", "opacity"]);
             };
 
-            return !Immutable.is(getRelevantProps(this.props), getRelevantProps(nextProps));
+            return this.props.disabled !== nextProps.disabled ||
+                !Immutable.is(getRelevantProps(this.props), getRelevantProps(nextProps));
         },
 
         /**


### PR DESCRIPTION
Addresses #3807 by setting the `layer.changeColors` action to be modal safe.

This PR also disables the Opacity element when in modal text edit state because attempting to set opacity while modal will throw an error.