### PR TITLE
Localize designspace help and adobe_xd go urls

### DIFF
--- a/src/js/actions/menu.js
+++ b/src/js/actions/menu.js
@@ -36,6 +36,7 @@ define(function (require, exports) {
         locks = require("js/locks"),
         system = require("js/util/system"),
         objUtil = require("js/util/object"),
+        nls = require("js/util/nls"),
         log = require("js/util/log"),
         headlights = require("js/util/headlights"),
         policyActions = require("./policy");
@@ -152,7 +153,12 @@ define(function (require, exports) {
             headlights.logEvent(payload.category, payload.subcategory, payload.eventName);
         }
 
-        return adapter.openURLInDefaultBrowser(payload.url);
+        var url = payload.url;
+        if (payload.localize) {
+            url = nls.localize(url);
+        }
+
+        return adapter.openURLInDefaultBrowser(url);
     };
     openURL.action = {
         reads: [],

--- a/src/js/jsx/help/FirstLaunch.jsx
+++ b/src/js/jsx/help/FirstLaunch.jsx
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
                 return null;
             }
 
-            var onClick = this._handleClick.bind(this, "http://www.adobe.com/go/experience-design", "xdAd"),
+            var onClick = this._handleClick.bind(this, nls.localize("strings.GO_URL.EXPERIENCE_DESIGN"), "xdAd"),
                 rawParts = nls.localize("strings.FIRST_LAUNCH.SLIDES.7.BODY_ADVERTISEMENT_1").split("{ADOBE_XD}"),
                 formattedParts = [
                     rawParts[0],

--- a/src/nls/en/strings.json
+++ b/src/nls/en/strings.json
@@ -52,6 +52,10 @@
         "NEW_VECTOR_MASK_FROM_SHAPE": "Create Vector Mask From Shape Layer"
     },
     "APP_NAME": "Photoshop",
+    "GO_URL": {
+        "EXPERIENCE_DESIGN": "http://www.adobe.com/go/experience-design",
+        "DESIGNSPACE_HELP": "http://www.adobe.com/go/designspace-help"
+    },
     "FIRST_LAUNCH": {
         "CONTINUE": "Continue",
         "GET_STARTED": "Get Started",

--- a/src/static/menu-actions.json
+++ b/src/static/menu-actions.json
@@ -555,7 +555,8 @@
         "HELPX": {
             "$action": "menu.openURL",
             "$payload": {
-                "url": "https://www.adobe.com/go/designspace-help",
+                "url": "strings.GO_URL.DESIGNSPACE_HELP",
+                "localize": true,
                 "category": "help",
                 "subcategory": "external-link",
                 "eventName": "helpX"


### PR DESCRIPTION
This PR localizes the two dynamic links we have to Design Space help page and Experience Design page. To achieve one of these, I've added a `localize` parameter to url payload in those menu items so DS knows to localize the string instead of directly trying to go to the provided URL. I couldn't do a string matching here, because we use this with libraries panel for certain actions as well.

@iwehrman please review.