### PR TITLE
Fix unrecoverable state after failure in sampling LLSO

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -268,11 +268,9 @@ define(function (require, exports) {
         this.flux.store("menu").on("change", _menuChangeHandler);
         
         if (!__PG_DEBUG__) {
-            var debugMenuIndex = rawMenuObj.menu.findIndex(function (menu) {
+            _.remove(rawMenuObj.menu, function (menu) {
                 return menu.id === "DEBUG";
             });
-
-            rawMenuObj.menu.splice(debugMenuIndex, 1);
         }
 
         // Menu store waits for this event to parse descriptors

--- a/src/js/jsx/tools/SamplerOverlay.jsx
+++ b/src/js/jsx/tools/SamplerOverlay.jsx
@@ -110,10 +110,18 @@ define(function (require, exports, module) {
         },
 
         shouldComponentUpdate: function (nextProps, nextState) {
-            var lastLayers = this.state.document.layers.selected,
-                nextLayers = nextState.document.layers.selected,
-                lastLayerProps = collection.pluck(lastLayers, "id"),
-                nextLayerProps = collection.pluck(nextLayers, "id"),
+            var getProps = function (state) {
+                var document = state.document;
+
+                if (!document || !document.layers) {
+                    return null;
+                }
+
+                return collection.pluck(document.layers.selected, "id");
+            };
+            
+            var lastLayerProps = getProps(this.state),
+                nextLayerProps = getProps(nextState),
                 layersChanged = !Immutable.is(lastLayerProps, nextLayerProps);
 
             return layersChanged ||


### PR DESCRIPTION
DS will fail to recover from action failure if the currently selected tool is sampler. This is because the `SamplerOverlay` is unable to read the selected layers in its `shouldComponentUpdate` function, as the current document is unavailable during resetting. This PR fixes the issue by checking the existence of the current document. I also checked the other tools to make sure doing the same checking in their SCU function. 

Fix: https://jira.corp.adobe.com/browse/PS-2645
Mitigate: https://github.com/adobe-photoshop/spaces-design/issues/3108 (it should not be a ship blocker now)