### PR TITLE
First-launch dialog localization fixes

### DIFF
--- a/src/index-debug.html
+++ b/src/index-debug.html
@@ -32,6 +32,16 @@
           locale = localeParts[0],
           js = document.createElement("script");
 
+      switch (locale) {
+      case "en":
+      case "de":
+      case "fr":
+      case "ja":
+          break;
+      default:
+          locale = "en";
+      }
+
       js.src = "./spaces-design-" + locale + ".js";
       js.type = "text/javascript";
 

--- a/src/index-debug.html
+++ b/src/index-debug.html
@@ -28,7 +28,8 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
     <script type ="text/javascript" src="./externalDeps.js"></script>
     <script type="text/javascript">
-      var locale = window.navigator.language,
+      var localeParts = window.navigator.language.split("-"),
+          locale = localeParts[0],
           js = document.createElement("script");
 
       js.src = "./spaces-design-" + locale + ".js";

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,16 @@
           locale = localeParts[0],
           js = document.createElement("script");
 
+      switch (locale) {
+      case "en":
+      case "de":
+      case "fr":
+      case "ja":
+          break;
+      default:
+          locale = "en";
+      }
+
       js.src = "./spaces-design-" + locale + ".js";
       js.type = "text/javascript";
 

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,8 @@
     <title>Photoshop Design Space</title>
     <link rel="stylesheet" type="text/css" href="style.css" />
     <script type="text/javascript">
-      var locale = window.navigator.language,
+      var localeParts = window.navigator.language.split("-"),
+          locale = localeParts[0],
           js = document.createElement("script");
 
       js.src = "./spaces-design-" + locale + ".js";

--- a/src/nls/de/strings.json
+++ b/src/nls/de/strings.json
@@ -55,41 +55,41 @@
     "FIRST_LAUNCH": {
         "CONTINUE": "Fortsetzen",
         "GET_STARTED": "Erste Schritte",
-        "SLIDES": [
-            {
+        "SLIDES": {
+            "0": {
                 "TITLE": "Start",
                 "HEADLINE": "Willkommen beim Design-Bereich",
                 "SUBHEAD": "",
                 "BODY_FIRST": "Der Design-Bereich (derzeit eine Vorschau) ist eine Companion-App zu Photoshop für Web- und App-Designer.",
                 "BODY_SECOND": "Wir arbeiten in HTML und JavaScript, um neue Interaktionen zu schaffen, die auf Ihre Arbeitsabläufe zugeschnitten sind. Dies ist eine Vorschauversion, für die wir Ihr Feedback benötigen – teilen Sie uns mit, was Sie denken."
             },
-            {
+            "1": {
                 "TITLE": "Werkzeugsatz",
                 "HEADLINE": "Ein minimierter Werkzeugsatz und kontextuelles Eigenschaftenbedienfeld."
             },
-            {
+            "2": {
                 "TITLE": "Suchen",
                 "HEADLINE_FIRST": "Suchen Sie nach Ebenen und geöffneten Dokumenten, platzieren Sie Bibliothekselemente und vieles mehr.",
                 "HEADLINE_SECOND": "Verwenden Sie Befehlstaste+F auf Mac oder Strg+F auf Windows."
             },
-            {
+            "3": {
                 "TITLE": "Farbaufnahme",
                 "HEADLINE_FIRST": "Nehmen Sie Farben und Effekte ganz einfach per Klick oder Umschalt-Klick auf.",
                 "HEADLINE_SECOND": "Nehmen Sie alles andere, sogar Grafiken, mit der Leertaste auf."
             },
-            {
+            "4": {
                 "TITLE": "Zeichenflächen",
                 "HEADLINE": "Erstellen Sie mehrere Zeichenflächen für einen visuelleren Arbeitsablauf."
             },
-            {
+            "5": {
                 "TITLE": "Vertauschen",
                 "HEADLINE": "Vertauschen Sie Inhalte und Positionen von Ebenen mit einem einzigen Klick."
             },
-            {
+            "6": {
                 "TITLE": "Wechseln",
                 "HEADLINE": "Wechseln Sie nahtlos zum Standard-Photoshop, um erweiterte Fotografiefunktionen in Anspruch zu nehmen."
             },
-            {
+            "7": {
                 "TITLE": "Kontakt",
                 "HEADLINE": "Design-Bereich",
                 "BODY_FIRST": "Twitter",
@@ -99,7 +99,7 @@
                 "BODY_ADVERTISEMENT_2": "Laden Sie einen Build herunter und testen Sie es!",
                 "ADOBE_XD": "Adobe Experience Design CC"
             }
-        ]
+        }
     },
     "KEYBOARD_SHORTCUTS": {
         "TOOLS_TITLE": "Werkzeuge",

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -55,41 +55,41 @@
     "FIRST_LAUNCH": {
         "CONTINUE": "Continue",
         "GET_STARTED": "Get Started",
-        "SLIDES": [
-            {
+        "SLIDES": {
+            "0": {
                 "TITLE": "landing",
                 "HEADLINE": "Welcome to Design Space",
                 "SUBHEAD": "",
                 "BODY_FIRST": "Design Space (currently a Preview) is a companion experience to Photoshop for web and app designers.",
                 "BODY_SECOND": "We’re working in HTML and JavaScript, creating new interactions tailored to your workflows. This is a preview release to get your feedback – so let us know what you think."
             },
-            {
+            "1": {
                 "TITLE": "Toolset",
                 "HEADLINE": "A minimized toolset & contextual properties panel."
             },
-            {
+            "2": {
                 "TITLE": "Search",
                 "HEADLINE_FIRST": "Search for layers, open documents, place library assets, and more.",
                 "HEADLINE_SECOND": "Use Command+F on Mac or Control+F on Windows."
             },
-            {
+            "3": {
                 "TITLE": "Sampler",
                 "HEADLINE_FIRST": "Sample colors and effects with just a click or a shift+click.",
                 "HEADLINE_SECOND": "Sample everything else, even graphics, with the spacebar."
             },
-            {
+            "4": {
                 "TITLE": "Artboards",
                 "HEADLINE": "Create multiple artboards for a more visual workflow."
             },
-            {
+            "5": {
                 "TITLE": "Swap",
                 "HEADLINE": "Swap the contents and positions of layers and artboards with a single click."
             },
-            {
+            "6": {
                 "TITLE": "Switching",
                 "HEADLINE": "Switch to standard Photoshop seamlessly for advanced photography features."
             },
-            {
+            "7": {
                 "TITLE": "Contact",
                 "HEADLINE": "Design Space",
                 "BODY_FIRST": "Twitter",
@@ -99,7 +99,7 @@
                 "BODY_ADVERTISEMENT_2": "Go download a build and try it out!",
                 "ADOBE_XD": "Adobe Experience Design CC"
             }
-        ]
+        }
     },
     "KEYBOARD_SHORTCUTS": {
         "TOOLS_TITLE": "Tools",

--- a/src/nls/fr/strings.json
+++ b/src/nls/fr/strings.json
@@ -55,41 +55,41 @@
     "FIRST_LAUNCH": {
         "CONTINUE": "Continuer",
         "GET_STARTED": "Prise en main",
-        "SLIDES": [
-            {
+        "SLIDES": {
+            "0": {
                 "TITLE": "destination",
                 "HEADLINE": "Bienvenue dans Design Space",
                 "SUBHEAD": "",
                 "BODY_FIRST": "Design Space (qui est pour l'instant un Aperçu) est une application qui s'utilise conjointement avec Photoshop pour les concepteurs Web et les concepteurs d'applications.",
                 "BODY_SECOND": "Nous utilisons le code HTML et Javascript afin de créer de nouvelles interactions personnalisées adaptées à vos flux de production. Il s'agit d'une version préliminaire destinée à obtenir vos commentaires. Faites-nous part de votre opinion."
             },
-            {
+            "1": {
                 "TITLE": "Ensemble d'outils",
                 "HEADLINE": "Ensemble d'outils réduit et panneau de propriétés contextuel."
             },
-            {
+            "2": {
                 "TITLE": "Rechercher",
                 "HEADLINE_FIRST": "Recherchez des calques, ouvrez des documents, importez des ressources de la bibliothèque, et plus encore.",
                 "HEADLINE_SECOND": "Utilisez Commande+F sous Mac ou Ctrl+F sous Windows."
             },
-            {
+            "3": {
                 "TITLE": "Echantillonnage",
                 "HEADLINE_FIRST": "Echantillonnez les couleurs et les effets d'un simple clic ou en utilisant Maj+clic.",
                 "HEADLINE_SECOND": "Echantillonnez tout le reste, même les graphiques, avec la barre d'espace."
             },
-            {
+            "4": {
                 "TITLE": "Plans de travail",
                 "HEADLINE": "Créez plusieurs plans de travail pour un flux de travaux plus visuel."
             },
-            {
+            "5": {
                 "TITLE": "Permuter",
                 "HEADLINE": "Echangez le contenu et les positions des calques et des plans de travail en un seul clic."
             },
-            {
+            "6": {
                 "TITLE": "Changement",
                 "HEADLINE": "Passez aisément à la version standard de Photoshop pour accéder aux fonctionnalités avancées des photos."
             },
-            {
+            "7": {
                 "TITLE": "Contact",
                 "HEADLINE": "Espace de conception",
                 "BODY_FIRST": "Twitter",
@@ -99,7 +99,7 @@
                 "BODY_ADVERTISEMENT_2": "Téléchargez la version bêta et essayez-la !",
                 "ADOBE_XD": "Adobe Experience Design CC"
             }
-        ]
+        }
     },
     "KEYBOARD_SHORTCUTS": {
         "TOOLS_TITLE": "Outils",

--- a/src/nls/ja/strings.json
+++ b/src/nls/ja/strings.json
@@ -55,51 +55,51 @@
     "FIRST_LAUNCH": {
         "CONTINUE": "続行",
         "GET_STARTED": "開始",
-        "SLIDES": [
-            {
+        "SLIDES": {
+            "0": {
                 "TITLE": "ランディング",
                 "HEADLINE": "デザインスペースへようこそ",
                 "SUBHEAD": "",
                 "BODY_FIRST": "デザインスペース（プレビュー）は、Webやアプリケーションデザイナー向けの Photoshop の関連機能です。",
                 "BODY_SECOND": "HTML および JavaScript を駆使して、ワークフローに合わせた新しいインタラクションを実現しました。これはフィードバックをいただくためのプレビューリリースです。ご意見をお待ちしています。"
             },
-            {
+            "1": {
                 "TITLE": "ツールセット",
                 "HEADLINE": "最小化されたツールセットと状況に即した属性パネル。"
             },
-            {
+            "2": {
                 "TITLE": "検索",
                 "HEADLINE_FIRST": "レイヤーを検索する、ドキュメントを開く、ライブラリアセットを配置するなどのことができます。",
                 "HEADLINE_SECOND": "Mac の場合は Command+F、Windows の場合は Control+F を使用します。"
             },
-            {
+            "3": {
                 "TITLE": "サンプラー",
                 "HEADLINE_FIRST": "クリックまたは Shift キーを押しながらクリックするだけで、カラーと効果をサンプリングできます。",
                 "HEADLINE_SECOND": "スペースパーで、他のすべて、グラフィックさえもサンプリングできます。"
             },
-            {
+            "4": {
                 "TITLE": "アートボード",
                 "HEADLINE": "複数のアートボードを作成して、ワークフローをより見やすくします。"
             },
-            {
+            "5": {
                 "TITLE": "入れ替え",
                 "HEADLINE": "１回のクリックで、レイヤーとアートボードの内容および位置を入れ替える。"
             },
-            {
+            "6": {
                 "TITLE": "切り替え",
                 "HEADLINE": "高度な写真機能を使用する場合は、標準の Photoshop にシームレスな切り替えが可能です。"
             },
-            {
+            "7": {
                 "TITLE": "連絡先",
                 "HEADLINE": "デザインスペース",
                 "BODY_FIRST": "Twitter",
                 "BODY_SECOND": "GitHub",
                 "BODY_THIRD": "フォーラム",
-                "BODY_ADVERTISEMENT_1": "ベータ版の使用についてご検討中でしょうか。Photoshop との大幅な連携など UX デザイナー向けの新しいエンドツーエンドのソリューションの構築に積極的に取り組んできました。ついに、パブリックベータ版の {ADOBE_ XD} を公開できることをうれしく思っています。",
+                "BODY_ADVERTISEMENT_1": "ベータ版の使用についてご検討中でしょうか。Photoshop との大幅な連携など UX デザイナー向けの新しいエンドツーエンドのソリューションの構築に積極的に取り組んできました。ついに、パブリックベータ版の {ADOBE_XD} を公開できることをうれしく思っています。",
                 "BODY_ADVERTISEMENT_2": "ビルドをダウンロードしてお試しください。",
                 "ADOBE_XD": "Adobe Experience Design CC"
             }
-        ]
+        }
     },
     "KEYBOARD_SHORTCUTS": {
         "TOOLS_TITLE": "ツール",

--- a/src/style/help/first-launch.less
+++ b/src/style/help/first-launch.less
@@ -460,6 +460,19 @@
     }
 }
 
+:lang(de) .carousel__slide .advertisement {
+    margin-top: 11em;
+}
+
+:lang(fr) .carousel__slide__body {
+    padding-right: 2em;
+    padding-left: 2em;
+}
+
+:lang(fr) .carousel__slide .advertisement {
+    margin-top: 0;
+}
+
 // LANGUAGE SPECIFIC STYLES //
 
 /**** FRENCH *****/

--- a/src/style/help/first-launch.less
+++ b/src/style/help/first-launch.less
@@ -442,7 +442,7 @@
 }
 
 .carousel__slide .advertisement {
-    margin-top: 12em;
+    margin-top: 0;
 
     h3 {
         font-size: 1.8rem;
@@ -460,17 +460,14 @@
     }
 }
 
-:lang(de) .carousel__slide .advertisement {
-    margin-top: 11em;
+:lang(ja) .advertisement,
+:lang(de) .advertisement {
+    text-align: left;
 }
 
 :lang(fr) .carousel__slide__body {
     padding-right: 2em;
     padding-left: 2em;
-}
-
-:lang(fr) .carousel__slide .advertisement {
-    margin-top: 0;
 }
 
 // LANGUAGE SPECIFIC STYLES //


### PR DESCRIPTION
1. Fixes a problem with how webpack was merging dictionaries at compile time that prevented non-English translations from showing in the first-launch dialog.
2. Fix some layout issues in the last slide in French and German.
3. Remove a dangling space in the `{ADOBE_XD}` separator in the Japanese translation that caused `undefined` to trickle into the last slide.

Addresses #3819 and partially addresses #3820.