### PR TITLE
Properties panel adjustable heights to accommodate app resizing

### DIFF
--- a/src/style/main.less
+++ b/src/style/main.less
@@ -134,6 +134,55 @@ input {
     html { font-size: @base-11; }
 }
 
+@media (min-height: 200px) {
+  .main__both-panel .panel-export-section, .main__both-panel .panel-effects-section {
+    min-height: 0rem;
+    overflow: hidden;
+  }
+
+  .main__both-panel .panel-appearance-section {
+    height: 6rem;
+    overflow: hidden;
+  }
+}
+
+@media (min-height: 300px) {
+  .main__both-panel .panel-export-section, .main__both-panel .panel-effects-section {
+    min-height: 0rem;
+    overflow: hidden;
+  }
+
+  .main__both-panel .panel-appearance-section {
+    height: 8rem;
+    overflow: hidden;
+  }
+}
+
+@media (min-height: 460px) {
+  .main__both-panel .panel-export-section, .main__both-panel .panel-effects-section {
+    min-height: 4.6rem;
+    overflow: hidden;
+  }
+
+  .main__both-panel .panel-appearance-section {
+    height: 12rem;
+    overflow: hidden;
+  }
+
+}
+
+@media (min-height: 580px) {
+  .main__both-panel .panel-export-section, .main__both-panel .panel-effects-section {
+    height: 8rem;
+    overflow: hidden;
+  }
+
+  .main__both-panel .panel-appearance-section {
+    min-height: 22rem;
+    overflow: hidden;
+  }
+}
+
 /* -- MASTER CONTAINER -- */
 
 .fade-in-mixin {

--- a/src/style/panel.less
+++ b/src/style/panel.less
@@ -45,14 +45,6 @@
     flex-grow: 0;
 }
 
-.panel-effects-section{
-    min-height: 24rem;
-}
-
-.panel-export-section{
-    min-height: 18rem;
-}
-
 .panel-appearance-section .section-container .stroke {
     margin-top: .4rem;
 }
@@ -279,6 +271,14 @@
     margin-left: .2rem;
 }
 
+.radius_input {
+    padding-bottom: 2rem;
+}
+
+.last-line__type {
+    padding-bottom: 2rem;
+}
+
 .transform.section {
     flex-grow: 0;
     flex-shrink: 0;
@@ -424,7 +424,7 @@
         border-right: @hairline solid @bg-border;
     }
     
-    .export {
+    .export, .layers {
         border-bottom: @panel-border-width solid @bg-border;
     }
 
@@ -463,9 +463,12 @@
             flex-basis: 0;
         }
     }
-    
-    .libraries, .layers {
-        min-height: 10rem;
+
+    .panel-layers-section,
+    .panel-export-section, .panel-effects-section, 
+    .panel-appearance-section {
+        min-height: 4.6rem;
+        overflow: hidden;
     }
 
     .appearance, .type {

--- a/src/style/sections/style/style-section.less
+++ b/src/style/sections/style/style-section.less
@@ -92,7 +92,6 @@
     }
 }
 
-.appearance,
 .type {
     height: 22rem;
     flex-grow: 0;


### PR DESCRIPTION
Issue #3824 

There was a minimum height on multiple panels in the properties panel. This pushed the entire UI upwards to accommodate each of them. Media queries now detect the app height and adjust the panels accordingly.