### PR TITLE
Removed extra div around rotation tool icon

### DIFF
--- a/src/js/jsx/sections/transform/Rotate.jsx
+++ b/src/js/jsx/sections/transform/Rotate.jsx
@@ -213,25 +213,23 @@ define(function (require, exports, module) {
 
             return (
                 <div className="control-group__horizontal">
-                    <div>
-                        <Label
-                            onScrubStart={this._handleScrubBegin}
-                            onScrub={this._handleScrub}
-                            onScrubEnd={this._handleScrubEnd}
-                            size="column-3"
-                            title={nls.localize("strings.TOOLTIPS.SET_ROTATION")}>
-                            <SVGIcon CSSID="rotation" />
-                        </Label>
-                        <NumberInput
-                            disabled={disabled}
-                            // HACK: This lets 0 as a value work and not be considered the starting value
-                            value={disabled ? "" : this.state.value}
-                            onChange={this._rotateLayer}
-                            step={1}
-                            bigstep={15}
-                            ref="rotate"
-                            size="column-4" />
-                    </div>
+                    <Label
+                        onScrubStart={this._handleScrubBegin}
+                        onScrub={this._handleScrub}
+                        onScrubEnd={this._handleScrubEnd}
+                        size="column-3"
+                        title={nls.localize("strings.TOOLTIPS.SET_ROTATION")}>
+                        <SVGIcon CSSID="rotation" />
+                    </Label>
+                    <NumberInput
+                        disabled={disabled}
+                        // HACK: This lets 0 as a value work and not be considered the starting value
+                        value={disabled ? "" : this.state.value}
+                        onChange={this._rotateLayer}
+                        step={1}
+                        bigstep={15}
+                        ref="rotate"
+                        size="column-4" />
                 </div>
             );
         }


### PR DESCRIPTION
There was an extra div around the rotation tool icon that caused the label and input to split into 2 different lines. References #3825 

Before:
![](https://s3.amazonaws.com/f.cl.ly/items/0h1O0n1L2e0y2o08193I/Image%202016-05-10%20at%2011.53.47%20AM.png?v=0f2bb665)

After: 
![](https://s3.amazonaws.com/f.cl.ly/items/2W3Z1Y1L1D3r2g3E0g1I/Image%202016-05-10%20at%2011.55.06%20AM.png?v=0461e732)